### PR TITLE
feat: ✨ add shell integration during bootstrap

### DIFF
--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -9,6 +9,7 @@ use crate::internal::commands::utils::omni_cmd;
 use crate::internal::config::config;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
 use crate::internal::ENV;
@@ -257,7 +258,7 @@ impl CdCommand {
 
         // Get all the repositories per org
         if !path_only {
-            let add_space = if ENV.shell != "fish" { " " } else { "" };
+            let add_space = if Shell::current().is_fish() { " " } else { "" };
             for match_repo in ORG_LOADER.complete(&repo) {
                 println!("{}{}", match_repo, add_space);
             }

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -2,8 +2,7 @@ use std::process::exit;
 
 use crate::internal::config::CommandSyntax;
 use crate::internal::dynenv::update_dynamic_env;
-use crate::internal::dynenv::DynamicEnvExportMode;
-use crate::internal::env::determine_shell;
+use crate::internal::env::Shell;
 use crate::internal::StringColor;
 
 #[derive(Debug, Clone)]
@@ -47,25 +46,26 @@ impl HookEnvCommand {
 
     pub fn exec(&self, argv: Vec<String>) {
         let shell_type = if argv.len() > 2 {
-            argv[2].clone()
+            Shell::from_str(&argv[2])
         } else {
-            determine_shell()
+            Shell::from_env()
         };
-        let export_mode = match shell_type.as_ref() {
-            "posix" | "bash" | "zsh" => DynamicEnvExportMode::Posix,
-            "fish" => DynamicEnvExportMode::Fish,
-            _ => {
+
+        match shell_type.dynenv_export_mode() {
+            Some(export_mode) => {
+                update_dynamic_env(export_mode);
+                exit(0);
+            }
+            None => {
                 eprintln!(
                     "{} {} {}",
                     "omni:".to_string().light_cyan(),
                     "invalid export mode:".to_string().red(),
-                    argv[2]
+                    shell_type.to_str(),
                 );
                 exit(1);
             }
-        };
-        update_dynamic_env(export_mode.clone());
-        exit(0);
+        }
     }
 
     pub fn autocompletion(&self) -> bool {

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -7,9 +7,9 @@ use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::command_loader;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 
 #[derive(Debug, Clone)]
@@ -261,7 +261,7 @@ impl ScopeCommand {
 
         // Get all the repositories per org
         if !path_only {
-            let add_space = if ENV.shell != "fish" { " " } else { "" };
+            let add_space = if Shell::current().is_fish() { " " } else { "" };
             for match_repo in ORG_LOADER.complete(&repo) {
                 println!("{}{}", match_repo, add_space);
             }

--- a/src/internal/config/bootstrap.rs
+++ b/src/internal/config/bootstrap.rs
@@ -17,7 +17,7 @@ pub fn ensure_bootstrap() {
     omni_print!("This seems to be the first time you're using omni.");
     omni_print!("Let's get you started with a few questions.");
 
-    match config_bootstrap() {
+    match config_bootstrap(None) {
         Ok(true) => {
             omni_print!("All done! Your configuration file has been written \u{1F389}");
         }

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -13,6 +13,7 @@ use once_cell::sync::OnceCell;
 use petname;
 
 use crate::internal::config::OrgConfig;
+use crate::internal::dynenv::DynamicEnvExportMode;
 use crate::internal::git::id_from_git_url;
 use crate::internal::git::safe_git_url_parse;
 use crate::internal::user_interface::StringColor;
@@ -42,6 +43,9 @@ lazy_static! {
         }
         None
     };
+
+    #[derive(Debug)]
+    static ref CURRENT_SHELL: Shell = Shell::from_env();
 }
 
 pub fn git_env<T: AsRef<str>>(path: T) -> GitRepoEnv {
@@ -175,7 +179,6 @@ pub struct Env {
     pub git_by_path: GitRepoEnvByPath,
 
     pub interactive_shell: bool,
-    pub shell: String,
 
     pub omnipath: Vec<String>,
     pub omni_cmd_file: Option<String>,
@@ -308,7 +311,6 @@ impl Env {
             xdg_data_home: xdg_data_home,
 
             interactive_shell: std::io::stdout().is_terminal(),
-            shell: determine_shell(),
 
             git_by_path: GitRepoEnvByPath::new(),
 
@@ -682,7 +684,82 @@ impl WorkDirEnv {
     }
 }
 
-pub fn determine_shell() -> String {
+#[derive(Debug, Clone)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Posix,
+    Unknown(String),
+}
+
+impl Shell {
+    pub fn current() -> Self {
+        CURRENT_SHELL.clone()
+    }
+
+    pub fn from_env() -> Self {
+        let shell = determine_shell();
+        Self::from_str(&shell)
+    }
+
+    pub fn from_str(shell: &str) -> Self {
+        match shell.to_lowercase().as_str() {
+            "bash" => Shell::Bash,
+            "zsh" => Shell::Zsh,
+            "fish" => Shell::Fish,
+            "posix" => Shell::Posix,
+            _ => Shell::Unknown(shell.to_string()),
+        }
+    }
+
+    pub fn to_str(&self) -> &str {
+        match self {
+            Shell::Bash => "bash",
+            Shell::Zsh => "zsh",
+            Shell::Fish => "fish",
+            Shell::Posix => "posix",
+            Shell::Unknown(shell) => shell,
+        }
+    }
+
+    pub fn dynenv_export_mode(&self) -> Option<DynamicEnvExportMode> {
+        match self {
+            Shell::Bash | Shell::Zsh | Shell::Posix => Some(DynamicEnvExportMode::Posix),
+            Shell::Fish => Some(DynamicEnvExportMode::Fish),
+            Shell::Unknown(_) => None,
+        }
+    }
+
+    pub fn is_fish(&self) -> bool {
+        match self {
+            Shell::Fish => true,
+            _ => false,
+        }
+    }
+
+    pub fn default_rc_file(&self) -> PathBuf {
+        match self {
+            Shell::Bash => PathBuf::from(user_home()).join(".bashrc"),
+            Shell::Zsh => PathBuf::from(user_home()).join(".zshrc"),
+            Shell::Fish => PathBuf::from(&ENV.xdg_config_home).join("fish/omni.fish"),
+            Shell::Posix => PathBuf::from("/dev/null"),
+            Shell::Unknown(_) => PathBuf::from("/dev/null"),
+        }
+    }
+
+    pub fn hook_init_command(&self) -> String {
+        match self {
+            Shell::Bash => format!("eval \"$(omni hook init bash)\""),
+            Shell::Zsh => format!("eval \"$(omni hook init zsh)\""),
+            Shell::Fish => format!("omni hook init fish | source"),
+            Shell::Posix => format!(""),
+            Shell::Unknown(_) => format!(""),
+        }
+    }
+}
+
+fn determine_shell() -> String {
     for var in &["OMNI_SHELL", "SHELL"] {
         if let Some(shell) = std::env::var_os(var) {
             let shell = shell.to_str().unwrap();


### PR DESCRIPTION
Omni's installation require setting up the shell integration. As part of https://github.com/XaF/omni/issues/179 we made an install script available to make it easy to install omni in a few instants, and as part of https://github.com/XaF/omni/pull/209 we added the `config bootstrap` command to bootstrap omni's configuration. This now adds automatic addition of omni's shell integration to the rc file of the caller, which will make it even easier to get started with omni.

Closes https://github.com/XaF/omni/issues/210