### PR TITLE
chore(deps): 📦 cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,9 +1199,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
Updating `Cargo.lock` with `cargo update`

The following crate dependencies are to be updated:

- [`libc`](https://crates.io/crates/libc) ([`v0.2.149`](https://docs.rs/libc/0.2.149/) -> [`v0.2.150`](https://docs.rs/libc/0.2.150/))
