### PR TITLE
feat: ✨ add new `config path switch` command

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -2,6 +2,7 @@ use std::process::exit;
 
 use crate::internal::commands::builtin::CdCommand;
 use crate::internal::commands::builtin::CloneCommand;
+use crate::internal::commands::builtin::ConfigPathSwitchCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::builtin::HookCommand;
 use crate::internal::commands::builtin::HookEnvCommand;
@@ -27,6 +28,7 @@ use crate::omni_error;
 pub enum Command {
     BuiltinCd(CdCommand),
     BuiltinClone(CloneCommand),
+    BuiltinConfigPathSwitch(ConfigPathSwitchCommand),
     BuiltinHelp(HelpCommand),
     BuiltinHook(HookCommand),
     BuiltinHookEnv(HookEnvCommand),
@@ -47,6 +49,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.name(),
             Command::BuiltinClone(command) => command.name(),
+            Command::BuiltinConfigPathSwitch(command) => command.name(),
             Command::BuiltinHelp(command) => command.name(),
             Command::BuiltinHook(command) => command.name(),
             Command::BuiltinHookEnv(command) => command.name(),
@@ -71,6 +74,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.aliases(),
             Command::BuiltinClone(command) => command.aliases(),
+            Command::BuiltinConfigPathSwitch(command) => command.aliases(),
             Command::BuiltinHelp(command) => command.aliases(),
             Command::BuiltinHook(command) => command.aliases(),
             Command::BuiltinHookEnv(command) => command.aliases(),
@@ -106,6 +110,7 @@ impl Command {
         match self {
             Command::BuiltinCd(_) => "builtin".to_string(),
             Command::BuiltinClone(_) => "builtin".to_string(),
+            Command::BuiltinConfigPathSwitch(_) => "builtin".to_string(),
             Command::BuiltinHelp(_) => "builtin".to_string(),
             Command::BuiltinHook(_) => "builtin".to_string(),
             Command::BuiltinHookEnv(_) => "builtin".to_string(),
@@ -159,6 +164,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.syntax(),
             Command::BuiltinClone(command) => command.syntax(),
+            Command::BuiltinConfigPathSwitch(command) => command.syntax(),
             Command::BuiltinHelp(command) => command.syntax(),
             Command::BuiltinHook(command) => command.syntax(),
             Command::BuiltinHookEnv(command) => command.syntax(),
@@ -179,6 +185,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.category(),
             Command::BuiltinClone(command) => command.category(),
+            Command::BuiltinConfigPathSwitch(command) => command.category(),
             Command::BuiltinHelp(command) => command.category(),
             Command::BuiltinHook(command) => command.category(),
             Command::BuiltinHookEnv(command) => command.category(),
@@ -199,6 +206,7 @@ impl Command {
         let help: Option<String> = match self {
             Command::BuiltinCd(command) => command.help(),
             Command::BuiltinClone(command) => command.help(),
+            Command::BuiltinConfigPathSwitch(command) => command.help(),
             Command::BuiltinHelp(command) => command.help(),
             Command::BuiltinHook(command) => command.help(),
             Command::BuiltinHookEnv(command) => command.help(),
@@ -329,6 +337,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.exec(argv),
             Command::BuiltinClone(command) => command.exec(argv),
+            Command::BuiltinConfigPathSwitch(command) => command.exec(argv),
             Command::BuiltinHelp(command) => command.exec(argv),
             Command::BuiltinHook(_command) => {}
             Command::BuiltinHookEnv(command) => command.exec(argv),
@@ -350,6 +359,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.autocompletion(),
             Command::BuiltinClone(command) => command.autocompletion(),
+            Command::BuiltinConfigPathSwitch(command) => command.autocompletion(),
             Command::BuiltinHelp(command) => command.autocompletion(),
             Command::BuiltinHook(command) => command.autocompletion(),
             Command::BuiltinHookEnv(command) => command.autocompletion(),
@@ -380,6 +390,7 @@ impl Command {
         match self {
             Command::BuiltinCd(command) => command.autocomplete(comp_cword, argv),
             Command::BuiltinClone(command) => command.autocomplete(comp_cword, argv),
+            Command::BuiltinConfigPathSwitch(command) => command.autocomplete(comp_cword, argv),
             Command::BuiltinHelp(command) => command.autocomplete(comp_cword, argv),
             Command::BuiltinHook(command) => command.autocomplete(comp_cword, argv),
             Command::BuiltinHookEnv(command) => command.autocomplete(comp_cword, argv),

--- a/src/internal/commands/builtin/config/mod.rs
+++ b/src/internal/commands/builtin/config/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod path;
+pub(crate) use path::ConfigPathSwitchCommand;

--- a/src/internal/commands/builtin/config/path/mod.rs
+++ b/src/internal/commands/builtin/config/path/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod switch;
+pub(crate) use switch::ConfigPathSwitchCommand;

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -1,0 +1,495 @@
+use std::path::PathBuf;
+use std::process::exit;
+use std::time::Duration;
+
+use clap;
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
+use once_cell::sync::OnceCell;
+
+use crate::internal::commands::builtin::CloneCommand;
+use crate::internal::commands::builtin::HelpCommand;
+use crate::internal::commands::builtin::TidyGitRepo;
+use crate::internal::commands::builtin::UpCommand;
+use crate::internal::commands::path::global_omnipath_entries;
+use crate::internal::config::CommandSyntax;
+use crate::internal::config::SyntaxOptArg;
+use crate::internal::git::full_git_url_parse;
+use crate::internal::git::id_from_git_url;
+use crate::internal::git::package_path_from_handle;
+use crate::internal::git::path_entry_config;
+use crate::internal::git::ORG_LOADER;
+use crate::internal::git_env;
+use crate::internal::user_interface::StringColor;
+use crate::internal::workdir_flush_cache;
+use crate::internal::ENV;
+use crate::omni_error;
+use crate::omni_info;
+
+#[derive(Debug, Clone)]
+struct ConfigPathSwitchCommandArgs {
+    repository: Option<String>,
+    source: ConfigPathSwitchCommandArgsSource,
+}
+
+#[derive(Debug, Clone)]
+enum ConfigPathSwitchCommandArgsSource {
+    Package,
+    Worktree,
+    Toggle,
+}
+
+impl ConfigPathSwitchCommandArgs {
+    fn parse(argv: Vec<String>) -> Self {
+        let mut parse_argv = vec!["".to_string()];
+        parse_argv.extend(argv);
+
+        let matches = clap::Command::new("")
+            .disable_help_subcommand(true)
+            .disable_version_flag(true)
+            .arg(
+                clap::Arg::new("package")
+                    .long("package")
+                    .short('p')
+                    .conflicts_with("worktree")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("worktree")
+                    .long("worktree")
+                    .short('w')
+                    .conflicts_with("package")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(clap::Arg::new("repo").action(clap::ArgAction::Set))
+            .try_get_matches_from(&parse_argv);
+
+        if let Err(err) = matches {
+            match err.kind() {
+                clap::error::ErrorKind::DisplayHelp
+                | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+                    HelpCommand::new().exec(vec!["status".to_string()]);
+                }
+                clap::error::ErrorKind::DisplayVersion => {
+                    unreachable!("version flag is disabled");
+                }
+                _ => {
+                    let err_str = format!("{}", err);
+                    let err_str = err_str
+                        .split('\n')
+                        .take_while(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let err_str = err_str.trim_start_matches("error: ");
+                    omni_error!(err_str);
+                }
+            }
+            exit(1);
+        }
+
+        let matches = matches.unwrap();
+
+        if *matches.get_one::<bool>("help").unwrap_or(&false) {
+            HelpCommand::new().exec(vec![
+                "config".to_string(),
+                "path".to_string(),
+                "switch".to_string(),
+            ]);
+            exit(1);
+        }
+
+        let source = if *matches.get_one::<bool>("package").unwrap_or(&false) {
+            ConfigPathSwitchCommandArgsSource::Package
+        } else if *matches.get_one::<bool>("worktree").unwrap_or(&false) {
+            ConfigPathSwitchCommandArgsSource::Worktree
+        } else {
+            ConfigPathSwitchCommandArgsSource::Toggle
+        };
+
+        Self {
+            repository: matches.get_one::<String>("repo").map(|arg| arg.to_string()),
+            source: source,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigPathSwitchCommand {
+    cli_args: OnceCell<ConfigPathSwitchCommandArgs>,
+}
+
+impl ConfigPathSwitchCommand {
+    pub fn new() -> Self {
+        Self {
+            cli_args: OnceCell::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn cli_args(&self) -> &ConfigPathSwitchCommandArgs {
+        self.cli_args.get_or_init(|| {
+            omni_error!("command arguments not initialized");
+            exit(1);
+        })
+    }
+
+    pub fn name(&self) -> Vec<String> {
+        vec![
+            "config".to_string(),
+            "path".to_string(),
+            "switch".to_string(),
+        ]
+    }
+
+    pub fn aliases(&self) -> Vec<Vec<String>> {
+        vec![]
+    }
+
+    pub fn help(&self) -> Option<String> {
+        Some(
+            concat!(
+                "Switch the source of a repository in the omnipath.\n",
+                "\n",
+                "This allows to change the omnipath source from using a package or ",
+                "a development version in a worktree.\n",
+                "\n",
+                "When switching into a mode, if the source of the requested type does ",
+                "not exist, the repository will be cloned.\n",
+            )
+            .to_string(),
+        )
+    }
+
+    pub fn syntax(&self) -> Option<CommandSyntax> {
+        Some(CommandSyntax {
+            usage: None,
+            parameters: vec![
+                SyntaxOptArg {
+                    name: "--<source>".to_string(),
+                    desc: Some(
+                        concat!(
+                            "The source to use for the repository; this can be either ",
+                            "\x1B[1m--package\x1B[0m or \x1B[1m--worktree\x1B[0m, or will ",
+                            "toggle between the two if not specified.\n",
+                        )
+                        .to_string()
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "repo".to_string(),
+                    desc: Some(
+                        concat!(
+                            "The name of the repository to switch the source from; this can be in the format ",
+                            "<org>/<repo>, or just <repo>. If the repository is not provided, the current ",
+                            "repository will be used, or the command will fail if not in a repository. If ",
+                            "the repo is not found in the omnipath, the command will fail.\n",
+                        )
+                        .to_string()
+                    ),
+                    required: false,
+                },
+            ],
+        })
+    }
+
+    pub fn category(&self) -> Option<Vec<String>> {
+        Some(vec!["General".to_string()])
+    }
+
+    pub fn exec(&self, argv: Vec<String>) {
+        if let Err(_) = self.cli_args.set(ConfigPathSwitchCommandArgs::parse(argv)) {
+            unreachable!();
+        }
+
+        let mut repo_id = None;
+        let mut repo_handle = None;
+        let mut worktree_path = None;
+        let mut package_path = None;
+
+        if let Some(repo) = self.cli_args().repository.clone() {
+            let repo_path = ORG_LOADER.find_repo(&repo, true, false);
+            if let Some(repo_path) = repo_path {
+                let git = git_env(&repo_path.to_string_lossy());
+                if git.in_repo() && git.has_origin() {
+                    repo_handle = Some(git.origin().unwrap().to_string());
+                    package_path = package_path_from_handle(&repo_handle.clone().unwrap());
+                    if let Some(package_path) = package_path.clone() {
+                        if package_path != repo_path {
+                            worktree_path = Some(repo_path);
+                        }
+                    }
+                }
+            }
+
+            if repo_handle.is_none() || worktree_path.is_none() {
+                let clone_command = CloneCommand::new();
+                let lookup_repo = repo_handle.unwrap_or(repo.clone());
+                let remote_repo = clone_command.lookup_repo_handle(
+                    &lookup_repo,
+                    false,
+                    if ENV.interactive_shell {
+                        let spinner = ProgressBar::new_spinner();
+                        spinner.set_style(
+                            ProgressStyle::default_spinner()
+                                .template("{spinner:.green} {msg:.green}")
+                                .unwrap(),
+                        );
+                        spinner.set_message(format!("Looking for {}", lookup_repo));
+                        spinner.enable_steady_tick(Duration::from_millis(50));
+                        Some(spinner)
+                    } else {
+                        None
+                    },
+                );
+                if remote_repo.is_none() {
+                    omni_error!(format!(
+                        "could not find repository {}",
+                        lookup_repo.yellow()
+                    ));
+                    exit(1);
+                }
+                let (repo_path, repo_git_url) = remote_repo.unwrap();
+
+                repo_id = id_from_git_url(&repo_git_url);
+                repo_handle = Some(repo_git_url.to_string());
+                worktree_path = Some(repo_path);
+                package_path = package_path_from_handle(&repo_handle.clone().unwrap());
+            }
+        } else {
+            let git = git_env(".");
+            if !git.in_repo() {
+                omni_error!("not in a repository");
+                exit(1);
+            }
+            if !git.has_origin() {
+                omni_error!("repository does not have an origin");
+                exit(1);
+            }
+
+            repo_handle = Some(git.origin().unwrap().to_string());
+            package_path = package_path_from_handle(&repo_handle.clone().unwrap());
+            let git_root = git.root().unwrap();
+            if let Some(package_path) = package_path.clone() {
+                if package_path != PathBuf::from(&git_root) {
+                    worktree_path = Some(git_root.into());
+                }
+            }
+
+            if worktree_path.is_none() {
+                let lookup_repo = repo_handle.clone().unwrap();
+                let clone_command = CloneCommand::new();
+                // Create a spinner to show that we're looking for the repository
+                let remote_repo = clone_command.lookup_repo_handle(
+                    &lookup_repo,
+                    false,
+                    if ENV.interactive_shell {
+                        let spinner = ProgressBar::new_spinner();
+                        spinner.set_style(
+                            ProgressStyle::default_spinner()
+                                .template("{spinner:.green} {msg:.green}")
+                                .unwrap(),
+                        );
+                        spinner.set_message(format!("Looking for {}", lookup_repo));
+                        spinner.enable_steady_tick(Duration::from_millis(50));
+                        Some(spinner)
+                    } else {
+                        None
+                    },
+                );
+                if remote_repo.is_none() {
+                    omni_error!(format!(
+                        "could not find repository {}",
+                        lookup_repo.yellow()
+                    ));
+                    exit(1);
+                }
+                let (repo_path, repo_git_url) = remote_repo.unwrap();
+
+                repo_id = id_from_git_url(&repo_git_url);
+                repo_handle = Some(repo_git_url.to_string());
+                worktree_path = Some(repo_path);
+            }
+        }
+
+        if repo_handle.is_none() || worktree_path.is_none() || package_path.is_none() {
+            omni_error!("could not find repository");
+            exit(1);
+        }
+        let repo_handle = repo_handle.unwrap();
+        let worktree_path = worktree_path.unwrap();
+        let package_path = package_path.unwrap();
+
+        let repo_id = repo_id.unwrap_or_else(|| {
+            let git_url = full_git_url_parse(&repo_handle);
+            if git_url.is_err() {
+                omni_error!(format!(
+                    "failed to parse git url {}",
+                    repo_handle.light_blue()
+                ));
+                exit(1);
+            }
+            let repo_id = id_from_git_url(&git_url.unwrap());
+            if repo_id.is_none() {
+                omni_error!(format!(
+                    "failed to resolve repository id from git url {}",
+                    repo_handle.light_blue()
+                ));
+                exit(1);
+            }
+            repo_id.unwrap()
+        });
+
+        let worktree_exists = worktree_path.exists();
+        let package_exists = package_path.exists();
+        if !worktree_exists && !package_exists {
+            omni_error!(format!("repository {} is not cloned", repo_handle.yellow()));
+            exit(1);
+        }
+
+        let worktree_entry = path_entry_config(&worktree_path.to_string_lossy());
+        let package_entry = path_entry_config(&package_path.to_string_lossy());
+
+        let worktree_in_omnipath = global_omnipath_entries()
+            .iter()
+            .any(|entry| entry.starts_with(&worktree_entry));
+
+        let package_in_omnipath = global_omnipath_entries()
+            .iter()
+            .any(|entry| entry.starts_with(&package_entry));
+
+        if !worktree_in_omnipath && !package_in_omnipath {
+            omni_error!(format!("{} is not in the omnipath", repo_handle.yellow(),));
+            exit(1);
+        }
+
+        let to_source = match &self.cli_args().source {
+            ConfigPathSwitchCommandArgsSource::Toggle => {
+                if worktree_in_omnipath {
+                    ConfigPathSwitchCommandArgsSource::Package
+                } else {
+                    ConfigPathSwitchCommandArgsSource::Worktree
+                }
+            }
+            _ => self.cli_args().source.clone(),
+        };
+
+        let (switch_from_path, switch_to_path, targets_package) = match to_source {
+            ConfigPathSwitchCommandArgsSource::Package => {
+                if !worktree_in_omnipath {
+                    omni_info!(format!(
+                        "{} is already using the {} source",
+                        repo_id.light_blue(),
+                        "📦 package".to_string().light_green(),
+                    ));
+                    exit(0);
+                }
+
+                (worktree_path, package_path, true)
+            }
+            ConfigPathSwitchCommandArgsSource::Worktree => {
+                if !package_in_omnipath {
+                    omni_info!(format!(
+                        "{} is already using the {} source",
+                        repo_id.light_blue(),
+                        "🌳 worktree".to_string().light_green(),
+                    ));
+                    exit(0);
+                }
+
+                (package_path, worktree_path, false)
+            }
+            ConfigPathSwitchCommandArgsSource::Toggle => unreachable!(),
+        };
+
+        // If the target path does not exist, clone it, but hold running `omni up` for now
+        let requires_cloning = !switch_to_path.exists();
+        if requires_cloning {
+            // Create a spinner to show that we're cloning the repository
+            let spinner = if ENV.interactive_shell {
+                let spinner = ProgressBar::new_spinner();
+                spinner.set_style(
+                    ProgressStyle::default_spinner()
+                        .template("{spinner:.green} {msg:.green}")
+                        .unwrap(),
+                );
+                spinner.set_message(format!("Looking for {}", repo_handle));
+                spinner.enable_steady_tick(Duration::from_millis(50));
+                Some(spinner)
+            } else {
+                None
+            };
+
+            let clone_command = CloneCommand::new();
+            let cloned = clone_command.clone_repo_handle(
+                &repo_handle,
+                &vec![],
+                targets_package,
+                spinner.clone(),
+                None,
+                false,
+            );
+
+            if cloned.is_none() {
+                omni_error!(format!(
+                    "failed to clone repository {}",
+                    repo_handle.light_blue()
+                ));
+                exit(1);
+            }
+
+            workdir_flush_cache(switch_to_path.to_string_lossy());
+        }
+
+        // Update the configuration files with the new path
+        TidyGitRepo::new_with_paths(switch_from_path.clone(), switch_to_path.clone())
+            .edit_config(|_s: String| {});
+
+        omni_info!(format!(
+            "Switched to {} {}",
+            if targets_package {
+                "📦 package"
+            } else {
+                "🌳 worktree"
+            },
+            repo_id.light_blue(),
+        ));
+
+        // If the target path is a package, run `omni up` to update the package
+        if targets_package {
+            if let Err(err) = std::env::set_current_dir(&switch_to_path) {
+                omni_error!(format!(
+                    "failed to change directory {}: {}",
+                    format!("({})", switch_to_path.to_string_lossy()).light_black(),
+                    format!("{}", err).red()
+                ));
+                exit(1);
+            }
+
+            omni_info!(format!(
+                "Running {} to make sure the package is up to date",
+                "omni up".to_string().light_yellow().underline(),
+            ));
+
+            let up_cmd = UpCommand::new_command();
+            up_cmd.exec(
+                if requires_cloning {
+                    vec![]
+                } else {
+                    vec!["--update-repository".to_string()]
+                },
+                Some(vec!["up".to_string()]),
+            );
+        }
+
+        exit(0);
+    }
+
+    pub fn autocompletion(&self) -> bool {
+        false
+    }
+
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
+        ()
+    }
+}

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -148,7 +148,7 @@ impl ConfigPathSwitchCommand {
     pub fn help(&self) -> Option<String> {
         Some(
             concat!(
-                "Switch the source of a repository in the omnipath.\n",
+                "Switch the source of a repository in the omnipath\n",
                 "\n",
                 "This allows to change the omnipath source from using a package or ",
                 "a development version in a worktree.\n",

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -20,7 +20,7 @@ impl HookCommand {
     }
 
     pub fn help(&self) -> Option<String> {
-        Some(concat!("Call one of omni's hooks for the shell.\n",).to_string())
+        Some(concat!("Call one of omni's hooks for the shell\n",).to_string())
     }
 
     pub fn syntax(&self) -> Option<CommandSyntax> {

--- a/src/internal/commands/builtin/mod.rs
+++ b/src/internal/commands/builtin/mod.rs
@@ -13,6 +13,9 @@ pub(crate) use hook::HookEnvCommand;
 pub(crate) use hook::HookInitCommand;
 pub(crate) use hook::HookUuidCommand;
 
+pub(crate) mod config;
+pub(crate) use config::ConfigPathSwitchCommand;
+
 pub(crate) mod scope;
 pub(crate) use scope::ScopeCommand;
 
@@ -21,6 +24,7 @@ pub(crate) use status::StatusCommand;
 
 pub(crate) mod tidy;
 pub(crate) use tidy::TidyCommand;
+pub(crate) use tidy::TidyGitRepo;
 
 pub(crate) mod up;
 pub(crate) use up::UpCommand;

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -10,6 +10,7 @@ use strsim::normalized_damerau_levenshtein;
 use crate::internal::commands::base::Command;
 use crate::internal::commands::builtin::CdCommand;
 use crate::internal::commands::builtin::CloneCommand;
+use crate::internal::commands::builtin::ConfigPathSwitchCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::builtin::HookCommand;
 use crate::internal::commands::builtin::HookEnvCommand;
@@ -80,6 +81,9 @@ impl CommandLoader {
         // Load all builtins first
         commands.push(Command::BuiltinCd(CdCommand::new()));
         commands.push(Command::BuiltinClone(CloneCommand::new()));
+        commands.push(Command::BuiltinConfigPathSwitch(
+            ConfigPathSwitchCommand::new(),
+        ));
         commands.push(Command::BuiltinHelp(HelpCommand::new()));
         commands.push(Command::BuiltinHook(HookCommand::new()));
         commands.push(Command::BuiltinHookEnv(HookEnvCommand::new()));

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -68,7 +68,7 @@ impl Serialize for ConfigValue {
 }
 
 impl ConfigValue {
-    fn new(source: ConfigSource, labels: Vec<String>, value: Option<Box<ConfigData>>) -> Self {
+    pub fn new(source: ConfigSource, labels: Vec<String>, value: Option<Box<ConfigData>>) -> Self {
         Self {
             source,
             labels,
@@ -400,6 +400,7 @@ up_command:
         None
     }
 
+    #[allow(dead_code)]
     pub fn as_str_mut(&mut self) -> Option<&mut String> {
         if let Some(data) = self.value.as_mut().map(|data| data.as_mut()) {
             if let ConfigData::Value(value) = data {

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -541,7 +541,7 @@ impl WorkDirEnv {
             workdir_env.root = git.root().map(|s| s.to_string());
         } else {
             // Start from `path` and go up until finding a `.omni/id` file
-            let mut path = PathBuf::from(path.clone());
+            let mut path = PathBuf::from(path);
             loop {
                 if let Some(id) = Self::read_id_file(&path.to_str().unwrap().to_string()) {
                     workdir_env.in_workdir = true;

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -1,22 +1,19 @@
 mod loader;
-pub use loader::RepoLoader;
-pub use loader::REPO_LOADER;
 
 mod org;
-pub use org::Org;
-pub use org::ORG_LOADER;
+pub(crate) use org::ORG_LOADER;
 
 mod utils;
-pub use utils::format_path;
-pub use utils::format_path_with_template;
-pub use utils::full_git_url_parse;
-pub use utils::package_path_from_git_url;
-pub use utils::package_path_from_handle;
-pub use utils::package_root_path;
-pub use utils::path_entry_config;
-pub use utils::safe_git_url_parse;
-pub use utils::safe_normalize_url;
+pub(crate) use utils::format_path;
+pub(crate) use utils::full_git_url_parse;
+pub(crate) use utils::id_from_git_url;
+pub(crate) use utils::package_path_from_git_url;
+pub(crate) use utils::package_path_from_handle;
+pub(crate) use utils::package_root_path;
+pub(crate) use utils::path_entry_config;
+pub(crate) use utils::safe_git_url_parse;
+pub(crate) use utils::safe_normalize_url;
 
 mod updater;
-pub use updater::auto_path_update;
-pub use updater::update_git_repo;
+pub(crate) use updater::auto_path_update;
+pub(crate) use updater::update_git_repo;

--- a/src/internal/git/org.rs
+++ b/src/internal/git/org.rs
@@ -181,7 +181,7 @@ impl OrgLoader {
         None
     }
 
-    fn basic_naive_lookup(&self, repo: &str) -> Option<PathBuf> {
+    pub fn basic_naive_lookup(&self, repo: &str) -> Option<PathBuf> {
         for org in self.orgs.iter() {
             if let Some(path) = org.get_repo_path(repo) {
                 if path.is_dir() {

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -113,7 +113,16 @@ pub fn auto_path_update() {
             continue;
         }
 
-        let desc = format!("Updating {}:", repo_id.to_string().italic().light_cyan()).light_blue();
+        let desc = format!(
+            "Updating {} {}:",
+            if path_entry.is_package() {
+                "📦"
+            } else {
+                "🌳"
+            },
+            repo_id.to_string().italic().light_cyan()
+        )
+        .light_blue();
         let progress_handler: Box<dyn ProgressHandler + Send> = if ENV.interactive_shell {
             let mut spinner =
                 SpinnerProgressHandler::new_with_multi(desc, None, multiprogress.clone());

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use config::ConfigValue;
 pub(crate) mod env;
 pub(crate) use env::git_env;
 pub(crate) use env::workdir;
+pub(crate) use env::workdir_flush_cache;
 pub(crate) use env::workdir_or_init;
 pub(crate) use env::ENV;
 

--- a/website/contents/reference/02-builtin-commands/02-overview.md
+++ b/website/contents/reference/02-builtin-commands/02-overview.md
@@ -15,6 +15,7 @@ Those commands take precedence over any custom commands, makefile commands or co
 
 | Builtin command         | Description                                               |
 |-------------------------|-----------------------------------------------------------|
+| [`config path switch`](builtin-commands/config/path/switch) | Switch the source of a repository in the omnipath |
 | [`help`](builtin-commands/help) | Show help for omni commands |
 | [`hook`](builtin-commands/hook) | Call one of omni's hooks for the shell |
 | [`status`](builtin-commands/status) | Show the status of omni |

--- a/website/contents/reference/02-builtin-commands/0250-config/0250-path/0250-switch.md
+++ b/website/contents/reference/02-builtin-commands/0250-config/0250-path/0250-switch.md
@@ -1,0 +1,50 @@
+---
+description: Builtin command `config path switch`
+---
+
+# `switch`
+
+Switch the source of a repository in the omnipath.
+
+This allows to change the omnipath source from using a package or a development version in a worktree.
+
+When switching into a mode, if the source of the requested type does not exist, the repository will be cloned. This allows to directly get a worktree version of a given package, or easily package a repository.
+
+Upon switching to a package, `omni up --update-repository` will automatically be run to make sure the package is up to date. This will not happen when switching to a development version in a worktree.
+
+## Parameters
+
+### Options
+
+| Option          | Value type | Description                                         |
+|-----------------|------------|-----------------------------------------------------|
+| `--package` | bool | Switches the omnipath to the package version of the repository. Cannot be used alongside `--worktree`. If not specified and `--worktree` is not specified either, will default to toggle the current state. |
+| `--worktree` | bool | Switches the omnipath to the development version of the repository in a worktree. Cannot be used alongside `--package`. If not specified and `--package` is not specified either, will default to toggle the current state. |
+| `repo` | string | The name of the repository to switch the source from; this can be in the format `<org>/<repo>`, or just `<repo>`. If the repository is not provided, the current repository will be used, or the command will fail if not in a repository. If the repo is not found in the omnipath, the command will fail. |
+
+## Examples
+
+```bash
+# Toggles the source of the current repository in the omnipath
+omni config path switch
+
+# Toggles the source of the omni repository in the omnipath
+omni config path switch omni
+
+# Toggles the source of the omni repository in the omnipath
+omni config path switch https://github.com/XaF/omni
+
+# Switches the source of the current repository to package
+omni config path switch --package
+
+# Switches the source of the current repository to a development
+# version in a worktree
+omni config path switch --worktree
+
+# Switches the source of the omni repository to package
+omni config path switch --package omni
+
+# Switches the source of the omni repository to a development
+# version in a worktree
+omni config path switch --worktree https://github.com/XaF/omni
+```

--- a/website/contents/reference/02-builtin-commands/0250-config/0250-path/0250-switch.md
+++ b/website/contents/reference/02-builtin-commands/0250-config/0250-path/0250-switch.md
@@ -12,6 +12,8 @@ When switching into a mode, if the source of the requested type does not exist, 
 
 Upon switching to a package, `omni up --update-repository` will automatically be run to make sure the package is up to date. This will not happen when switching to a development version in a worktree.
 
+This command requires the target to be a repository, and for the repository to already be cloned, either in a worktree or as a package.
+
 ## Parameters
 
 ### Options


### PR DESCRIPTION
This command allows to easily switch a repository between worktree and package modes. The command usage is as follows:

```sh
omni config path switch [--package|--worktree] [repo]
```

If none of `--package` or `--worktree` is provided, the command will simply toggle the source of the repository. If `repo` is not provided, the current directory will be used.

The command errors out if:
- No `repo` is provided and the current directory is not a repository
- The `repo` is not found, or cannot be resolved
- The repository is not currently cloned (at all)

Closes https://github.com/XaF/omni/issues/196