### PR TITLE
chore(refactor): arguments and options are now a list

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -213,15 +213,15 @@ impl Command {
             if let Some(syntax_usage) = syntax.usage {
                 usage += &format!(" {}", syntax_usage);
             } else {
-                if !syntax.arguments.is_empty() {
-                    for arg in syntax.arguments {
-                        usage += &format!(" <{}>", arg.name).cyan();
-                    }
-                }
-
-                if !syntax.options.is_empty() {
-                    for opt in syntax.options {
-                        usage += &format!(" [{}]", opt.name).cyan();
+                if !syntax.parameters.is_empty() {
+                    for param in syntax.parameters {
+                        let param_usage = if param.required {
+                            format!(" <{}>", param.name)
+                        } else {
+                            format!(" [{}]", param.name)
+                        }
+                        .cyan();
+                        usage += &param_usage;
                     }
                 }
             }

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -140,8 +140,7 @@ impl CdCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![],
-            options: vec![
+            parameters: vec![
                 SyntaxOptArg {
                     name: "--locate".to_string(),
                     desc: Some(
@@ -153,6 +152,7 @@ impl CdCommand {
                         )
                         .to_string()
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--[no-]include-packages".to_string(),
@@ -164,6 +164,7 @@ impl CdCommand {
                         )
                         .to_string()
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "repo".to_string(),
@@ -176,6 +177,7 @@ impl CdCommand {
                         )
                         .to_string()
                     ),
+                    required: false,
                 },
             ],
         })

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -142,20 +142,32 @@ impl CloneCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![
-                SyntaxOptArg {
-                    name: "repo".to_string(),
-                    desc: Some("The repository to clone; this can be in format <org>/<repo>, just <repo>, or the full URL. If the case where only the repo name is specified, \x1B[3mOMNI_ORG\x1B[0m will be used to search for the repository to clone.".to_string()),
-                },
-            ],
-            options: vec![
+            parameters: vec![
                 SyntaxOptArg {
                     name: "--package".to_string(),
-                    desc: Some("Clone the repository as a package \x1B[90m(default: no)\x1B[0m".to_string()),
+                    desc: Some(
+                        "Clone the repository as a package \x1B[90m(default: no)\x1B[0m"
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "repo".to_string(),
+                    desc: Some(
+                        concat!(
+                            "The repository to clone; this can be in format <org>/<repo>, ",
+                            "just <repo>, or the full URL. If the case where only the repo ",
+                            "name is specified, \x1B[3mOMNI_ORG\x1B[0m will be used to search ",
+                            "for the repository to clone."
+                        )
+                        .to_string(),
+                    ),
+                    required: true,
                 },
                 SyntaxOptArg {
                     name: "options...".to_string(),
                     desc: Some("Any additional options to pass to git clone.".to_string()),
+                    required: false,
                 },
             ],
         })

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -117,10 +117,10 @@ impl HelpCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![],
-            options: vec![SyntaxOptArg {
+            parameters: vec![SyntaxOptArg {
                 name: "command".to_string(),
                 desc: Some("The command to get help for".to_string()),
+                required: false,
             }],
         })
     }
@@ -199,19 +199,21 @@ impl HelpCommand {
         );
 
         if let Some(syntax) = command.syntax() {
-            if syntax.arguments.len() > 0 || syntax.options.len() > 0 {
+            if syntax.parameters.len() > 0 {
                 // Make a single vector with contents from both syntax.arguments and syntax.options
-                let mut args = syntax.arguments.clone();
-                args.extend(syntax.options.clone());
-
-                let longest = args.iter().map(|arg| arg.name.len()).max().unwrap_or(0);
+                let longest = syntax
+                    .parameters
+                    .iter()
+                    .map(|arg| arg.name.len())
+                    .max()
+                    .unwrap_or(0);
                 let ljust = std::cmp::max(longest + 2, 15);
                 let join_str = format!("\n  {}", " ".repeat(ljust));
 
-                for arg in args {
+                for arg in syntax.parameters.iter() {
                     let missing_just = ljust - arg.name.len();
                     let str_name = format!("  {}{}", arg.name.cyan(), " ".repeat(missing_just));
-                    let help = if let Some(desc) = arg.desc {
+                    let help = if let Some(desc) = &arg.desc {
                         wrap_text(&desc, max_width - ljust).join(join_str.as_str())
                     } else {
                         "".to_string()

--- a/src/internal/commands/builtin/hook.rs
+++ b/src/internal/commands/builtin/hook.rs
@@ -47,14 +47,18 @@ impl HookCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![SyntaxOptArg {
-                name: "hook".to_string(),
-                desc: Some("Which hook to call".to_string()),
-            }],
-            options: vec![SyntaxOptArg {
-                name: "options...".to_string(),
-                desc: Some("Any options to pass to the hook.".to_string()),
-            }],
+            parameters: vec![
+                SyntaxOptArg {
+                    name: "hook".to_string(),
+                    desc: Some("Which hook to call".to_string()),
+                    required: true,
+                },
+                SyntaxOptArg {
+                    name: "options...".to_string(),
+                    desc: Some("Any options to pass to the hook.".to_string()),
+                    required: false,
+                },
+            ],
         })
     }
 

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -125,20 +125,35 @@ impl ScopeCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![
+            parameters: vec![
                 SyntaxOptArg {
                     name: "repo".to_string(),
-                    desc: Some("The name of the repo to run commands in the context of; this can be in the format <org>/<repo>, or just <repo>, in which case the repo will be searched for in all the organizations, trying to use \x1B[3mOMNI_ORG\x1B[0m if it is set, and then trying all the other organizations alphabetically.".to_string()),
+                    desc: Some(
+                        concat!(
+                            "The name of the repo to run commands in the context of; this ",
+                            "can be in the format <org>/<repo>, or just <repo>, in which case ",
+                            "the repo will be searched for in all the organizations, trying ",
+                            "to use \x1B[3mOMNI_ORG\x1B[0m if it is set, and then trying all ",
+                            "the other organizations alphabetically."
+                        )
+                        .to_string(),
+                    ),
+                    required: true,
                 },
                 SyntaxOptArg {
                     name: "command".to_string(),
-                    desc: Some("The omni command to run in the context of the specified repository.".to_string()),
+                    desc: Some(
+                        "The omni command to run in the context of the specified repository."
+                            .to_string(),
+                    ),
+                    required: true,
+                },
+                SyntaxOptArg {
+                    name: "options...".to_string(),
+                    desc: Some("Any options to pass to the omni command.".to_string()),
+                    required: false,
                 },
             ],
-            options: vec![SyntaxOptArg {
-                name: "options...".to_string(),
-                desc: Some("Any options to pass to the omni command.".to_string()),
-            }],
         })
     }
 

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -105,8 +105,7 @@ impl StatusCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![],
-            options: vec![],
+            parameters: vec![],
         })
     }
 

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -168,13 +168,13 @@ impl TidyCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![],
-            options: vec![
+            parameters: vec![
                 SyntaxOptArg {
                     name: "--yes".to_string(),
                     desc: Some(
                         "Do not ask for confirmation before organizing repositories".to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--search-path".to_string(),
@@ -185,6 +185,7 @@ impl TidyCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--up-all".to_string(),
@@ -198,6 +199,7 @@ impl TidyCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
             ],
         })

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -285,8 +285,7 @@ impl UpCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![],
-            options: vec![
+            parameters: vec![
                 SyntaxOptArg {
                     name: "--bootstrap".to_string(),
                     desc: Some(
@@ -297,6 +296,7 @@ impl UpCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--clone-suggested".to_string(),
@@ -308,6 +308,7 @@ impl UpCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--trust".to_string(),
@@ -315,6 +316,7 @@ impl UpCommand {
                         "Define how to trust the repository (always/yes/no) to run the command"
                             .to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--update-repository".to_string(),
@@ -326,6 +328,7 @@ impl UpCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
                 SyntaxOptArg {
                     name: "--update-user-config".to_string(),
@@ -339,6 +342,7 @@ impl UpCommand {
                         )
                         .to_string(),
                     ),
+                    required: false,
                 },
             ],
         })

--- a/src/internal/commands/void.rs
+++ b/src/internal/commands/void.rs
@@ -40,14 +40,18 @@ impl VoidCommand {
     pub fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
-            arguments: vec![SyntaxOptArg {
-                name: "subcommand".to_string(),
-                desc: Some("Subcommand to be called".to_string()),
-            }],
-            options: vec![SyntaxOptArg {
-                name: "options...".to_string(),
-                desc: Some("Options to pass to the subcommand".to_string()),
-            }],
+            parameters: vec![
+                SyntaxOptArg {
+                    name: "subcommand".to_string(),
+                    desc: Some("Subcommand to be called".to_string()),
+                    required: true,
+                },
+                SyntaxOptArg {
+                    name: "options...".to_string(),
+                    desc: Some("Options to pass to the subcommand".to_string()),
+                    required: false,
+                },
+            ],
         })
     }
 


### PR DESCRIPTION
Arguments and options were two separate lists and are now handled as a single list, allowing to keep the order of parameters as provided.

Closes https://github.com/XaF/omni/issues/181