### PR TITLE
feat: ✨ Add support for 'packages'

### DIFF
--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -268,7 +268,7 @@ impl ScopeCommand {
             return;
         }
 
-        if let Some(repo_path) = ORG_LOADER.find_repo(repo, true) {
+        if let Some(repo_path) = ORG_LOADER.find_repo(repo, false, true) {
             if let Err(err) = std::env::set_current_dir(&repo_path) {
                 if !silent_failure {
                     omni_error!(format!(

--- a/src/internal/commands/fromconfig.rs
+++ b/src/internal/commands/fromconfig.rs
@@ -120,6 +120,7 @@ impl ConfigCommand {
         match self.details.source {
             ConfigSource::Default => "/default".to_string(),
             ConfigSource::File(ref path) => path.clone(),
+            ConfigSource::Package(ref path_entry_config) => path_entry_config.full_path.clone(),
             ConfigSource::Null => "/null".to_string(),
         }
     }

--- a/src/internal/commands/path.rs
+++ b/src/internal/commands/path.rs
@@ -4,6 +4,7 @@ use lazy_static::lazy_static;
 
 use crate::internal::config::config;
 use crate::internal::config::global_config;
+use crate::internal::config::parser::PathEntryConfig;
 use crate::internal::config::OmniConfig;
 use crate::internal::env::ENV;
 
@@ -17,9 +18,19 @@ pub fn omnipath() -> Vec<String> {
     omnipath_from_config(&config)
 }
 
-pub fn global_omnipath() -> Vec<String> {
+pub fn omnipath_entries() -> Vec<PathEntryConfig> {
+    let config = config(".");
+    omnipath_entries_from_config(&config)
+}
+
+// pub fn global_omnipath() -> Vec<String> {
+// let config = global_config();
+// omnipath_from_config(&config)
+// }
+
+pub fn global_omnipath_entries() -> Vec<PathEntryConfig> {
     let config = global_config();
-    omnipath_from_config(&config)
+    omnipath_entries_from_config(&config)
 }
 
 fn omnipath_from_config(config: &OmniConfig) -> Vec<String> {
@@ -27,20 +38,48 @@ fn omnipath_from_config(config: &OmniConfig) -> Vec<String> {
     let mut omnipath_seen = HashSet::new();
 
     for path in &config.path.prepend {
-        if !path.is_empty() && omnipath_seen.insert(path) {
-            omnipath.push(path.clone());
+        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+            omnipath.push(path.as_string());
         }
     }
 
     for path in &ENV.omnipath {
-        if !path.is_empty() && omnipath_seen.insert(path) {
+        if !path.is_empty() && omnipath_seen.insert(path.clone()) {
             omnipath.push(path.clone());
         }
     }
 
     for path in &config.path.append {
-        if !path.is_empty() && omnipath_seen.insert(path) {
-            omnipath.push(path.clone());
+        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+            omnipath.push(path.as_string());
+        }
+    }
+
+    omnipath
+}
+
+fn omnipath_entries_from_config(config: &OmniConfig) -> Vec<PathEntryConfig> {
+    let mut omnipath = vec![];
+    let mut omnipath_seen = HashSet::new();
+
+    for path in &config.path.prepend {
+        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+            omnipath.push(path.to_owned());
+        }
+    }
+
+    for path in &ENV.omnipath {
+        if !path.is_empty() && omnipath_seen.insert(path.clone()) {
+            let entry = PathEntryConfig::from_path(path);
+            if entry.is_valid() {
+                omnipath.push(entry);
+            }
+        }
+    }
+
+    for path in &config.path.append {
+        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+            omnipath.push(path.to_owned());
         }
     }
 

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -8,6 +8,12 @@ pub use org::ORG_LOADER;
 
 mod utils;
 pub use utils::format_path;
+pub use utils::format_path_with_template;
+pub use utils::full_git_url_parse;
+pub use utils::package_path_from_git_url;
+pub use utils::package_path_from_handle;
+pub use utils::package_root_path;
+pub use utils::path_entry_config;
 pub use utils::safe_git_url_parse;
 pub use utils::safe_normalize_url;
 

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -4,14 +4,33 @@ use std::time::Duration;
 
 use git_url_parse::normalize_url;
 use git_url_parse::GitUrl;
+use lazy_static::lazy_static;
 use tokio::runtime::Runtime;
 use tokio::time::timeout;
 use url::ParseError;
 use url::Url;
 
 use crate::internal::config;
+use crate::internal::config::parser::PathEntryConfig;
+use crate::internal::git_env;
+use crate::internal::ENV;
 
-/* These helpers are to avoid the risk of Regular Expression Denial of Service (ReDos) attacks.
+lazy_static! {
+    pub static ref PACKAGE_PATH: String = {
+        let omni_data_home = ENV.data_home.clone();
+        let package_path = format!("{}/packages", omni_data_home);
+
+        package_path
+    };
+}
+
+const PACKAGE_PATH_FORMAT: &str = "%{host}/%{org}/%{repo}";
+
+pub fn package_root_path() -> String {
+    PACKAGE_PATH.clone()
+}
+
+/* The safe_* helpers are to avoid the risk of Regular Expression Denial of Service (ReDos) attacks.
  * This is a similar issue to CVE-2023-32758 - https://github.com/advisories/GHSA-4xqq-73wg-5mjp
  * By setting a timeout, we prevent things from hanging indefinitely in case of such attack.
  */
@@ -46,12 +65,32 @@ pub fn safe_git_url_parse(url: &str) -> Result<GitUrl, <GitUrl as FromStr>::Err>
     })
 }
 
-pub fn format_path(worktree: &str, git_url: &GitUrl) -> PathBuf {
-    // Create a path object
-    let mut path = PathBuf::from(worktree.to_string());
+pub fn full_git_url_parse(url: &str) -> Result<GitUrl, <GitUrl as FromStr>::Err> {
+    // let url = safe_normalize_url(url)?;
+    // let git_url = safe_git_url_parse(url.as_str())?;
+    let git_url = safe_git_url_parse(url)?;
 
+    if git_url.scheme.to_string() == "file" {
+        return Err(<GitUrl as FromStr>::Err::new(ParseError::Overflow));
+    }
+
+    if git_url.name.is_empty() || git_url.owner.is_none() || git_url.host.is_none() {
+        return Err(<GitUrl as FromStr>::Err::new(ParseError::Overflow));
+    }
+
+    Ok(git_url)
+}
+
+pub fn format_path(worktree: &str, git_url: &GitUrl) -> PathBuf {
     // Get the configured path format
     let path_format = config(".").repo_path_format.clone();
+
+    format_path_with_template(worktree, git_url, path_format)
+}
+
+pub fn format_path_with_template(worktree: &str, git_url: &GitUrl, path_format: String) -> PathBuf {
+    // Create a path object
+    let mut path = PathBuf::from(worktree.to_string());
 
     // Replace %{host}, #{owner}, and %{repo} with the actual values
     let git_url = git_url.clone();
@@ -69,4 +108,67 @@ pub fn format_path(worktree: &str, git_url: &GitUrl) -> PathBuf {
 
     // Return the path as a string
     path
+}
+
+pub fn package_path_from_handle(handle: &str) -> Option<PathBuf> {
+    if let Ok(git_url) = full_git_url_parse(&handle) {
+        package_path_from_git_url(&git_url)
+    } else {
+        None
+    }
+}
+
+pub fn package_path_from_git_url(git_url: &GitUrl) -> Option<PathBuf> {
+    if git_url.scheme.to_string() == "file"
+        || git_url.name.is_empty()
+        || git_url.owner.is_none()
+        || git_url.host.is_none()
+    {
+        return None;
+    }
+
+    let package_path = format_path_with_template(
+        &PACKAGE_PATH.clone(),
+        &git_url,
+        PACKAGE_PATH_FORMAT.to_string(),
+    );
+
+    Some(PathBuf::from(package_path))
+}
+
+// pub fn package_id(path: &str) -> Option<String> {
+// let git_env = git_env(path);
+
+// if let (Some(id), Some(root)) = (git_env.id(), git_env.root()) {
+// if root.starts_with(&*PACKAGE_PATH.as_str()) {
+// return Some(id.to_string());
+// }
+// }
+
+// None
+// }
+
+pub fn path_entry_config<T: AsRef<str>>(path: T) -> PathEntryConfig {
+    let path: &str = path.as_ref();
+    let git_env = git_env(path);
+
+    let mut path_entry_config = PathEntryConfig {
+        path: path.to_string(),
+        package: None,
+        full_path: path.to_string(),
+    };
+
+    if let (Some(id), Some(root)) = (git_env.id(), git_env.root()) {
+        if root.starts_with(&*PACKAGE_PATH.as_str()) {
+            path_entry_config.package = Some(id.to_string());
+            path_entry_config.path = PathBuf::from(path)
+                .strip_prefix(root)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+        }
+    }
+
+    path_entry_config
 }

--- a/website/contents/reference/01-configuration/0102-parameters/010250-path.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-path.md
@@ -12,10 +12,19 @@ Once built, the omni path works like the `PATH` environment variable but for omn
 
 | Parameter  | Type           | Description                                       |
 |------------|----------------|---------------------------------------------------|
-| `append` | list of strings | List of the paths (strings) to append to the omni path |
-| `prepend` | list of strings | List of the paths (strings) to prepend to the omni path |
+| `append` | list of path entries | List of the paths to append to the omni path |
+| `prepend` | list of path entries | List of the paths to prepend to the omni path |
 
 If you want to be able to stack paths in different configuration files, you can take advantage of [the configuration merging strategies](suggest_config#configuration-merging-strategies).
+
+### Path entries
+
+Each path entry can either be a string or a map with the following keys:
+
+| Parameter  | Type           | Description                                       |
+|------------|----------------|---------------------------------------------------|
+| `package` | string | Handle of the repository to be used as a package; if provided and `path` is relative, the package path will be prepended to the value of `path` to compute the absolute path to be considered. |
+| `path` | string | The absolute or relative path to the directory to be added to the omni path. If relative and not provided alongside a `package` value, will be considered as a relative path from the directory of the configuration file containing the path entry. |
 
 ## Example
 
@@ -24,9 +33,13 @@ path:
   append:
     - /absolute/path
     - relative/path
+    - path: /other/absolute/path
+    - package: git@github.com:XaF/omni
+      path: path/in/the/package
   prepend:
     - /absolute/path
     - relative/path
+    - path: other/relative/path
 ```
 
 ## Environment

--- a/website/contents/reference/02-builtin-commands/0250-cd.md
+++ b/website/contents/reference/02-builtin-commands/0250-cd.md
@@ -15,6 +15,7 @@ If no repository or path is specified, change to the git directory of the first 
 | Argument        | Value type | Description                                         |
 |-----------------|------------|-----------------------------------------------------|
 | `--locate` | bool | If provided, will only return the path to the repository instead of switching directory to it. When this flag is passed, interactions are also disabled, as it is assumed to be used for command line purposes. This will exit with 0 if the repository is found, 1 otherwise. |
+| `--[no-]include-packages` | bool | If provided, overrides the default behavior of considering or not packages when calling the command. When using `--locate`, packages will by default be included, otherwise they won't. |
 | `repo` | string | The name of the repo to change directory to; this can be in the format of a full git URL, or `<org>/<repo>`, or just `<repo>`, in which case the repo will be searched for in all the organizations in the order in which they are defined, and then trying all the other repositories in the configured worktrees. |
 
 ## Examples

--- a/website/contents/reference/02-builtin-commands/0250-clone.md
+++ b/website/contents/reference/02-builtin-commands/0250-clone.md
@@ -24,6 +24,7 @@ Upon successful cloning, `omni clone` will run `omni up --update-user-config` in
 
 | Option          | Value type | Description                                         |
 |-----------------|------------|-----------------------------------------------------|
+| `--package`  | bool | Clone the repository as a package, instead of the worktree |
 | `options...` | any | Any additional options to pass to git clone. |
 
 ## Examples
@@ -44,4 +45,7 @@ omni clone omni --branch some_other_branch
 
 # Or really, any other parameter that `git clone` supports
 omni clone omni --depth 1
+
+# Clone the repository as a package
+omni clone --package https://github.com/XaF/omni
 ```

--- a/website/contents/reference/02-builtin-commands/0250-tidy.md
+++ b/website/contents/reference/02-builtin-commands/0250-tidy.md
@@ -4,11 +4,13 @@ description: Builtin command `tidy`
 
 # `tidy`
 
-Organize your git repositories using the configured format
+Organize your git repositories using the configured format.
 
 This will offer to organize your git repositories, moving them from their current path to the path they should be at
 if they had been cloned using `omni clone`. This is useful if you have a bunch of repositories that you have cloned
 manually, and you want to start using omni, or if you changed your mind on the repo path format you wish to use.
+
+This will also download any package in your global omnipath that is not yet downloaded.
 
 ## Parameters
 


### PR DESCRIPTION
This might include **breaking changes** in terms of the behaviors of some commands.

Packages are a stable, non-development copy of a git repository that can be used for providing commands in a stable way. Those repositories will be cloned in a different (data) directory than the development repositories, and will be loaded in the omnipath as a simple package reference, e.g.

```
path:
  append:
    - package: git@github.com:XaF/omni
      path: cmd
```

This will be handled the same way as the regular omnipath is, except that it won't be in your development directories. Use this approach for repositories that provide you commands, but that you don't expect to develop with. You can also use this as to have a stable copy of a repository, even if that repository also exists in your development directories.

The following configuration is affected by this change:
- `suggest_clone` entries could take `handle` and `args`, and can now also take `clone_type` as one of `package` or `worktree`, affecting how the package is going to be suggested to the user when suggesting the clone; this defaults to `package` if not specified

The following commands are also evolved from this change:
- `omni up` now defaults to clone suggested repositories as packages, with a new option `p` when being asked about cloning or not those repositories. The `y` option is still available to clone in the worktree. When splitting the list with `s`, a second question will be asked the user, allowing to individually indicate how to clone each selected repository.
- `omni clone` gets a new `--package` option to clone a repository as a package. It will default to clone, as usual, in the development worktree corresponding to the matching organization.
- `omni cd` gets a new `--[no-]include-packages` option to indicate whether to include or not packages when calling `omni cd`. This defaults to not including packages when calling `omni cd` directly as it is expected to be used for development purposes, but will default to including packages when calling `omni cd` with the `--locate` option as it is expected to be used in programmatic uses. The option allows to force one behavior or the other.
- Repository location, using `omni scope` and `omni cd` will now consider the omnipath in priority to locating the repository in order of organizations.
- `omni tidy` will identify and clone packages in the omnipath that are not available locally

Closes https://github.com/XaF/omni/issues/16