### PR TITLE
✨ Add self updater for omni

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -80,9 +80,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -92,6 +92,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -121,6 +127,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytes"
@@ -188,6 +200,40 @@ name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossterm"
@@ -260,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +361,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +420,54 @@ checksum = "7672706608ecb74ab2e055c68327ffc25ae4cac1e12349204fd5fb0f3487cce2"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -405,6 +536,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,18 +586,80 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "idna"
@@ -474,6 +686,16 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -519,6 +741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,9 +787,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libgit2-sys"
@@ -623,10 +860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.6.2"
+name = "mime"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -644,12 +887,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
+name = "native-tls"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
- "hermit-abi 0.2.6",
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
 ]
 
@@ -661,9 +922,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -675,6 +936,7 @@ dependencies = [
  "atty",
  "blake3",
  "duct",
+ "flate2",
  "fs4",
  "getopts",
  "git-url-parse",
@@ -690,12 +952,18 @@ dependencies = [
  "pathdiff",
  "regex",
  "requestty",
+ "reqwest",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "shell-escape",
  "shell-words",
  "strsim",
+ "tar",
+ "tempfile",
  "term_size",
  "time",
  "tokio",
@@ -733,7 +1001,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -798,9 +1066,9 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -828,6 +1096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,18 +1121,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -891,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -946,6 +1229,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,9 +1273,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "62f25693a73057a1b4cb56179dd3c7ea21a7c6c5ee7d85781f5749b46f34b79c"
 dependencies = [
  "bitflags",
  "errno",
@@ -987,10 +1307,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e7c919783db74b5995f13506069227e4721d388bea4a8ac3055acac864ac16"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -1009,7 +1378,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1024,16 +1393,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1095,6 +1487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1163,13 +1564,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1181,7 +1593,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1261,9 +1673,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
  "backtrace",
@@ -1287,8 +1699,38 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -1310,7 +1752,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1343,6 +1785,12 @@ dependencies = [
  "thread_local",
  "tracing-core",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -1449,10 +1897,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1487,6 +2020,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -1500,7 +2048,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1520,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -1618,7 +2166,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winsplit"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab703352da6a72f35c39a533526393725640575bb211f61987a2748323ad956"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ time = { version = "0.3.22", features = ["serde-well-known"] }
 atty = "0.2.14"
 blake3 = "1.4.0"
 duct = "0.13.6"
+flate2 = "1.0.26"
 fs4 = "0.6.5"
 getopts = "0.2.21"
 git-url-parse = "0.4.4"
@@ -28,12 +29,18 @@ path-clean = "1.0.1"
 pathdiff = "0.2.1"
 regex = "1.8.3"
 requestty = "0.5.0"
+reqwest = { version = "0.11.18", features = ["blocking"] }
+self-replace = "1.3.5"
+semver = "1.0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.99"
 serde_yaml = "0.9"
+sha2 = "0.10.7"
 shell-escape = "0.1.5"
 shell-words = "1.1.0"
 strsim = "0.10.0"
+tar = "0.4.38"
+tempfile = "3.6.0"
 term_size = "0.3.2"
 time = { version = "0.3.22", features = ["serde-well-known"] }
 tokio = { version = "1.29.0", features = ["full"] }

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -106,6 +106,7 @@ path:
   prepend: []
 path_repo_updates:
   enabled: true
+  self_update: ask
   interval: 43200 # 12 hours
   ref_type: "branch" # branch or tag
   ref_match: null # regex or null

--- a/src/internal/config/mod.rs
+++ b/src/internal/config/mod.rs
@@ -22,6 +22,7 @@ pub use parser::OrgConfig;
 pub use parser::PathConfig;
 pub use parser::PathRepoUpdatesConfig;
 pub use parser::PathRepoUpdatesPerRepoConfig;
+pub use parser::PathRepoUpdatesSelfUpdateEnum;
 pub use parser::SyntaxOptArg;
 
 pub mod up;

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -1,5 +1,6 @@
 use indicatif::MultiProgress;
 use indicatif::ProgressBar;
+use indicatif::ProgressDrawTarget;
 use indicatif::ProgressStyle;
 use regex::Regex;
 use tokio;
@@ -256,6 +257,8 @@ pub trait ProgressHandler {
     fn success_with_message(&self, message: String);
     fn error(&self);
     fn error_with_message(&self, message: String);
+    fn hide(&self);
+    fn show(&self);
 }
 
 #[derive(Debug, Clone)]
@@ -377,6 +380,14 @@ impl ProgressHandler for SpinnerProgressHandler {
             println!();
         }
     }
+
+    fn hide(&self) {
+        self.spinner.set_draw_target(ProgressDrawTarget::hidden());
+    }
+
+    fn show(&self) {
+        self.spinner.set_draw_target(ProgressDrawTarget::stderr());
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -444,5 +455,13 @@ impl ProgressHandler for PrintProgressHandler {
                 .replacen("{}", "✖".to_string().red().as_str(), 1)
                 .replacen("{}", message.red().as_str(), 1)
         );
+    }
+
+    fn hide(&self) {
+        // do nothing
+    }
+
+    fn show(&self) {
+        // do nothing
     }
 }

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -13,6 +13,7 @@ use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::git_env;
+use crate::internal::self_update;
 use crate::internal::user_interface::StringColor;
 use crate::internal::Cache;
 use crate::internal::ENV;
@@ -64,9 +65,14 @@ fn should_update() -> bool {
 }
 
 pub fn auto_path_update() {
+    // Get the configuration
+    let config = config(".");
+
+    // Get the omnipath
     let omnipath = omnipath();
-    if omnipath.is_empty() {
-        // Nothing to do if nothing is in the omnipath
+    if omnipath.is_empty() && config.path_repo_updates.self_update.is_false() {
+        // Nothing to do if nothing is in the omnipath and we
+        // don't check for omni updates
         return;
     }
 
@@ -74,8 +80,11 @@ pub fn auto_path_update() {
         return;
     }
 
-    // Get the configuration
-    let config = config(".");
+    self_update();
+
+    if omnipath.is_empty() {
+        return;
+    }
 
     // Let's do all the git updates in parallel since we don't require
     // switching directory for that

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -49,3 +49,6 @@ pub use user_interface::StringColor;
 pub mod dynenv;
 
 pub mod hooks;
+
+pub mod self_updater;
+pub use self_updater::self_update;

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -1,0 +1,335 @@
+use std::fs::OpenOptions;
+use std::io;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::path::Path;
+use std::process::exit;
+
+use lazy_static::lazy_static;
+use semver::{Prerelease, Version};
+use serde::Deserialize;
+use sha2::Digest;
+use sha2::Sha256;
+use tempfile;
+use tokio::process::Command as TokioCommand;
+
+use crate::internal::config::config;
+use crate::internal::config::up::utils::run_progress;
+use crate::internal::config::up::utils::PrintProgressHandler;
+use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::config::PathRepoUpdatesSelfUpdateEnum;
+use crate::internal::user_interface::colors::StringColor;
+use crate::internal::ENV;
+use crate::omni_info;
+
+lazy_static! {
+    static ref RELEASE_ARCH: String = {
+        let arch = match std::env::consts::ARCH {
+            "aarch64" => "arm64",
+            _ => std::env::consts::ARCH,
+        };
+        arch.to_string()
+    };
+
+    static ref RELEASE_OS: String = {
+        let os = match std::env::consts::OS {
+            "macos" => "darwin",
+            _ => std::env::consts::OS,
+        };
+        os.to_string()
+    };
+
+    static ref CURRENT_VERSION: Version = {
+        let mut version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        if !version.pre.is_empty() {
+            // Check if it starts with `rc` or `beta` or `alpha`, in which case
+            // we wanna keep them, otherwise we consider we're at the version,
+            // as otherwise semver would consider `1.0.0-5-xxxx` < `1.0.0`
+            if !(version.pre.starts_with("rc")
+                || version.pre.starts_with("beta")
+                || version.pre.starts_with("alpha"))
+            {
+                // Clear prerelease
+                version.pre = Prerelease::EMPTY;
+            }
+        }
+        version
+    };
+
+    static ref INSTALLED_WITH_BREW: bool = {
+        // Get the path of the current binary
+        let current_exe = std::env::current_exe().expect("Failed to get current exe path");
+
+        // Get the homebrew prefix, either through the HOMEBREW_PREFIX env var
+        // if available, or by calling `brew --prefix`; if both fail, we're not
+        // installed with homebrew since... probably no homebrew.
+        let homebrew_prefix = std::env::var("HOMEBREW_PREFIX")
+            .ok()
+            .or_else(|| {
+                let output = std::process::Command::new("brew")
+                    .arg("--prefix")
+                    .output()
+                    .ok()?;
+                String::from_utf8(output.stdout).ok()
+            });
+
+        if let Some(homebrew_prefix) = homebrew_prefix {
+            // Check if the current binary is in the homebrew prefix
+            current_exe.starts_with(format!("{}/", homebrew_prefix))
+        } else {
+            false
+        }
+    };
+}
+
+pub fn self_update() {
+    if let Some(omni_release) = OmniRelease::latest() {
+        omni_release.check_and_update();
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OmniRelease {
+    version: String,
+    binaries: Vec<OmniReleaseBinary>,
+}
+
+impl OmniRelease {
+    fn latest() -> Option<Self> {
+        let json_url =
+            "https://raw.githubusercontent.com/XaF/homebrew-omni/main/Formula/resources/omni.json";
+
+        let mut response = reqwest::blocking::get(json_url);
+        if let Err(err) = response {
+            dbg!("Failed to get latest release: {:?}", err);
+            return None;
+        }
+        let mut response = response.unwrap();
+
+        let mut content = String::new();
+        response
+            .read_to_string(&mut content)
+            .expect("Failed to read response");
+
+        let json: Result<OmniRelease, _> = serde_json::from_str(content.as_str());
+        if let Err(err) = json {
+            dbg!("Failed to parse latest release: {:?}", err);
+            return None;
+        }
+        let json = json.unwrap();
+
+        Some(json)
+    }
+
+    fn is_newer(&self) -> bool {
+        let latest_version =
+            Version::parse(self.version.as_str()).expect("Failed to parse version");
+
+        latest_version > *CURRENT_VERSION
+    }
+
+    fn compatible_binary(&self) -> Option<&OmniReleaseBinary> {
+        for binary in self.binaries.iter() {
+            if binary.os == *RELEASE_OS && binary.arch == *RELEASE_ARCH {
+                return Some(binary);
+            }
+        }
+        None
+    }
+
+    fn check_and_update(&self) {
+        let config = config(".");
+        if config.path_repo_updates.self_update.is_false() {
+            return;
+        }
+
+        let desc = format!("{} update:", "omni".to_string().light_cyan()).light_blue();
+        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+            Box::new(SpinnerProgressHandler::new(desc, None))
+        } else {
+            Box::new(PrintProgressHandler::new(desc, None))
+        };
+
+        progress_handler.progress("Checking for updates".to_string());
+
+        if !self.is_newer() {
+            progress_handler.success_with_message("already up-to-date".to_string().light_black());
+            return;
+        }
+
+        if config.path_repo_updates.self_update.is_ask() {
+            progress_handler.hide();
+
+            let question = requestty::Question::confirm("do_you_want_to_update")
+                .ask_if_answered(true)
+                .on_esc(requestty::OnEsc::Terminate)
+                .message(format!(
+                    "{} version {} is available; {}",
+                    "omni:".to_string().light_cyan(),
+                    self.version.to_string().light_blue(),
+                    "do you want to install it?".to_string().yellow(),
+                ))
+                .default(true)
+                .build();
+
+            match requestty::prompt_one(question) {
+                Ok(answer) => match answer {
+                    requestty::Answer::Bool(confirmed) => {
+                        if confirmed {
+                            omni_info!(format!(
+                                "{} you can set {} to {} in your configuration to automatically install updates",
+                                "Tip:".to_string().bold(),
+                                "path_repo_updates/self_update".to_string().light_blue(),
+                                "true".to_string().light_green(),
+                            ));
+                        } else {
+                            omni_info!(format!(
+                                "{} you can set {} to {} in your configuration to disable this check",
+                                "Tip:".to_string().bold(),
+                                "path_repo_updates/self_update".to_string().light_blue(),
+                                "false".to_string().light_red(),
+                            ));
+                            return;
+                        }
+                    }
+                    _ => {}
+                },
+                Err(err) => {
+                    println!("{}", format!("[✘] {:?}", err).red());
+                    return;
+                }
+            }
+
+            progress_handler.show();
+        }
+
+        let updated = if *INSTALLED_WITH_BREW {
+            self.brew_upgrade(Box::new(progress_handler.as_ref()))
+        } else {
+            self.download(Box::new(progress_handler.as_ref()))
+        };
+
+        if updated.is_err() {
+            progress_handler.error_with_message("Failed to update".to_string());
+            return;
+        }
+        let updated = updated.unwrap();
+
+        if updated {
+            progress_handler
+                .success_with_message(format!("updated to version {}", self.version).light_green());
+        } else {
+            progress_handler.success_with_message("already up-to-date".to_string().light_black());
+        }
+    }
+
+    fn brew_upgrade(&self, progress_handler: Box<&dyn ProgressHandler>) -> io::Result<bool> {
+        progress_handler.progress("updating with homebrew".to_string());
+
+        let mut brew_upgrade = TokioCommand::new("brew");
+        brew_upgrade.arg("upgrade");
+        brew_upgrade.arg("xaf/omni/omni");
+        brew_upgrade.stdout(std::process::Stdio::piped());
+        brew_upgrade.stderr(std::process::Stdio::piped());
+
+        let run = run_progress(
+            &mut brew_upgrade,
+            Some(progress_handler.clone()),
+            RunConfig::default(),
+        );
+        if let Err(err) = run {
+            return Err(io::Error::new(io::ErrorKind::Other, err.to_string()));
+        }
+
+        Ok(true)
+    }
+
+    fn download(&self, progress_handler: Box<&dyn ProgressHandler>) -> io::Result<bool> {
+        let binary = self.compatible_binary();
+        if binary.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "no compatible binary found for {} {}",
+                    *RELEASE_OS, *RELEASE_ARCH,
+                ),
+            ));
+        }
+        let binary = binary.unwrap();
+
+        // Prepare a temporary directory to download the assets
+        progress_handler.progress("preparing download".to_string());
+        let tmp_dir = tempfile::Builder::new().prefix("omni_update.").tempdir()?;
+
+        // Prepare the path to the tar.gz
+        let archive_name = Path::new(binary.url.as_str()).file_name();
+        if archive_name.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to get archive name",
+            ));
+        }
+        let archive_name = archive_name.unwrap();
+        let tarball_path = tmp_dir.path().join(archive_name);
+
+        // Download tar.gz to the temp directory
+        progress_handler.progress(format!("downloading: {}", binary.url));
+        let mut response = reqwest::blocking::get(binary.url.as_str());
+        if response.is_err() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("failed to download: {:?}", response),
+            ));
+        }
+        let mut response = response.unwrap();
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(tarball_path.as_path())?;
+        io::copy(&mut response, &mut file)?;
+
+        // Check the sha256
+        progress_handler.progress("checking archive integrity (sha256)".to_string());
+        let mut hasher = Sha256::new();
+        let mut tarball_file = std::fs::File::open(&tarball_path)?;
+        std::io::copy(&mut tarball_file, &mut hasher)?;
+        let sha256 = format!("{:x}", hasher.finalize());
+        if sha256 != binary.sha256 {
+            // Hashes don't match, something went wrong
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "hashes don't match: expected {}, got {}",
+                    binary.sha256, sha256
+                ),
+            ));
+        }
+
+        // Extract the archive in the temp directory
+        progress_handler.progress("extracting binary".to_string());
+        tarball_file.seek(SeekFrom::Start(0))?;
+        let tar = flate2::read::GzDecoder::new(tarball_file);
+        let mut archive = tar::Archive::new(tar);
+        archive.unpack(&tmp_dir.path())?;
+
+        // Replace current binary with new binary
+        progress_handler.progress("updating in-place".to_string());
+        let new_binary = tmp_dir.path().join("omni");
+        self_replace::self_replace(&new_binary)?;
+
+        progress_handler.progress("done".to_string());
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OmniReleaseBinary {
+    os: String,
+    arch: String,
+    url: String,
+    sha256: String,
+}


### PR DESCRIPTION
As was done in the ruby version, omni will offer to auto-update when a new version is published. This by default will be queried to the user, but can be configured (`path_repo_updates.self_update`) to never happen (`false`), happen automatically (`true`) or keep asking (`ask`, which is the default).

The update will work for binary installs, having the binary download the new version tarball, check against the sha256 for integrity, and replace itself. It will also work for brew installs, where the binary will simply call `brew upgrade xaf/omni/omni` to trigger an upgrade of itself.

Closes https://github.com/XaF/omni/issues/24