### PR TITLE
feat: ✨ add `--exists` flag to check if command exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,13 +67,31 @@ fn run_omni_subcommand(argv: &[String]) {
         argv[0] = "help".to_owned();
     }
 
+    let only_check_exists = if argv[0] == "--exists" || argv[0] == "-e" {
+        argv = argv[1..].to_vec();
+        true
+    } else {
+        false
+    };
+
     // Update the path if necessary
     auto_path_update();
 
     let command_loader = command_loader(".");
     if let Some((omni_cmd, called_as, argv)) = command_loader.to_serve(&argv) {
+        if only_check_exists {
+            exit(match argv.len() {
+                0 => 0,
+                _ => 1,
+            });
+        }
+
         omni_cmd.exec(argv, Some(called_as));
         panic!("exec returned");
+    }
+
+    if only_check_exists {
+        exit(1);
     }
 
     eprintln!(

--- a/website/contents/reference/03-custom-commands/03-overview.md
+++ b/website/contents/reference/03-custom-commands/03-overview.md
@@ -9,3 +9,18 @@ Omni supports custom commands provided through different means:
 - [Omni configuration files](custom-commands/configuration)
 - [Paths added to your omnipath](custom-commands/path)
 - [`Makefile` files in your git repository](custom-commands/makefile)
+
+## Checking that a command exists
+
+Some processes might require to verify that an omni command is available. This is possible through the use of the `--exists` global flag for any call to omni. When using this flag followed by a command, as you would call it through omni, the exit code will indicate if the command is being provided through omni (`0`) or does not seem to exist (`1`).
+
+```bash
+# Exits with 0 if the command exists
+omni --exists help
+
+# Exits with 1 if the command does not exist
+omni --exists this is not a command
+
+# Also works with the short flag
+omni -e help
+```


### PR DESCRIPTION
So far, it was possible to use the help command to check if a command existed, as it would return exit code 1 if the command was not found:

    $ omni help <command>

With the support for the folded help, it now requires slightly more logic as there are auto-generated sections for elements leading to the path of an existing command:

    $ omni help config 2>&1 | grep '^Source:' | grep -qv 'auto-generated'; echo $?
    1
    $ omni help config path switch 2>&1 | grep '^Source:' | grep -qv 'auto-generated'; echo $?
    0

This introduces a new `--exists` flag which aims specifically at checking if a subcommand indeed exists:

    omni --exists <command>

This flag does not return anything on stdout or stderr, but has a 0 or 1 exit code, depending if the subcommand exists or does not exist, respectively.

Closes https://github.com/XaF/omni/issues/206