### PR TITLE
feat: ✨ Add configuration of the shell aliases for the init hook

### DIFF
--- a/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
+++ b/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
@@ -24,6 +24,7 @@ Omni configuration files accept the following parameters:
 | `path_repo_updates` | [path_repo_updates](parameters/path_repo_updates) | Configuration for the automated updates of the repositories in omni path |
 | `path` | [path](parameters/path) | Configuration of the omni path |
 | `repo_path_format` | [repo_path_format](parameters/repo_path_format) (string) | How to format repositories when cloning them with `omni clone` or searching them with `omni cd` *(default: `%{host}/%{org}/%{repo}`)* |
+| `shell_aliases` | [shell_aliases](parameters/shell_aliases) | Configuration of the shell aliases to be injected by the init hook. |
 | `suggest_config` | [suggest_config](parameters/suggest_config) | Configuration that a git repository suggests should be added to the user configuration. *Should only be used in git repositories configuration.* |
 | `suggest_clone` | [suggest_clone](parameters/suggest_clone) | Repositories that a git repository suggests should be clone. *Should only be used in git repositories configuration.* |
 | `up` | [up](parameters/up) (list) | List of operations needed to set up or tear down a repository |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-shell_aliases.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-shell_aliases.md
@@ -1,0 +1,31 @@
+---
+description: Configuration of the `shell_aliases` parameter
+---
+
+# `shell_aliases`
+
+Configuration of the shell aliases to be injected by the init hook.
+
+## Parameters
+
+This is expected to be a list of objects containing the following parameters:
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `alias` | string | The alias to be injected (e.g. `o`, `ocd`) |
+| `target` | string | The command to alias to; if not specified, the alias will simply target omni |
+
+## Example
+
+```yaml
+shell_aliases:
+  # Create a shell alias `o` which targets `omni`
+  - o
+
+  # Create a shell alias `o2` which targets `omni`
+  - alias: o2
+
+  # Create a shell alias `ocd` which targets `omni cd`
+  - alias: ocd
+    target: cd
+```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -4,9 +4,9 @@ description: Configuration of the `up_command` parameter
 
 # `up_command`
 
-## Parameters
-
 Configuration related to the `omni up` command.
+
+## Parameters
 
 | Parameter       | Type      | Description                                         |
 |-----------------|-----------|-----------------------------------------------------|


### PR DESCRIPTION
This allows to configure the shell aliases that the init hook will inject directly from the configuration file instead of only supporting it from the command line parameters.

This adds the following configuration option:

```yaml
shell_aliases:
  # alias o to omni
  - o

  # alias o2 to omni
  - alias: o2

  # Alias ocd to omni cd
  - alias: ocd
    target: cd
```

Closes https://github.com/XaF/omni/issues/195