### PR TITLE
Move fish config into conf.d directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to work as expected, omni will also require its shell integration, whic
   [[ -f "<path/to/omni/git/repo>/shell_integration/omni.zsh" ]] && source "<path/to/omni/git/repo>/shell_integration/omni.zsh"
   ```
 
-- `config.fish`
+- `fish/conf.d/omni.fish`
   ```
   test -f "<path/to/omni/git/repo>/shell_integration/omni.fish"; and source "<path/to/omni/git/repo>/shell_integration/omni.fish"
   ```

--- a/install.sh
+++ b/install.sh
@@ -575,7 +575,7 @@ function setup_shell_integration() {
 	if [[ -z "$rc_file" ]] && [[ "$INTERACTIVE" == "true" ]]; then
 		local default_rc_file="${HOME}/.${shell}rc"
 		if [[ "$shell" == "fish" ]]; then
-		  default_rc_file="${HOME}/.config/fish/config.fish"
+		  default_rc_file="${HOME}/.config/fish/conf.d/omni.fish"
 		fi
 
 		print_query "Location of the .${shell}rc file to edit? \033[90m(default: ${default_rc_file})\033[0m "


### PR DESCRIPTION
# Summary
This moves the fish config from `config.fish` into `conf.d/omni.fish` to make the install a bit more fish-y. Fish config docs are available [here](https://fishshell.com/docs/current/language.html#configuration-files).

# Test Plan
- [x] Removed omni-related fish configs and verified re-running `install.sh` works.
- [ ] Ran a fresh install and ensured that the fish configuration was setup correctly.