### PR TITLE
build(cargo dependencies): 👷 fix passing the github token as env var

### DIFF
--- a/.github/workflows/cargo-dependencies.yaml
+++ b/.github/workflows/cargo-dependencies.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           STATE=$(gh pr view "${{ env.PR_BRANCH }}" \
                     --repo "${{ github.repository }}" \
-                    --json state --jq '.state' 2>/dev/null || \
+                    --json state --jq '.state' || \
                   echo "NOT FOUND")
 
           echo "PR_STATE=${STATE}" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/cargo-dependencies.yaml
+++ b/.github/workflows/cargo-dependencies.yaml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check if pull request already exists
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           STATE=$(gh pr view "${{ env.PR_BRANCH }}" \
                     --repo "${{ github.repository }}" \
@@ -181,7 +183,7 @@ jobs:
 
       - name: Create or update pull-request
         env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
           PR_STATE: ${{ needs.check-pull-request.outputs.pull_request_state }}
         run: |
           if [[ "$PR_STATE" != "OPEN" ]]; then

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -101,6 +101,11 @@ const config = {
             position: 'left',
             label: 'Reference',
           },
+          //{
+          //  // To version: npm run docusaurus docs:version <version>
+          //  type: 'docsVersionDropdown',
+          //  position: 'right',
+          //},
           {
             href: 'https://github.com/XaF/omni/releases',
             className: 'header-github-release',


### PR DESCRIPTION
This is required to use the `gh` command line in a github action, and was the missing piece for the cargo dependencies auto-updater to work as expected.