### PR TITLE
build(auth): 👷🔐 use github app tokens for operations requiring a token

### DIFF
--- a/.github/workflows/auto-pr-cargo-dependencies.yaml
+++ b/.github/workflows/auto-pr-cargo-dependencies.yaml
@@ -32,6 +32,7 @@ env:
   # Which branch to use to make the pull request
   PR_BRANCH: auto/cargo_update
 
+
 jobs:
   check-pull-request:
     name: Check if the pull request exists
@@ -54,7 +55,7 @@ jobs:
 
       - name: Check if pull request already exists
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           STATE=$(gh pr view "${{ env.PR_BRANCH }}" \
                     --repo "${{ github.repository }}" \
@@ -126,13 +127,18 @@ jobs:
     env:
       PR_TITLE: "chore(deps): 📦 cargo update"
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
+
       - name: Checkout commit
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download Cargo.lock from update job
         uses: actions/download-artifact@v3
@@ -179,7 +185,7 @@ jobs:
 
       - name: Create or update pull-request
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_STATE: ${{ needs.check-pull-request.outputs.pull_request_state }}
         run: |
           if [[ "$PR_STATE" != "OPEN" ]]; then
@@ -213,17 +219,17 @@ jobs:
     env:
       PR_CLOSING_COMMENT: "Superseded. No more dependencies to be updated for now."
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
-      - name: Checkout commit
-        uses: actions/checkout@v4
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
 
       - name: Close pull-request
         env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr close \
             --title "${{ env.PR_TITLE }}" \

--- a/.github/workflows/auto-pr-cargo-fixes.yaml
+++ b/.github/workflows/auto-pr-cargo-fixes.yaml
@@ -146,13 +146,18 @@ jobs:
     env:
       PR_TITLE: "chore(lints): 💅 cargo fixes"
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
+
       - name: Checkout commit
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download cargo-fix.zip from update job
         uses: actions/download-artifact@v3
@@ -189,7 +194,7 @@ jobs:
 
       - name: Create or update pull-request
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_STATE: ${{ needs.check-pull-request.outputs.pull_request_state }}
         run: |
           if [[ "$PR_STATE" != "OPEN" ]]; then
@@ -221,17 +226,17 @@ jobs:
     env:
       PR_CLOSING_COMMENT: "Superseded. No more lints to be fixed for now."
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
-      - name: Checkout commit
-        uses: actions/checkout@v4
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
 
       - name: Close pull-request
         env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr close \
             --title "${{ env.PR_TITLE }}" \

--- a/.github/workflows/auto-pr-yarn-dependencies.yaml
+++ b/.github/workflows/auto-pr-yarn-dependencies.yaml
@@ -31,6 +31,7 @@ env:
   # Which branch to use to make the pull request
   PR_BRANCH: auto/yarn_update
 
+
 jobs:
   check-pull-request:
     name: Check if the pull request exists
@@ -153,13 +154,18 @@ jobs:
     env:
       PR_TITLE: "chore(deps): 📦 yarn update"
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
+
       - name: Checkout commit
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download package.json from update job
         if: needs.run-yarn-update.outputs.package_updates == 'true'
@@ -281,7 +287,7 @@ jobs:
 
       - name: Create or update pull-request
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_STATE: ${{ needs.check-pull-request.outputs.pull_request_state }}
         run: |
           if [[ "$PR_STATE" != "OPEN" ]]; then
@@ -315,17 +321,17 @@ jobs:
     env:
       PR_CLOSING_COMMENT: "Superseded. No more dependencies to be updated for now."
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
-      - name: Checkout commit
-        uses: actions/checkout@v4
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
 
       - name: Close pull-request
         env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr close \
             --title "${{ env.PR_TITLE }}" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,9 +172,16 @@ jobs:
       - create-release
 
     steps:
+      - name: Create application token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMNICLI_APP_ID }}
+          private-key: ${{ secrets.OMNICLI_PRIVATE_KEY }}
+
       - name: Send repository dispatch with update-formulae event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: XaF/homebrew-omni
           event-type: update-formulae

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,17 +6,20 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - .github/workflows/release.yaml
-      - '.github/workflows/auto-pr-*'
+    paths:
+      - '.github/workflows/build.yaml'
+      - '.github/workflows/tests.yaml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'build.rs'
+      - 'shell_integration/**'
+      - 'src/**'
+      - 'website/**'
 
   # Runs on a pull request
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - .github/workflows/release.yaml
-      - '.github/workflows/auto-pr-*'
 
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -62,14 +65,16 @@ jobs:
         with:
           files_yaml: |
             website:
-              - .github/workflows/tests.yaml
-              - website/
-              - website/**
+              - '.github/workflows/tests.yaml'
+              - 'website/**'
             core:
-              - '**'
-              - '!.github/workflows/release.yaml'
-              - '!README.md'
-              - '!website/**'
+              - '.github/workflows/build.yaml'
+              - '.github/workflows/tests.yaml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'build.rs'
+              - 'shell_integration/**'
+              - 'src/**'
 
       - name: List all changed files
         run: |


### PR DESCRIPTION
This avoids having to keep a unique, not-as-secure token for those operations, and instead use an `omnicli`'s org github app to handle those operations.