### PR TITLE
✨ Add caching for asdf updates and plugin versions

### DIFF
--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -10,9 +10,9 @@ use crate::internal::commands::path::omnipath;
 use crate::internal::config::config;
 use crate::internal::config::config_loader;
 use crate::internal::config::CommandSyntax;
+use crate::internal::get_cache;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
-use crate::internal::CACHE;
 use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_header;
@@ -172,7 +172,7 @@ impl StatusCommand {
         println!("\n{}", format!("Cache").bold());
 
         // Use serde_yaml to convert the cache to yaml
-        let yaml_code = serde_yaml::to_string(&*CACHE).unwrap();
+        let yaml_code = serde_yaml::to_string(&get_cache()).unwrap();
         println!("{}", self.color_yaml(&yaml_code));
     }
 

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -34,6 +34,7 @@ use crate::internal::config::ConfigExtendStrategy;
 use crate::internal::config::ConfigLoader;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::get_cache;
 use crate::internal::git::format_path;
 use crate::internal::git::safe_git_url_parse;
 use crate::internal::git::ORG_LOADER;
@@ -41,7 +42,6 @@ use crate::internal::git_env;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::internal::workdir_or_init;
-use crate::internal::CACHE;
 use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
@@ -545,7 +545,7 @@ impl UpCommand {
         let workdir = workdir(".");
         let repo_id = workdir.id();
         if repo_id.is_some() {
-            if let Some(trusted_repos) = &CACHE.trusted_repositories {
+            if let Some(trusted_repos) = get_cache().trusted_repositories {
                 if trusted_repos
                     .repositories
                     .contains(&repo_id.clone().unwrap())

--- a/src/internal/config/up/error.rs
+++ b/src/internal/config/up/error.rs
@@ -10,6 +10,7 @@ pub enum UpError {
     Config(String),
     Exec(String),
     Timeout(String),
+    Cache(String),
     HomebrewTapInUse,
 }
 
@@ -30,6 +31,7 @@ impl Display for UpError {
             UpError::Config(message) => write!(f, "configuration error: {}", message),
             UpError::Exec(message) => write!(f, "execution error: {}", message),
             UpError::Timeout(message) => write!(f, "timeout: {}", message),
+            UpError::Cache(message) => write!(f, "cache error: {}", message),
             UpError::HomebrewTapInUse => write!(f, "tap in use"),
         }
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,6 +1,6 @@
 pub mod cache;
+pub use cache::get_cache;
 pub use cache::Cache;
-pub use cache::CACHE;
 
 pub mod commands;
 pub use commands::command_loader;


### PR DESCRIPTION
This allows to avoid updating more than once a day, and checking for available versions more than once an hour. This thus allows for multiple successive 'up' commands to be faster, even more when doing auto-updates of many repositories.