### PR TITLE
feat(help): ✨ add `--unfold` flag to show all commands

### DIFF
--- a/website/contents/reference/02-builtin-commands/0250-help.md
+++ b/website/contents/reference/02-builtin-commands/0250-help.md
@@ -18,14 +18,21 @@ Printing the help of a specific command will show you the `Source:` of that comm
 
 | Option          | Value type | Description                                         |
 |-----------------|------------|-----------------------------------------------------|
+| `--unfold` | bool | Show all the commands, instead of folding them |
 | `command` | string... | The command to get help for. |
 
 ## Examples
 
 ```bash
-# Show all available commands
+# Show all available commands (folds when >1 subcommand)
 omni help
 
-# Show help for a specific command
+# Show all available commands (no fold)
+omni help --unfold
+
+# Show help for a specific command, and list all subcommands (folds)
 omni help cd
+
+# Show help for a specific command, and list all subcommands (no fold)
+omni help --unfold cd
 ```


### PR DESCRIPTION
Since 74463b9 (#182) the commands are folded by default in `omni help`; this allows to pass a `--unfold` flag to the help command in order to see all commands.