### PR TITLE
refactor(StringColor): make it work for all string-like objects

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
           token: ${{ github.token }}
           fromTag: ${{ github.sha }}
           toTag: ${{ steps.previous-release-tag.outputs.ref }}
-          excludeTypes: build,docs,other,style,chore,test,tests
+          excludeTypes: build,docs,other,style,chore,test,tests,refactor
           writeToFile: false
 
       - name: Create release

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -315,7 +315,7 @@ impl CdCommand {
             exit(1);
         }
 
-        omni_error!(format!("{}: No such repository", repo.to_string().yellow()));
+        omni_error!(format!("{}: No such repository", repo.yellow()));
         exit(1);
     }
 

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -359,7 +359,7 @@ impl CloneCommand {
             .on_esc(requestty::OnEsc::Terminate)
             .message(format!(
                 "{} {}",
-                "omni:".to_string().light_cyan(),
+                "omni:".light_cyan(),
                 format!("Do you want to run {} ?", "omni up".to_string().underline()),
             ))
             .default(true)

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -342,7 +342,7 @@ pub fn config_bootstrap(options: Option<ConfigBootstrapOptions>) -> Result<bool,
                 omni_info!("shell integration detected in this shell");
                 omni_info!(format!(
                     "still proceeding as requested through {}",
-                    "--shell".to_string().light_cyan()
+                    "--shell".light_cyan()
                 ));
             }
         }
@@ -353,7 +353,7 @@ pub fn config_bootstrap(options: Option<ConfigBootstrapOptions>) -> Result<bool,
             Shell::Unknown(_) | Shell::Posix => {
                 omni_warning!(format!(
                     "omni does not provide a shell integration for your shell ({})",
-                    current_shell.to_str().to_string().light_cyan(),
+                    current_shell.to_str().light_cyan(),
                 ));
                 omni_warning!("you can still use omni, but dynamic environment and easy");
                 omni_warning!("navigation will not be available");
@@ -386,7 +386,7 @@ pub fn config_bootstrap(options: Option<ConfigBootstrapOptions>) -> Result<bool,
                             if line.trim() == hook {
                                 omni_info!(format!(
                                     "omni hook already present in {}",
-                                    rc_file.to_string_lossy().to_string().light_blue(),
+                                    rc_file.to_string_lossy().light_blue(),
                                 ));
                                 return Ok(true);
                             }
@@ -433,7 +433,7 @@ pub fn config_bootstrap(options: Option<ConfigBootstrapOptions>) -> Result<bool,
 
                 omni_info!(format!(
                     "omni hook added to {}; remember to reload your shell",
-                    rc_file.to_string_lossy().to_string().light_blue(),
+                    rc_file.to_string_lossy().light_blue(),
                 ));
             }
             Err(err) => {
@@ -580,7 +580,7 @@ fn question_repo_path_format(worktree: String) -> (String, bool) {
         .transform(|selected, _, backend| {
             // Let's stop at the first parenthesis we encounter
             let selected = selected.text.split('(').next().unwrap_or(&selected.text);
-            write!(backend, "{}", selected.to_string().cyan())
+            write!(backend, "{}", selected.cyan())
         })
         .build();
 
@@ -595,7 +595,7 @@ fn question_repo_path_format(worktree: String) -> (String, bool) {
                         .default("%{host}/%{org}/%{repo}")
                         .validate(|format, _| {
                             if format.is_empty() {
-                                return Err("You need to provide a format".to_string().light_red());
+                                return Err("You need to provide a format".light_red());
                             }
 
                             // Check that at least %{repo} exists
@@ -812,7 +812,7 @@ fn question_org(worktree: &str) -> (Vec<OrgConfig>, bool) {
                             org,
                             if hosts.contains(org) {
                                 // Unicode warning sign
-                                " \u{26A0}\u{FE0F}  (broad trust)".to_string().light_black()
+                                " \u{26A0}\u{FE0F}  (broad trust)".light_black()
                             } else {
                                 "".to_string()
                             }
@@ -931,17 +931,17 @@ fn question_rc_file(current_shell: &Shell) -> (PathBuf, bool) {
             if canonicalized.exists() {
                 // Check if the path is a file
                 if !canonicalized.is_file() {
-                    return Err("The provided path must be a file".to_string().light_red());
+                    return Err("The provided path must be a file".light_red());
                 }
 
                 // Check if the file is writeable
                 match canonicalized.metadata() {
                     Ok(metadata) => {
                         if metadata.permissions().readonly() {
-                            return Err("The file must be writeable".to_string().light_red());
+                            return Err("The file must be writeable".light_red());
                         }
                     }
-                    Err(err) => return Err(err.to_string().light_red()),
+                    Err(err) => return Err(err.light_red()),
                 }
 
                 return Ok(());

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -380,7 +380,7 @@ impl ConfigPathSwitchCommand {
                     omni_info!(format!(
                         "{} is already using the {} source",
                         repo_id.light_blue(),
-                        "📦 package".to_string().light_green(),
+                        "📦 package".light_green(),
                     ));
                     exit(0);
                 }
@@ -392,7 +392,7 @@ impl ConfigPathSwitchCommand {
                     omni_info!(format!(
                         "{} is already using the {} source",
                         repo_id.light_blue(),
-                        "🌳 worktree".to_string().light_green(),
+                        "🌳 worktree".light_green(),
                     ));
                     exit(0);
                 }
@@ -468,7 +468,7 @@ impl ConfigPathSwitchCommand {
 
             omni_info!(format!(
                 "Running {} to make sure the package is up to date",
-                "omni up".to_string().light_yellow().underline(),
+                "omni up".light_yellow().underline(),
             ));
 
             let up_cmd = UpCommand::new_command();

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -171,11 +171,7 @@ impl HelpCommand {
             exit(0);
         }
 
-        omni_print!(format!(
-            "{} {}",
-            "command not found:".to_string().red(),
-            argv.join(" ")
-        ));
+        omni_print!(format!("{} {}", "command not found:".red(), argv.join(" ")));
         exit(1);
     }
 
@@ -193,9 +189,9 @@ impl HelpCommand {
             omni_header!(),
             "Usage:".to_string().italic().bold(),
             "omni".to_string().bold(),
-            "<command>".to_string().cyan().bold(),
-            "[options]".to_string().cyan().bold(),
-            "ARG...".to_string().cyan().bold(),
+            "<command>".cyan().bold(),
+            "[options]".cyan().bold(),
+            "ARG...".cyan().bold(),
         );
 
         self.print_categorized_command_help(vec![]);
@@ -247,7 +243,7 @@ impl HelpCommand {
 
         eprintln!(
             "\n{} {}",
-            "Source:".to_string().light_black(),
+            "Source:".light_black(),
             command.help_source().underline()
         );
     }
@@ -354,7 +350,7 @@ impl HelpCommand {
             };
             let num_folded = match cmd.num_folded() {
                 0 => "".to_string(),
-                _ => " ▶".to_string().light_black(),
+                _ => " ▶".light_black(),
             };
 
             let missing_just = ljust - all_names_len - num_folded_len;

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -59,8 +59,8 @@ impl HookEnvCommand {
             None => {
                 eprintln!(
                     "{} {} {}",
-                    "omni:".to_string().light_cyan(),
-                    "invalid export mode:".to_string().red(),
+                    "omni:".light_cyan(),
+                    "invalid export mode:".red(),
                     shell_type.to_str(),
                 );
                 exit(1);

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -177,8 +177,8 @@ impl ScopeCommand {
 
         eprintln!(
             "{} {} {}",
-            "omni:".to_string().light_cyan(),
-            "command not found:".to_string().red(),
+            "omni:".light_cyan(),
+            "command not found:".red(),
             argv.join(" ")
         );
 
@@ -298,7 +298,7 @@ impl ScopeCommand {
         }
 
         if !silent_failure {
-            omni_error!(format!("{}: No such repository", repo.to_string().yellow()));
+            omni_error!(format!("{}: No such repository", repo.yellow()));
         }
         exit(1);
     }

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -204,11 +204,11 @@ impl StatusCommand {
             for path in &omnipath {
                 if let Some(package) = &path.package {
                     let mut pkg_string =
-                        format!("{} {}", "package:".to_string().light_cyan(), package);
+                        format!("{} {}", "package:".light_cyan(), package);
                     if !path.path.is_empty() {
                         pkg_string.push_str(&format!(
                             ", {} {}",
-                            "path:".to_string().light_cyan(),
+                            "path:".light_cyan(),
                             path.path
                         ));
                     }
@@ -239,7 +239,7 @@ impl StatusCommand {
             .map(|line| {
                 if let Some(captures) = regex_keys.captures(line) {
                     let key = captures.get(3).unwrap().as_str();
-                    let colored_key = key.to_string().light_cyan();
+                    let colored_key = key.light_cyan();
                     line.replace(key, &colored_key)
                 } else {
                     line.to_string()

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -314,7 +314,7 @@ impl TidyCommand {
 
             omni_info!(format!(
                 "use {} to organize them",
-                "--yes".to_string().light_blue()
+                "--yes".light_blue()
             ));
             exit(0);
         } else {
@@ -328,7 +328,7 @@ impl TidyCommand {
                 .on_esc(requestty::OnEsc::Terminate)
                 .message(format!(
                     "{} Found {} repositor{} to tidy up:",
-                    "omni:".to_string().light_cyan(),
+                    "omni:".light_cyan(),
                     format!("{}", repositories.len()).underline(),
                     if repositories.len() > 1 { "ies" } else { "y" },
                 ))
@@ -400,7 +400,7 @@ impl TidyCommand {
                 for repository in repos_to_organize.iter() {
                     printstr(format!(
                         "{} Skipping {}",
-                        "[✘]".to_string().light_red(),
+                        "[✘]".light_red(),
                         format!("{}", repository.to_string())
                     ));
                     progress_bar.as_ref().map(|pb| pb.inc(1));
@@ -510,14 +510,14 @@ impl TidyCommand {
                 Some(ref package) => format!(
                     "{}:{}",
                     "package".to_string().underline(),
-                    package.to_string().light_cyan(),
+                    package.light_cyan(),
                 ),
                 None => path_entry.as_string().light_cyan(),
             };
 
             omni_info!(format!(
                 "running {} in {}",
-                "omni up".to_string().light_yellow(),
+                "omni up".light_yellow(),
                 location,
             ));
 
@@ -746,7 +746,7 @@ impl TidyGitRepo {
 
         println(format!(
             "{} Moved {}",
-            "[✔]".to_string().light_green(),
+            "[✔]".light_green(),
             self.to_string(),
         ));
 
@@ -831,27 +831,27 @@ impl TidyGitRepo {
             if let Err(err) = result {
                 println(format!(
                     "{} Failed to update {} to {} in {}: {:?}",
-                    "[-]".to_string().light_black(),
-                    self.current_path.to_str().unwrap().to_string().light_red(),
+                    "[-]".light_black(),
+                    self.current_path.to_str().unwrap().light_red(),
                     self.expected_path
                         .to_str()
                         .unwrap()
                         .to_string()
                         .light_green(),
-                    file_path.to_string().light_yellow(),
+                    file_path.light_yellow(),
                     err,
                 ));
             } else {
                 println(format!(
                     "{} Updated {} to {} in {}",
-                    "[-]".to_string().light_black(),
-                    self.current_path.to_str().unwrap().to_string().light_red(),
+                    "[-]".light_black(),
+                    self.current_path.to_str().unwrap().light_red(),
                     self.expected_path
                         .to_str()
                         .unwrap()
                         .to_string()
                         .light_green(),
-                    file_path.to_string().light_yellow(),
+                    file_path.light_yellow(),
                 ));
             }
         }

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -849,14 +849,14 @@ impl UpCommand {
                 Some(ref package) => format!(
                     "{}:{}",
                     "package".to_string().underline(),
-                    package.to_string().light_cyan(),
+                    package.light_cyan(),
                 ),
                 None => path_entry.as_string().light_cyan(),
             };
 
             omni_info!(format!(
                 "running {} in {}",
-                "omni up".to_string().light_yellow(),
+                "omni up".light_yellow(),
                 location,
             ));
 
@@ -993,7 +993,7 @@ impl UpCommand {
 
         let total = to_clone.len();
         for (idx, repo) in to_clone.iter_mut().enumerate() {
-            let desc = format!("cloning {}:", repo.clone_url.to_string().light_cyan()).light_blue();
+            let desc = format!("cloning {}:", repo.clone_url.light_cyan()).light_blue();
             let progress = Some((idx + 1, total));
             let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
                 Box::new(SpinnerProgressHandler::new(desc, progress))
@@ -1011,7 +1011,7 @@ impl UpCommand {
                 } else {
                     omni_error!(format!(
                         "Unable to determine package path for {}; skipping",
-                        repo.clone_url.to_string().light_green()
+                        repo.clone_url.light_green()
                     ));
                     continue;
                 }
@@ -1118,16 +1118,16 @@ impl UpCommand {
                 } else {
                     "🌳".to_string()
                 },
-                repo.clone_url.to_string().light_green(),
+                repo.clone_url.light_green(),
                 format!(
                     "{} {}{}",
-                    "(from".to_string().light_black(),
+                    "(from".light_black(),
                     repo.suggested_by
                         .iter()
-                        .map(|x| x.to_string().light_blue())
+                        .map(|x| x.light_blue())
                         .collect::<Vec<_>>()
                         .join(", "),
-                    ")".to_string().light_black(),
+                    ")".light_black(),
                 )
                 .to_string()
                 .italic(),

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -307,8 +307,8 @@ impl CommandLoader {
                         .on_esc(requestty::OnEsc::Terminate)
                         .message(format!(
                             "{} {}",
-                            "omni:".to_string().light_cyan(),
-                            "Did you mean?".to_string().yellow()
+                            "omni:".light_cyan(),
+                            "Did you mean?".yellow()
                         ))
                         .choices(sub_names.iter())
                         .should_loop(false)
@@ -320,9 +320,9 @@ impl CommandLoader {
                         .on_esc(requestty::OnEsc::Terminate)
                         .message(format!(
                             "{} {} {} {}",
-                            "omni:".to_string().light_cyan(),
-                            "Did you mean?".to_string().yellow(),
-                            "·".to_string().light_black(),
+                            "omni:".light_cyan(),
+                            "Did you mean?".yellow(),
+                            "·".light_black(),
                             sub_names[0].normal(),
                         ))
                         .default(true)
@@ -412,8 +412,8 @@ impl CommandLoader {
                     .on_esc(requestty::OnEsc::Terminate)
                     .message(format!(
                         "{} {}",
-                        "omni:".to_string().light_cyan(),
-                        "Did you mean?".to_string().yellow()
+                        "omni:".light_cyan(),
+                        "Did you mean?".yellow()
                     ))
                     .choices(with_score.iter().map(|found| found.command.flat_name()))
                     .should_loop(false)
@@ -425,9 +425,9 @@ impl CommandLoader {
                     .on_esc(requestty::OnEsc::Terminate)
                     .message(format!(
                         "{} {} {} {}",
-                        "omni:".to_string().light_cyan(),
-                        "Did you mean?".to_string().yellow(),
-                        "·".to_string().light_black(),
+                        "omni:".light_cyan(),
+                        "Did you mean?".yellow(),
+                        "·".light_black(),
                         with_score[0].command.flat_name().normal(),
                     ))
                     .default(true)

--- a/src/internal/config/bootstrap.rs
+++ b/src/internal/config/bootstrap.rs
@@ -25,7 +25,7 @@ pub fn ensure_bootstrap() {
             omni_print!("Alright, I won't write your configuration for now \u{1F44D}");
             omni_print!(format!(
                 "You can always run {} later.",
-                "omni config bootstrap".to_string().light_yellow()
+                "omni config bootstrap".light_yellow()
             ));
         }
         Err(err) => {

--- a/src/internal/config/up/bundler.rs
+++ b/src/internal/config/up/bundler.rs
@@ -187,7 +187,7 @@ impl UpConfigBundler {
         } else {
             progress_handler.clone().map(|progress_handler| {
                 progress_handler
-                    .success_with_message("skipping (nothing to do)".to_string().light_black())
+                    .success_with_message("skipping (nothing to do)".light_black())
             });
         }
 

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -91,7 +91,7 @@ impl UpConfigCustom {
         if self.met().unwrap_or(false) {
             progress_handler.clone().map(|progress_handler| {
                 progress_handler
-                    .success_with_message("skipping (already met)".to_string().light_black())
+                    .success_with_message("skipping (already met)".light_black())
             });
             return Ok(());
         }
@@ -137,13 +137,13 @@ impl UpConfigCustom {
             if !self.met().unwrap_or(true) {
                 progress_handler.clone().map(|progress_handler| {
                     progress_handler
-                        .success_with_message("skipping (not met)".to_string().light_black())
+                        .success_with_message("skipping (not met)".light_black())
                 });
                 return Ok(());
             }
 
             progress_handler.clone().map(|progress_handler| {
-                progress_handler.progress("reverting".to_string().light_black())
+                progress_handler.progress("reverting".light_black())
             });
 
             if let Err(err) = self.unmeet(progress_handler.clone()) {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -363,7 +363,7 @@ impl HomebrewTap {
         if self.is_tapped() {
             self.update_cache(progress_handler.clone());
             progress_handler.clone().map(|progress_handler| {
-                progress_handler.success_with_message("already tapped".to_string().light_black())
+                progress_handler.success_with_message("already tapped".light_black())
             });
             return Ok(());
         }
@@ -419,7 +419,7 @@ impl HomebrewTap {
         if !self.is_tapped() {
             progress_handler.clone().map(|progress_handler| {
                 progress_handler
-                    .success_with_message("not currently tapped".to_string().light_black())
+                    .success_with_message("not currently tapped".light_black())
             });
             return Ok(());
         }
@@ -688,7 +688,7 @@ impl HomebrewInstall {
         if installed && self.version.is_some() {
             self.update_cache(progress_handler.clone());
             progress_handler.clone().map(|progress_handler| {
-                progress_handler.success_with_message("already installed".to_string().light_black())
+                progress_handler.success_with_message("already installed".light_black())
             });
             return Ok(());
         }
@@ -748,7 +748,7 @@ impl HomebrewInstall {
         let installed = self.is_installed();
         if !installed {
             progress_handler.clone().map(|progress_handler| {
-                progress_handler.success_with_message("not installed".to_string().light_black())
+                progress_handler.success_with_message("not installed".light_black())
             });
             return Ok(());
         }
@@ -798,7 +798,7 @@ impl HomebrewInstall {
         }
 
         progress_handler.clone().map(|progress_handler| {
-            progress_handler.success_with_message("uninstalled".to_string().light_green());
+            progress_handler.success_with_message("uninstalled".light_green());
         });
 
         Ok(())

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -288,7 +288,7 @@ impl SpinnerProgressHandler {
     ) -> Self {
         let template = format!(
             "{{prefix}}{} {} {{msg}}",
-            "{spinner}".to_string().yellow(),
+            "{spinner}".yellow(),
             desc,
         );
 
@@ -354,18 +354,18 @@ impl ProgressHandler for SpinnerProgressHandler {
     }
 
     fn success(&self) {
-        // self.replace_spinner("✔".to_string().green());
+        // self.replace_spinner("✔".green());
         // self.spinner.finish();
         self.success_with_message("done".to_string());
     }
 
     fn success_with_message(&self, message: String) {
-        self.replace_spinner("✔".to_string().green());
+        self.replace_spinner("✔".green());
         self.spinner.finish_with_message(message);
     }
 
     fn error(&self) {
-        self.replace_spinner("✖".to_string().red());
+        self.replace_spinner("✖".red());
         self.spinner
             .finish_with_message(self.spinner.message().red());
         if self.newline_on_error {
@@ -374,7 +374,7 @@ impl ProgressHandler for SpinnerProgressHandler {
     }
 
     fn error_with_message(&self, message: String) {
-        self.replace_spinner("✖".to_string().red());
+        self.replace_spinner("✖".red());
         self.spinner.finish_with_message(message.red());
         if self.newline_on_error {
             println!();
@@ -426,7 +426,7 @@ impl ProgressHandler for PrintProgressHandler {
         eprintln!(
             "{}",
             self.template
-                .replacen("{}", "-".to_string().light_black().as_str(), 1)
+                .replacen("{}", "-".light_black().as_str(), 1)
                 .replacen("{}", message.as_str(), 1)
         );
     }
@@ -439,7 +439,7 @@ impl ProgressHandler for PrintProgressHandler {
         eprintln!(
             "{}",
             self.template
-                .replacen("{}", "✔".to_string().green().as_str(), 1)
+                .replacen("{}", "✔".green().as_str(), 1)
                 .replacen("{}", message.as_str(), 1)
         );
     }
@@ -452,7 +452,7 @@ impl ProgressHandler for PrintProgressHandler {
         eprintln!(
             "{}",
             self.template
-                .replacen("{}", "✖".to_string().red().as_str(), 1)
+                .replacen("{}", "✖".red().as_str(), 1)
                 .replacen("{}", message.red().as_str(), 1)
         );
     }

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -145,7 +145,7 @@ pub fn workdir_or_init<T: AsRef<str>>(path: T) -> Result<WorkDirEnv, String> {
 
             omni_warning!(format!(
                 "generated workdir id {}",
-                id.to_string().light_yellow()
+                id.light_yellow()
             ));
         }
         Err(err) => {

--- a/src/internal/git/org.rs
+++ b/src/internal/git/org.rs
@@ -335,8 +335,8 @@ impl OrgLoader {
                     .on_esc(requestty::OnEsc::Terminate)
                     .message(format!(
                         "{} {}",
-                        "omni:".to_string().light_cyan(),
-                        "Did you mean?".to_string().yellow()
+                        "omni:".light_cyan(),
+                        "Did you mean?".yellow()
                     ))
                     .choices(
                         with_score
@@ -352,9 +352,9 @@ impl OrgLoader {
                     .on_esc(requestty::OnEsc::Terminate)
                     .message(format!(
                         "{} {} {} {}",
-                        "omni:".to_string().light_cyan(),
-                        "Did you mean?".to_string().yellow(),
-                        "·".to_string().light_black(),
+                        "omni:".light_cyan(),
+                        "Did you mean?".yellow(),
+                        "·".light_black(),
                         with_score[0].abspath.to_str().unwrap().to_string().normal(),
                     ))
                     .default(true)

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -181,14 +181,14 @@ pub fn auto_path_update() {
             Some(ref package) => format!(
                 "{}:{}",
                 "package".to_string().underline(),
-                package.to_string().light_cyan(),
+                package.light_cyan(),
             ),
             None => path_entry.as_string().light_cyan(),
         };
 
         omni_info!(format!(
             "running {} in {}",
-            "omni up".to_string().light_yellow(),
+            "omni up".light_yellow(),
             location,
         ));
 
@@ -229,7 +229,7 @@ pub fn update_git_repo(
         "branch" => update_git_branch(repo_id, ref_match, repo_path, progress_handler),
         "tag" => update_git_tag(repo_id, ref_match, repo_path, progress_handler),
         _ => {
-            omni_error!("invalid ref type: {}", ref_type.to_string().light_red());
+            omni_error!("invalid ref type: {}", ref_type.light_red());
             false
         }
     }
@@ -327,11 +327,11 @@ fn update_git_branch(
         .to_string();
     let output_lines = output.lines().collect::<Vec<&str>>();
     if output_lines.len() == 1 && output_lines[0].contains("Already up to date.") {
-        progress_handler.success_with_message("already up to date".to_string().light_black());
+        progress_handler.success_with_message("already up to date".light_black());
         return false;
     }
 
-    progress_handler.success_with_message("updated".to_string().light_green());
+    progress_handler.success_with_message("updated".light_green());
 
     true
 }
@@ -438,7 +438,7 @@ fn update_git_tag(
     if fetched_out.trim().is_empty() && fetched_err.trim().is_empty() {
         // If no new tags, nothing more to do!
         progress_handler
-            .success_with_message("no new tags, nothing to do".to_string().light_black());
+            .success_with_message("no new tags, nothing to do".light_black());
         return false;
     }
 
@@ -490,14 +490,14 @@ fn update_git_tag(
     // If the current tag is the same as the target tag, nothing more to do!
     if current_tag == target_tag {
         progress_handler
-            .success_with_message("already on latest matching tag".to_string().light_black());
+            .success_with_message("already on latest matching tag".light_black());
         return false;
     }
 
     // Check out the target tag
     progress_handler.progress(format!(
         "checking out {}",
-        target_tag.to_string().light_green()
+        target_tag.light_green()
     ));
     let mut git_checkout_cmd = std::process::Command::new("git");
     if let Some(repo_path) = repo_path {
@@ -515,7 +515,7 @@ fn update_git_tag(
         return false;
     }
 
-    progress_handler.success_with_message("updated".to_string().light_green());
+    progress_handler.success_with_message("updated".light_green());
 
     true
 }

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -159,7 +159,7 @@ impl OmniRelease {
     fn check_and_update(&self) {
         let config = config(".");
 
-        let desc = format!("{} update:", "omni".to_string().light_cyan()).light_blue();
+        let desc = format!("{} update:", "omni".light_cyan()).light_blue();
         let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
             Box::new(SpinnerProgressHandler::new(desc, None))
         } else {
@@ -169,15 +169,15 @@ impl OmniRelease {
         progress_handler.progress("Checking for updates".to_string());
 
         if !self.is_newer() {
-            progress_handler.success_with_message("already up-to-date".to_string().light_black());
+            progress_handler.success_with_message("already up-to-date".light_black());
             return;
         }
 
         if config.path_repo_updates.self_update.is_false() {
             progress_handler.success_with_message(format!(
                 "{} version {} is available",
-                "omni:".to_string().light_cyan(),
-                self.version.to_string().light_blue(),
+                "omni:".light_cyan(),
+                self.version.light_blue(),
             ));
             return;
         }
@@ -190,9 +190,9 @@ impl OmniRelease {
                 .on_esc(requestty::OnEsc::Terminate)
                 .message(format!(
                     "{} version {} is available; {}",
-                    "omni:".to_string().light_cyan(),
-                    self.version.to_string().light_blue(),
-                    "do you want to install it?".to_string().yellow(),
+                    "omni:".light_cyan(),
+                    self.version.light_blue(),
+                    "do you want to install it?".yellow(),
                 ))
                 .choices(vec![
                     ('a', "Yes, always (update without asking in the future)"),
@@ -249,7 +249,7 @@ impl OmniRelease {
 
             panic!("Failed to replace current process with the new binary");
         } else {
-            progress_handler.success_with_message("already up-to-date".to_string().light_black());
+            progress_handler.success_with_message("already up-to-date".light_black());
         }
     }
 

--- a/src/internal/user_interface/colors.rs
+++ b/src/internal/user_interface/colors.rs
@@ -121,7 +121,7 @@ pub trait StringColor {
 }
 
 // Implement the extension trait for the existing type
-impl StringColor for String {
+impl<T: ToString> StringColor for T {
     fn colorize(&self, color: &str) -> String {
         if *COLORS_ENABLED {
             self.force_colorize(color)
@@ -131,7 +131,7 @@ impl StringColor for String {
     }
 
     fn force_colorize(&self, color: &str) -> String {
-        format!("\x1B[{}m{}\x1B[39m", color, self)
+        format!("\x1B[{}m{}\x1B[39m", color, self.to_string())
     }
 
     fn noncolormodifier(&self, modifier: &str, cancel_modifier: &str) -> String {
@@ -143,7 +143,12 @@ impl StringColor for String {
     }
 
     fn force_noncolormodifier(&self, modifier: &str, cancel_modifier: &str) -> String {
-        format!("\x1B[{}m{}\x1B[{}m", modifier, self, cancel_modifier)
+        format!(
+            "\x1B[{}m{}\x1B[{}m",
+            modifier,
+            self.to_string(),
+            cancel_modifier
+        )
     }
 
     fn black(&self) -> String {
@@ -348,13 +353,13 @@ impl StringColor for String {
 
     fn normal(&self) -> String {
         if ENV.interactive_shell {
-            format!("\x1B[{}m{}", RESET, self)
+            format!("\x1B[{}m{}", RESET, self.to_string())
         } else {
             self.to_string()
         }
     }
 
     fn force_normal(&self) -> String {
-        format!("\x1B[{}m{}", RESET, self)
+        format!("\x1B[{}m{}", RESET, self.to_string())
     }
 }

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -18,7 +18,7 @@ macro_rules! omni_header {
 #[macro_export]
 macro_rules! omni_print {
     ($message:expr) => {
-        eprintln!("{} {}", "omni:".to_string().light_cyan(), $message,)
+        eprintln!("{} {}", "omni:".light_cyan(), $message,)
     };
 }
 
@@ -33,7 +33,7 @@ macro_rules! omni_info {
         };
         eprintln!(
             "{}",
-            format!("{}{} {}", "omni:".to_string().light_cyan(), cmd, $message)
+            format!("{}{} {}", "omni:".light_cyan(), cmd, $message)
         );
     };
     ($message:expr, $cmd:expr) => {
@@ -44,7 +44,7 @@ macro_rules! omni_info {
         };
         eprintln!(
             "{}",
-            format!("{}{} {}", "omni:".to_string().light_cyan(), cmd, $message)
+            format!("{}{} {}", "omni:".light_cyan(), cmd, $message)
         );
     };
 }
@@ -62,8 +62,8 @@ macro_rules! omni_warning {
             "{}",
             format!(
                 "{}{} {}",
-                "omni:".to_string().light_cyan(),
-                format!("{} warning:", cmd).to_string().yellow(),
+                "omni:".light_cyan(),
+                format!("{} warning:", cmd).yellow(),
                 $message
             )
         );
@@ -78,8 +78,8 @@ macro_rules! omni_warning {
             "{}",
             format!(
                 "{}{} {}",
-                "omni:".to_string().light_cyan(),
-                format!("{} warning:", cmd).to_string().yellow(),
+                "omni:".light_cyan(),
+                format!("{} warning:", cmd).yellow(),
                 $message
             )
         );
@@ -99,8 +99,8 @@ macro_rules! omni_error {
             "{}",
             format!(
                 "{}{} {}",
-                "omni:".to_string().light_cyan(),
-                format!("{} command failed:", cmd).to_string().red(),
+                "omni:".light_cyan(),
+                format!("{} command failed:", cmd).red(),
                 $message
             )
         );
@@ -115,8 +115,8 @@ macro_rules! omni_error {
             "{}",
             format!(
                 "{}{} {}",
-                "omni:".to_string().light_cyan(),
-                format!("{} command failed:", cmd).to_string().red(),
+                "omni:".light_cyan(),
+                format!("{} command failed:", cmd).red(),
                 $message
             )
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,8 @@ fn run_omni_subcommand(argv: &[String]) {
         // If we didn't match any hooks, let's just exit on error
         eprintln!(
             "{} {} {}",
-            "omni:".to_string().light_cyan(),
-            "command not found:".to_string().red(),
+            "omni:".light_cyan(),
+            "command not found:".red(),
             argv.join(" ")
         );
         exit(1);
@@ -102,8 +102,8 @@ fn run_omni_subcommand(argv: &[String]) {
 
     eprintln!(
         "{} {} {}",
-        "omni:".to_string().light_cyan(),
-        "command not found:".to_string().red(),
+        "omni:".light_cyan(),
+        "command not found:".red(),
         argv.join(" ")
     );
 


### PR DESCRIPTION
The `StringColor` trait was only implemented for String objects, which required to call `.to_string()` on many objects before coloring them. This fixes that by making that trait work on any object that implements the `ToString` trait.