### PR TITLE
chore(deps): 📦 cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1369bc6b9e9a7dfdae2055f6ec151fe9c554a9d23d357c0237cee2e25eaabb7"
+checksum = "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f5ebdc942f57ed96d560a6d1a459bae5851102a25d5bf89dc04ae453e31ecf"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
  "phf",


### PR DESCRIPTION
Updating `Cargo.lock` with `cargo update`

The following crate dependencies are to be updated:

- [`chrono-tz`](https://crates.io/crates/chrono-tz) ([`v0.8.3`](https://docs.rs/chrono-tz/0.8.3/) -> [`v0.8.4`](https://docs.rs/chrono-tz/0.8.4/))
- [`chrono-tz-build`](https://crates.io/crates/chrono-tz-build) ([`v0.2.0`](https://docs.rs/chrono-tz-build/0.2.0/) -> [`v0.2.1`](https://docs.rs/chrono-tz-build/0.2.1/))
