### PR TITLE
chore(deps): 📦 cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1485,9 +1485,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.58"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.94"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -2100,7 +2100,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -2763,9 +2763,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2773,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -2788,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2800,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2823,15 +2823,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3048,18 +3048,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.20"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.20"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Updating `Cargo.lock` with `cargo update`

The following crate dependencies are to be updated:

- [`indexmap`](https://crates.io/crates/indexmap) ([`v2.0.2`](https://docs.rs/indexmap/2.0.2/) -> [`v2.1.0`](https://docs.rs/indexmap/2.1.0/))
- [`js-sys`](https://crates.io/crates/js-sys) ([`v0.3.64`](https://docs.rs/js-sys/0.3.64/) -> [`v0.3.65`](https://docs.rs/js-sys/0.3.65/))
- [`openssl`](https://crates.io/crates/openssl) ([`v0.10.58`](https://docs.rs/openssl/0.10.58/) -> [`v0.10.59`](https://docs.rs/openssl/0.10.59/))
- [`openssl-sys`](https://crates.io/crates/openssl-sys) ([`v0.9.94`](https://docs.rs/openssl-sys/0.9.94/) -> [`v0.9.95`](https://docs.rs/openssl-sys/0.9.95/))
- [`wasm-bindgen`](https://crates.io/crates/wasm-bindgen) ([`v0.2.87`](https://docs.rs/wasm-bindgen/0.2.87/) -> [`v0.2.88`](https://docs.rs/wasm-bindgen/0.2.88/))
- [`wasm-bindgen-backend`](https://crates.io/crates/wasm-bindgen-backend) ([`v0.2.87`](https://docs.rs/wasm-bindgen-backend/0.2.87/) -> [`v0.2.88`](https://docs.rs/wasm-bindgen-backend/0.2.88/))
- [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures) ([`v0.4.37`](https://docs.rs/wasm-bindgen-futures/0.4.37/) -> [`v0.4.38`](https://docs.rs/wasm-bindgen-futures/0.4.38/))
- [`wasm-bindgen-macro`](https://crates.io/crates/wasm-bindgen-macro) ([`v0.2.87`](https://docs.rs/wasm-bindgen-macro/0.2.87/) -> [`v0.2.88`](https://docs.rs/wasm-bindgen-macro/0.2.88/))
- [`wasm-bindgen-macro-support`](https://crates.io/crates/wasm-bindgen-macro-support) ([`v0.2.87`](https://docs.rs/wasm-bindgen-macro-support/0.2.87/) -> [`v0.2.88`](https://docs.rs/wasm-bindgen-macro-support/0.2.88/))
- [`wasm-bindgen-shared`](https://crates.io/crates/wasm-bindgen-shared) ([`v0.2.87`](https://docs.rs/wasm-bindgen-shared/0.2.87/) -> [`v0.2.88`](https://docs.rs/wasm-bindgen-shared/0.2.88/))
- [`web-sys`](https://crates.io/crates/web-sys) ([`v0.3.64`](https://docs.rs/web-sys/0.3.64/) -> [`v0.3.65`](https://docs.rs/web-sys/0.3.65/))
- [`zerocopy`](https://crates.io/crates/zerocopy) ([`v0.7.20`](https://docs.rs/zerocopy/0.7.20/) -> [`v0.7.25`](https://docs.rs/zerocopy/0.7.25/))
- [`zerocopy-derive`](https://crates.io/crates/zerocopy-derive) ([`v0.7.20`](https://docs.rs/zerocopy-derive/0.7.20/) -> [`v0.7.25`](https://docs.rs/zerocopy-derive/0.7.25/))
