### PR TITLE
docs: 📝 Add issue links for missing features

### DIFF
--- a/website/contents/reference/01-configuration/0102-parameters/010250-clone.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-clone.md
@@ -8,6 +8,7 @@ sidebar_label: clone ⚠
 :::caution
 This configuration hasn't been ported from the ruby version of `omni` yet.
 It will eventually be supported again, but is not for now.
+You can comment on [this issue](https://github.com/XaF/omni/issues/200) to manifest your interest.
 :::
 
 ## Parameters

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-apt.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-apt.md
@@ -8,6 +8,7 @@ sidebar_label: apt operation ⚠
 :::caution
 This configuration hasn't been ported from the ruby version of `omni` yet.
 It will eventually be supported again, but is not for now.
+You can comment on [this issue](https://github.com/XaF/omni/issues/201) to manifest your interest.
 :::
 
 Installs apt packages.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-dnf.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-dnf.md
@@ -8,6 +8,7 @@ sidebar_label: dnf operation ⚠
 :::caution
 This configuration hasn't been ported from the ruby version of `omni` yet.
 It will eventually be supported again, but is not for now.
+You can comment on [this issue](https://github.com/XaF/omni/issues/202) to manifest your interest.
 :::
 
 Installs dnf packages.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-pacman.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-pacman.md
@@ -8,6 +8,7 @@ sidebar_label: pacman operation ⚠
 :::caution
 This configuration hasn't been ported from the ruby version of `omni` yet.
 It will eventually be supported again, but is not for now.
+You can comment on [this issue](https://github.com/XaF/omni/issues/203) to manifest your interest.
 :::
 
 Installs pacman packages.


### PR DESCRIPTION
Some of the features that were available in the ruby version of omni haven't been ported yet to the rust version.
This adds links to the issues tracking the addition of those features in the documentation.