### PR TITLE
feat: ✨ Add `suggest_config` and `suggest_clone` fingerprints

### DIFF
--- a/src/internal/cache/handler.rs
+++ b/src/internal/cache/handler.rs
@@ -120,7 +120,9 @@ where
     let cache_path = cache_dir_path.join(format!("{}.json", cache_name));
 
     let file = File::open(cache_path)?;
-    let _file_lock = file.lock_shared();
+    // TODO: re-evaluate, but shared lock does not seem necessary
+    // let _file_lock = file.lock_shared();
+
     let cache: C = serde_json::from_reader(file)?;
     Ok(cache)
 }

--- a/src/internal/cache/repositories.rs
+++ b/src/internal/cache/repositories.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::io;
 
 use serde::Deserialize;
@@ -19,6 +20,8 @@ const REPOSITORIES_CACHE_NAME: &str = "repositories";
 pub struct RepositoriesCache {
     #[serde(default = "BTreeSet::new", skip_serializing_if = "BTreeSet::is_empty")]
     pub trusted: BTreeSet<String>,
+    #[serde(default = "HashMap::new", skip_serializing_if = "HashMap::is_empty")]
+    pub fingerprints: HashMap<String, RepositoryFingerprints>,
     #[serde(default = "utils::origin_of_time", with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
 }
@@ -37,6 +40,65 @@ impl RepositoriesCache {
             false
         }
     }
+
+    pub fn check_fingerprint(
+        &self,
+        repository: &str,
+        fingerprint_type: &str,
+        fingerprint: u64,
+    ) -> bool {
+        let cur_fingerprint = match self.fingerprints.get(repository) {
+            Some(repo) => repo.get(fingerprint_type),
+            None => 0,
+        };
+
+        cur_fingerprint == fingerprint
+    }
+
+    pub fn update_fingerprint(
+        &mut self,
+        repository: &str,
+        fingerprint_type: &str,
+        fingerprint: u64,
+    ) -> bool {
+        if self.check_fingerprint(repository, fingerprint_type, fingerprint) {
+            return false;
+        }
+
+        if let None = self.fingerprints.get(repository) {
+            if fingerprint == 0 {
+                return false;
+            }
+            self.fingerprints
+                .insert(repository.to_string(), RepositoryFingerprints::new());
+        }
+
+        if let Some(repo) = self.fingerprints.get_mut(repository) {
+            let updated = if fingerprint == 0 {
+                let mut updated = repo.fingerprints.remove(fingerprint_type).is_some();
+
+                if repo.is_empty() {
+                    self.fingerprints.remove(repository);
+                    updated = true;
+                }
+
+                updated
+            } else {
+                repo.fingerprints
+                    .insert(fingerprint_type.to_string(), fingerprint);
+                true
+            };
+
+            if updated {
+                self.updated_at = OffsetDateTime::now_utc();
+                return true;
+            }
+
+            return false;
+        }
+
+        unreachable!();
+    }
 }
 
 impl Empty for RepositoriesCache {
@@ -49,6 +111,7 @@ impl CacheObject for RepositoriesCache {
     fn new_empty() -> Self {
         Self {
             trusted: BTreeSet::new(),
+            fingerprints: HashMap::new(),
             updated_at: utils::origin_of_time(),
         }
     }
@@ -70,5 +133,37 @@ impl CacheObject for RepositoriesCache {
             processing_fn,
             set_repositories_cache,
         )
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RepositoryFingerprints {
+    #[serde(
+        default = "HashMap::new",
+        skip_serializing_if = "HashMap::is_empty",
+        flatten
+    )]
+    fingerprints: HashMap<String, u64>,
+}
+
+impl RepositoryFingerprints {
+    pub fn new() -> Self {
+        Self {
+            fingerprints: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, fingerprint: &str) -> u64 {
+        if let Some(fingerprint) = self.fingerprints.get(fingerprint) {
+            *fingerprint
+        } else {
+            0
+        }
+    }
+}
+
+impl Empty for RepositoryFingerprints {
+    fn is_empty(&self) -> bool {
+        self.fingerprints.is_empty()
     }
 }

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -124,6 +124,7 @@ pub struct OmniConfig {
     pub clone: CloneConfig,
     pub up: Option<UpConfig>,
     pub suggest_clone: SuggestCloneConfig,
+    pub up_command: UpCommandConfig,
 }
 
 impl OmniConfig {
@@ -193,6 +194,7 @@ impl OmniConfig {
             clone: CloneConfig::from_config_value(config_value.get("clone")),
             up: UpConfig::from_config_value(config_value.get("up")),
             suggest_clone: SuggestCloneConfig::from_config_value(config_value.get("suggest_clone")),
+            up_command: UpCommandConfig::from_config_value(config_value.get("up_command")),
         }
     }
 
@@ -846,5 +848,29 @@ impl SuggestCloneRepositoryConfig {
         }
 
         None
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpCommandConfig {
+    pub auto_bootstrap: bool,
+}
+
+impl UpCommandConfig {
+    fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        if let Some(config_value) = config_value {
+            if let Some(config_value) = config_value.reject_label("git_repo") {
+                return Self {
+                    auto_bootstrap: match config_value.get("auto_bootstrap") {
+                        Some(value) => value.as_bool().unwrap(),
+                        None => true,
+                    },
+                };
+            }
+        }
+
+        Self {
+            auto_bootstrap: true,
+        }
     }
 }

--- a/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
+++ b/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
@@ -27,6 +27,7 @@ Omni configuration files accept the following parameters:
 | `suggest_config` | [suggest_config](parameters/suggest_config) | Configuration that a git repository suggests should be added to the user configuration. *Should only be used in git repositories configuration.* |
 | `suggest_clone` | [suggest_clone](parameters/suggest_clone) | Repositories that a git repository suggests should be clone. *Should only be used in git repositories configuration.* |
 | `up` | [up](parameters/up) (list) | List of operations needed to set up or tear down a repository |
+| `up_command` | [up_command](parameters/up_command) | Configuration related to the `omni up` command |
 | `worktree` | [worktree](parameters/worktree) (string) | Default location of the worktree, where the git repositories are expected to be located |
 
 ## Examples
@@ -82,4 +83,6 @@ path_repo_updates:
   ref_match: null # regex or null
   per_repo_config: {}
 repo_path_format: "%{host}/%{org}/%{repo}"
+up_command:
+  auto_bootstrap: true
 ```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -1,0 +1,20 @@
+---
+description: Configuration of the `up_command` parameter
+---
+
+# `up_command`
+
+## Parameters
+
+Configuration related to the `omni up` command.
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `auto_bootstrap` | boolean | whether or not to automatically run `omni up` with the `--bootstrap` parameter when changes to the configuration suggestions from the work directory are detected |
+
+## Example
+
+```yaml
+up_command:
+  auto_bootstrap: true
+```


### PR DESCRIPTION
This allows to take fingerprints of the contents of `suggest_config` and `suggest_clone` when bootstrapping a repository. No matter what the user decides to do, it saves that fingerprint and compares it on future runs, allowing to track any change to those from the repository point of view, which would warrant suggesting the changes again to the use.

This also introduces a new `up_command/auto_bootstrap` boolean configuration parameter to now default to `omni up --bootstrap` when running `omni up`, and thus automatically suggesting changes whenever the repository suggestions get updated.

Closes https://github.com/XaF/omni/issues/66