### PR TITLE
refactor(env): ♻️  decommission the env struct in favor of lazy_static

### DIFF
--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -8,10 +8,10 @@ use crate::internal::commands::utils::omni_cmd;
 use crate::internal::config::config;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::omni_cmd_file;
 use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 
 #[derive(Debug, Clone)]
@@ -192,7 +192,7 @@ impl CdCommand {
             unreachable!();
         }
 
-        if ENV.omni_cmd_file.is_none() && !self.cli_args().locate {
+        if omni_cmd_file().is_none() && !self.cli_args().locate {
             omni_error!("not available without the shell integration");
             exit(1);
         }

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -18,12 +18,13 @@ use crate::internal::config::up::utils::run_command_with_handler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::omni_cmd_file;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::format_path;
 use crate::internal::git::package_path_from_git_url;
 use crate::internal::git::safe_git_url_parse;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 
 #[derive(Debug, Clone)]
@@ -186,7 +187,7 @@ impl CloneCommand {
         let clone_as_package = self.cli_args().package;
 
         // Create a spinner
-        let spinner = if ENV.interactive_shell {
+        let spinner = if shell_is_interactive() {
             let spinner = ProgressBar::new_spinner();
             spinner.set_style(
                 ProgressStyle::default_spinner()
@@ -487,7 +488,7 @@ impl CloneCommand {
 
         // If we reach here, the repo either exists or just got cloned, so we can
         // directly cd into it
-        if auto_cd && ENV.omni_cmd_file.is_some() {
+        if auto_cd && omni_cmd_file().is_some() {
             let path_str = clone_path.to_string_lossy();
             let path_escaped = escape(path_str);
             match omni_cmd(format!("cd {}", path_escaped).as_str()) {

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -26,13 +26,13 @@ use crate::internal::config::ConfigLoader;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::OrgConfig;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::shell_integration_is_loaded;
 use crate::internal::env::user_home;
 use crate::internal::env::Shell;
 use crate::internal::git::format_path_with_template;
 use crate::internal::git::full_git_url_parse;
 use crate::internal::git::Org;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
 use crate::omni_warning;
@@ -358,7 +358,7 @@ pub fn config_bootstrap(options: Option<ConfigBootstrapOptions>) -> Result<bool,
     }
 
     if options.shell {
-        if ENV.omni_cmd_file.is_some() {
+        if shell_integration_is_loaded() {
             if options.default {
                 // If the shell integration is already setup, no need to do anything else
                 return Ok(true);

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -13,6 +13,7 @@ use crate::internal::commands::builtin::UpCommand;
 use crate::internal::commands::path::global_omnipath_entries;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::full_git_url_parse;
 use crate::internal::git::id_from_git_url;
 use crate::internal::git::package_path_from_handle;
@@ -21,7 +22,6 @@ use crate::internal::git::ORG_LOADER;
 use crate::internal::git_env;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir_flush_cache;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
 
@@ -231,7 +231,7 @@ impl ConfigPathSwitchCommand {
                 let remote_repo = clone_command.lookup_repo_handle(
                     &lookup_repo,
                     false,
-                    if ENV.interactive_shell {
+                    if shell_is_interactive() {
                         let spinner = ProgressBar::new_spinner();
                         spinner.set_style(
                             ProgressStyle::default_spinner()
@@ -286,7 +286,7 @@ impl ConfigPathSwitchCommand {
                 let remote_repo = clone_command.lookup_repo_handle(
                     &lookup_repo,
                     false,
-                    if ENV.interactive_shell {
+                    if shell_is_interactive() {
                         let spinner = ProgressBar::new_spinner();
                         spinner.set_style(
                             ProgressStyle::default_spinner()
@@ -409,7 +409,7 @@ impl ConfigPathSwitchCommand {
         let requires_cloning = !switch_to_path.exists();
         if requires_cloning {
             // Create a spinner to show that we're cloning the repository
-            let spinner = if ENV.interactive_shell {
+            let spinner = if shell_is_interactive() {
                 let spinner = ProgressBar::new_spinner();
                 spinner.set_style(
                     ProgressStyle::default_spinner()

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -8,9 +8,9 @@ use crate::internal::commands::path::omnipath_entries;
 use crate::internal::config::config;
 use crate::internal::config::config_loader;
 use crate::internal::config::CommandSyntax;
+use crate::internal::env::shell_integration_is_loaded;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_header;
 
@@ -136,7 +136,7 @@ impl StatusCommand {
 
     fn print_shell_integration(&self) {
         println!("\n{}", "Shell integration".bold());
-        let status = if ENV.omni_cmd_file.is_some() {
+        let status = if shell_integration_is_loaded() {
             "loaded".light_green()
         } else {
             "not loaded".light_red()

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -19,6 +19,7 @@ use crate::internal::config::parser::PathEntryConfig;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::ConfigSource;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::format_path;
 use crate::internal::git::package_path_from_handle;
 use crate::internal::git::package_root_path;
@@ -27,7 +28,6 @@ use crate::internal::git::safe_git_url_parse;
 use crate::internal::git_env;
 use crate::internal::user_interface::StringColor;
 use crate::internal::ConfigLoader;
-use crate::internal::ENV;
 use crate::internal::ORG_LOADER;
 use crate::omni_error;
 use crate::omni_info;
@@ -300,7 +300,7 @@ impl TidyCommand {
 
         let selected_repositories = if self.cli_args().yes {
             repositories
-        } else if !ENV.interactive_shell {
+        } else if !shell_is_interactive() {
             omni_info!(format!(
                 "Found {} repositor{} to tidy up:",
                 format!("{}", repositories.len()).underline(),
@@ -363,7 +363,7 @@ impl TidyCommand {
         }
 
         // Let's create a progress bar if the shell is interactive
-        let progress_bar = if ENV.interactive_shell {
+        let progress_bar = if shell_is_interactive() {
             let progress_bar = ProgressBar::new(selected_repositories.len() as u64);
             progress_bar.tick();
             Some(progress_bar)
@@ -566,7 +566,7 @@ pub struct TidyGitRepo {
 impl TidyGitRepo {
     pub fn list_repositories(worktrees: HashSet<PathBuf>) -> Vec<Self> {
         // Prepare a spinner for the research
-        let spinner = if ENV.interactive_shell {
+        let spinner = if shell_is_interactive() {
             let spinner = ProgressBar::new_spinner();
             spinner.set_style(
                 ProgressStyle::default_spinner()

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -34,6 +34,7 @@ use crate::internal::config::ConfigExtendOptions;
 use crate::internal::config::ConfigLoader;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::format_path;
 use crate::internal::git::package_path_from_git_url;
 use crate::internal::git::path_entry_config;
@@ -45,7 +46,6 @@ use crate::internal::workdir;
 use crate::internal::workdir::add_trust;
 use crate::internal::workdir::is_trusted_or_ask;
 use crate::internal::workdir_or_init;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
 use crate::omni_warning;
@@ -587,7 +587,7 @@ impl UpCommand {
     fn should_suggest_config(&self) -> bool {
         match self.cli_args().update_user_config {
             UpCommandArgsUpdateUserConfigOptions::Yes => true,
-            UpCommandArgsUpdateUserConfigOptions::Ask => ENV.interactive_shell,
+            UpCommandArgsUpdateUserConfigOptions::Ask => shell_is_interactive(),
             UpCommandArgsUpdateUserConfigOptions::No => false,
         }
     }
@@ -595,7 +595,7 @@ impl UpCommand {
     fn should_suggest_clone(&self) -> bool {
         match self.cli_args().clone_suggested {
             UpCommandArgsCloneSuggestedOptions::Yes => true,
-            UpCommandArgsCloneSuggestedOptions::Ask => ENV.interactive_shell,
+            UpCommandArgsCloneSuggestedOptions::Ask => shell_is_interactive(),
             UpCommandArgsCloneSuggestedOptions::No => false,
         }
     }
@@ -989,7 +989,7 @@ impl UpCommand {
         for (idx, repo) in to_clone.iter_mut().enumerate() {
             let desc = format!("cloning {}:", repo.clone_url.light_cyan()).light_blue();
             let progress = Some((idx + 1, total));
-            let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+            let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
                 Box::new(SpinnerProgressHandler::new(desc, progress))
             } else {
                 Box::new(PrintProgressHandler::new(desc, progress))

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -25,8 +25,8 @@ use crate::internal::commands::fromconfig::ConfigCommand;
 use crate::internal::commands::frommakefile::MakefileCommand;
 use crate::internal::commands::frompath::PathCommand;
 use crate::internal::config;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::colors::StringColor;
-use crate::internal::ENV;
 use crate::omni_info;
 
 lazy_static! {
@@ -268,7 +268,7 @@ impl CommandLoader {
 
         // This preempt the score search if we are in interactive mode and the arguments
         // are prefix of an existing subcommand
-        if ENV.interactive_shell && !argv.is_empty() && self.has_subcommand_of(argv) {
+        if shell_is_interactive() && !argv.is_empty() && self.has_subcommand_of(argv) {
             let mut subcommands = BTreeMap::new();
             for command in self.commands.iter() {
                 command
@@ -402,7 +402,7 @@ impl CommandLoader {
             return with_score[0].to_return(argv);
         }
 
-        if ENV.interactive_shell {
+        if shell_is_interactive() {
             let question = if with_score.len() > 1 {
                 requestty::Question::select("did_you_mean_command")
                     .ask_if_answered(true)

--- a/src/internal/commands/path.rs
+++ b/src/internal/commands/path.rs
@@ -6,7 +6,7 @@ use crate::internal::config::config;
 use crate::internal::config::global_config;
 use crate::internal::config::parser::PathEntryConfig;
 use crate::internal::config::OmniConfig;
-use crate::internal::env::ENV;
+use crate::internal::env::omnipath_env;
 
 lazy_static! {
     #[derive(Debug)]
@@ -43,7 +43,7 @@ fn omnipath_from_config(config: &OmniConfig) -> Vec<String> {
         }
     }
 
-    for path in &ENV.omnipath {
+    for path in omnipath_env() {
         if !path.is_empty() && omnipath_seen.insert(path.clone()) {
             omnipath.push(path.clone());
         }
@@ -68,9 +68,9 @@ fn omnipath_entries_from_config(config: &OmniConfig) -> Vec<PathEntryConfig> {
         }
     }
 
-    for path in &ENV.omnipath {
+    for path in omnipath_env() {
         if !path.is_empty() && omnipath_seen.insert(path.clone()) {
-            let entry = PathEntryConfig::from_path(path);
+            let entry = PathEntryConfig::from_path(&path);
             if entry.is_valid() {
                 omnipath.push(entry);
             }

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -7,8 +7,8 @@ use path_clean::PathClean;
 
 use requestty::question::{completions, Completions};
 
+use crate::internal::env::omni_cmd_file;
 use crate::internal::env::user_home;
-use crate::internal::ENV;
 
 pub fn split_name(string: &str, split_on: &str) -> Vec<String> {
     string.split(split_on).map(|s| s.to_string()).collect()
@@ -61,10 +61,7 @@ pub fn abs_path(path: impl AsRef<Path>) -> PathBuf {
 }
 
 pub fn omni_cmd(cmd: &str) -> Result<(), io::Error> {
-    let cmd_file = ENV
-        .omni_cmd_file
-        .clone()
-        .expect("shell integration not loaded");
+    let cmd_file = omni_cmd_file().expect("shell integration not loaded");
 
     let mut file = OpenOptions::new()
         .create(true)

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::config::parser::PathEntryConfig;
-use crate::internal::env::ENV;
-use crate::internal::env::HOME;
+use crate::internal::env::cache_home;
+use crate::internal::env::user_home;
 use crate::internal::user_interface::colors::StringColor;
 use crate::omni_error;
 
@@ -114,7 +114,7 @@ impl ConfigValue {
 
     pub fn default() -> Self {
         // Check if ~/git exists and is a directory
-        let default_cache_path = ENV.cache_home.to_string();
+        let default_cache_path = cache_home();
         let default_cache_config = format!("cache:\n  path: \"{}\"\n", default_cache_path);
 
         // Parse a default yaml file using serde
@@ -869,7 +869,7 @@ up_command:
                         let value_string = string_value.to_owned();
                         let mut abs_path = value_string.clone();
                         if abs_path.starts_with("~/") {
-                            abs_path = Path::new(&*HOME)
+                            abs_path = Path::new(&user_home())
                                 .join(abs_path.trim_start_matches("~/"))
                                 .to_str()
                                 .unwrap()

--- a/src/internal/config/loader.rs
+++ b/src/internal/config/loader.rs
@@ -17,8 +17,9 @@ use crate::internal::config::ConfigExtendOptions;
 use crate::internal::config::ConfigExtendStrategy;
 use crate::internal::config::ConfigSource;
 use crate::internal::config::ConfigValue;
-use crate::internal::env::ENV;
-use crate::internal::env::HOME;
+use crate::internal::env::config_home;
+use crate::internal::env::user_home;
+use crate::internal::env::xdg_config_home;
 use crate::internal::git::path_entry_config;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
@@ -91,11 +92,11 @@ impl ConfigLoader {
 
     fn user_config_files() -> Vec<String> {
         vec![
-            format!("{}/.omni.yaml", *HOME),
-            format!("{}/omni.yaml", ENV.xdg_config_home),
-            format!("{}/config.yaml", ENV.config_home),
+            format!("{}/.omni.yaml", user_home()),
+            format!("{}/omni.yaml", xdg_config_home()),
+            format!("{}/config.yaml", config_home()),
             if cfg!(debug_assertions) {
-                format!("{}/config-dev.yaml", ENV.config_home)
+                format!("{}/config-dev.yaml", config_home())
             } else {
                 "".to_owned()
             },

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -25,18 +25,14 @@ use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::ConfigValue;
+use crate::internal::env::data_home;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
-use crate::internal::ENV;
 use crate::omni_error;
 
 lazy_static! {
-    pub static ref ASDF_PATH: String = {
-        let omni_data_home = ENV.data_home.clone();
-        let asdf_path = format!("{}/asdf", omni_data_home);
-
-        asdf_path
-    };
+    pub static ref ASDF_PATH: String = format!("{}/asdf", data_home());
     pub static ref ASDF_BIN: String = format!("{}/bin/asdf", *ASDF_PATH);
 }
 
@@ -271,7 +267,7 @@ impl UpConfigAsdfBase {
 
     pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         let desc = format!("{} ({}):", self.tool, self.version).light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, progress))
@@ -679,7 +675,7 @@ impl UpConfigAsdfBase {
         progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
         let desc = "resources cleanup:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, progress))

--- a/src/internal/config/up/bundler.rs
+++ b/src/internal/config/up/bundler.rs
@@ -14,9 +14,9 @@ use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::ConfigValue;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
-use crate::internal::ENV;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpConfigBundler {
@@ -70,7 +70,7 @@ impl UpConfigBundler {
 
     pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         let desc = "install Gemfile dependencies:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, progress))
@@ -126,7 +126,7 @@ impl UpConfigBundler {
 
     pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         let desc = "remove Gemfile dependencies:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, progress))

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -9,8 +9,8 @@ use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::ConfigValue;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpConfigCustom {
@@ -76,7 +76,7 @@ impl UpConfigCustom {
         };
         let desc = format!("{}:", name).light_blue();
 
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, progress))
@@ -119,7 +119,7 @@ impl UpConfigCustom {
 
         let spinner_progress_handler;
         let mut progress_handler: Option<&dyn ProgressHandler> = None;
-        if ENV.interactive_shell {
+        if shell_is_interactive() {
             spinner_progress_handler = Box::new(SpinnerProgressHandler::new(
                 format!("{}:", name).light_blue(),
                 progress,

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -14,7 +14,7 @@ use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::ConfigValue;
-use crate::internal::env::ENV;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::omni_warning;
@@ -342,7 +342,7 @@ impl HomebrewTap {
 
         let desc = format!("  {}{} {}:", progress_str, "tap".underline(), self.name).light_yellow();
 
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, main_progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, main_progress))
@@ -392,7 +392,7 @@ impl HomebrewTap {
         let desc =
             format!("  {}{} {}:", progress_str, "untap".underline(), self.name).light_yellow();
 
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, main_progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, main_progress))
@@ -649,7 +649,7 @@ impl HomebrewInstall {
         let desc =
             format!("  {}install {}{}:", progress_str, self.name, version_hint).light_yellow();
 
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, main_progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, main_progress))
@@ -709,7 +709,7 @@ impl HomebrewInstall {
         let desc =
             format!("  {}uninstall {}{}:", progress_str, self.name, version_hint).light_yellow();
 
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, main_progress))
         } else {
             Box::new(PrintProgressHandler::new(desc, main_progress))

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -24,19 +24,113 @@ extern crate machine_uid;
 
 lazy_static! {
     #[derive(Debug)]
-    pub static ref ENV: Env = Env::new();
-
-    #[derive(Debug)]
-    pub static ref GIT_ENV: Mutex<GitRepoEnvByPath> = Mutex::new(GitRepoEnvByPath::new());
+    static ref GIT_ENV: Mutex<GitRepoEnvByPath> = Mutex::new(GitRepoEnvByPath::new());
 
     #[derive(Debug)]
     static ref WORKDIR_ENV: Mutex<WorkDirEnvByPath> = Mutex::new(WorkDirEnvByPath::new());
 
     #[derive(Debug)]
-    pub static ref HOME: String = std::env::var("HOME").expect("Failed to determine user's home directory");
+    static ref HOME: String = std::env::var("HOME").expect("Failed to determine user's home directory");
 
     #[derive(Debug)]
-    pub static ref OMNI_GIT: Option<String> = {
+    static ref XDG_CONFIG_HOME: String = match std::env::var("XDG_CONFIG_HOME") {
+        Ok(xdg_config_home)
+            if !xdg_config_home.is_empty() && xdg_config_home.starts_with('/') =>
+            {
+                xdg_config_home
+            }
+        _ => {
+            format!("{}/.config", user_home())
+            }
+    };
+
+    #[derive(Debug)]
+    static ref CONFIG_HOME: String = match std::env::var("OMNI_CONFIG_HOME") {
+        Ok(config_home)
+            if !config_home.is_empty()
+                && (config_home.starts_with('/') || config_home.starts_with("~/")) =>
+            {
+                if let Some(path_in_home) = config_home.strip_prefix("~/") {
+                    format!("{}/{}", user_home(), path_in_home)
+                } else {
+                    config_home
+                }
+            }
+        _ => {
+            format!("{}/omni", xdg_config_home())
+        }
+    };
+
+    #[derive(Debug)]
+    static ref XDG_DATA_HOME: String = match std::env::var("XDG_DATA_HOME") {
+        Ok(xdg_data_home) if !xdg_data_home.is_empty() && xdg_data_home.starts_with('/') => {
+            xdg_data_home
+        }
+        _ => {
+            format!("{}/.local/share", user_home())
+        }
+    };
+
+    #[derive(Debug)]
+    static ref DATA_HOME: String = match std::env::var("OMNI_DATA_HOME") {
+        Ok(data_home)
+            if !data_home.is_empty()
+                && (data_home.starts_with('/') || data_home.starts_with("~/")) =>
+            {
+                if let Some(path_in_home) = data_home.strip_prefix("~/") {
+                    format!("{}/{}", user_home(), path_in_home)
+                } else {
+                    data_home
+                }
+            }
+        _ => {
+            format!("{}/omni", xdg_data_home())
+        }
+    };
+
+    #[derive(Debug)]
+    static ref XDG_CACHE_HOME: String = match std::env::var("XDG_CACHE_HOME") {
+        Ok(xdg_cache_home) if !xdg_cache_home.is_empty() && xdg_cache_home.starts_with('/') => {
+            xdg_cache_home
+        }
+        _ => {
+            format!("{}/.cache", user_home())
+        }
+    };
+
+    #[derive(Debug)]
+    static ref CACHE_HOME: String = match std::env::var("OMNI_CACHE_HOME") {
+        Ok(cache_home)
+            if !(cache_home.is_empty()
+                || (!cache_home.starts_with('/') && !cache_home.starts_with("~/"))) =>
+            {
+                if let Some(path_in_home) = cache_home.strip_prefix("~/") {
+                    format!("{}/{}", user_home(), path_in_home)
+                } else {
+                    cache_home
+                }
+            }
+        _ => {
+            format!("{}/omni", xdg_cache_home())
+        }
+    };
+
+    #[derive(Debug)]
+    static ref OMNIPATH: Vec<String> = {
+        let mut omnipath = Vec::new();
+        let mut omnipath_seen = HashSet::new();
+        if let Ok(omnipath_str) = std::env::var("OMNIPATH") {
+            for path in omnipath_str.split(':') {
+                if !path.is_empty() && omnipath_seen.insert(path.to_string()) {
+                    omnipath.push(path.to_string());
+                }
+            }
+        }
+        omnipath
+    };
+
+    #[derive(Debug)]
+    static ref OMNI_GIT: Option<String> = {
         if let Ok(omni_git) = std::env::var("OMNI_GIT") {
             if !omni_git.is_empty() && omni_git.starts_with('/') {
                 return Some(omni_git);
@@ -44,6 +138,33 @@ lazy_static! {
         }
         None
     };
+
+    #[derive(Debug)]
+    static ref OMNI_ORG: Vec<OrgConfig> = {
+        let mut omni_org = Vec::new();
+        if let Ok(omni_org_str) = std::env::var("OMNI_ORG") {
+            for path in omni_org_str.split(',') {
+                if !path.is_empty() {
+                    omni_org.push(OrgConfig::from_str(path));
+                }
+            }
+        }
+        omni_org
+    };
+
+    #[derive(Debug)]
+    static ref OMNI_CMD_FILE: Option<String> = {
+        let mut omni_cmd_file = None;
+        if let Ok(omni_cmd_file_str) = std::env::var("OMNI_CMD_FILE") {
+            if !omni_cmd_file_str.is_empty() {
+                omni_cmd_file = Some(omni_cmd_file_str);
+            }
+        }
+        omni_cmd_file
+    };
+
+    #[derive(Debug)]
+    static ref INTERACTIVE_SHELL: bool = std::io::stdout().is_terminal();
 
     #[derive(Debug)]
     static ref CURRENT_SHELL: Shell = Shell::from_env();
@@ -164,159 +285,52 @@ pub fn user_home() -> String {
     (*HOME).to_string()
 }
 
-#[derive(Debug, Clone)]
-pub struct Env {
-    pub cache_home: String,
-    pub config_home: String,
-    pub data_home: String,
-
-    pub xdg_cache_home: String,
-    pub xdg_config_home: String,
-    pub xdg_data_home: String,
-
-    pub git_by_path: GitRepoEnvByPath,
-
-    pub interactive_shell: bool,
-
-    pub omnipath: Vec<String>,
-    pub omni_cmd_file: Option<String>,
-    pub omni_org: Vec<OrgConfig>,
+pub fn xdg_config_home() -> String {
+    (*XDG_CONFIG_HOME).to_string()
 }
 
-impl Env {
-    fn new() -> Self {
-        // Find XDG_CONFIG_HOME
-        let xdg_config_home = match std::env::var("XDG_CONFIG_HOME") {
-            Ok(xdg_config_home)
-                if !xdg_config_home.is_empty() && xdg_config_home.starts_with('/') =>
-            {
-                xdg_config_home
-            }
-            _ => {
-                format!("{}/.config", user_home())
-            }
-        };
+pub fn config_home() -> String {
+    (*CONFIG_HOME).to_string()
+}
 
-        // Resolve omni's config home
-        let config_home = match std::env::var("OMNI_CONFIG_HOME") {
-            Ok(config_home)
-                if !config_home.is_empty()
-                    && (config_home.starts_with('/') || config_home.starts_with("~/")) =>
-            {
-                if let Some(path_in_home) = config_home.strip_prefix("~/") {
-                    format!("{}/{}", user_home(), path_in_home)
-                } else {
-                    config_home
-                }
-            }
-            _ => {
-                format!("{}/omni", xdg_config_home)
-            }
-        };
+pub fn xdg_data_home() -> String {
+    (*XDG_DATA_HOME).to_string()
+}
 
-        // Find XDG_DATA_HOME
-        let xdg_data_home = match std::env::var("XDG_DATA_HOME") {
-            Ok(xdg_data_home) if !xdg_data_home.is_empty() && xdg_data_home.starts_with('/') => {
-                xdg_data_home
-            }
-            _ => {
-                format!("{}/.local/share", user_home())
-            }
-        };
+pub fn data_home() -> String {
+    (*DATA_HOME).to_string()
+}
 
-        // Resolve omni's data home
-        let data_home = match std::env::var("OMNI_DATA_HOME") {
-            Ok(data_home)
-                if !data_home.is_empty()
-                    && (data_home.starts_with('/') || data_home.starts_with("~/")) =>
-            {
-                if let Some(path_in_home) = data_home.strip_prefix("~/") {
-                    format!("{}/{}", user_home(), path_in_home)
-                } else {
-                    data_home
-                }
-            }
-            _ => {
-                format!("{}/omni", xdg_data_home)
-            }
-        };
+pub fn xdg_cache_home() -> String {
+    (*XDG_CACHE_HOME).to_string()
+}
 
-        // Find XDG_CACHE_HOME
-        let xdg_cache_home = match std::env::var("XDG_CACHE_HOME") {
-            Ok(xdg_cache_home) if !xdg_cache_home.is_empty() && xdg_cache_home.starts_with('/') => {
-                xdg_cache_home
-            }
-            _ => {
-                format!("{}/.cache", user_home())
-            }
-        };
+pub fn cache_home() -> String {
+    (*CACHE_HOME).to_string()
+}
 
-        // Resolve omni's cache home
-        let cache_home = match std::env::var("OMNI_CACHE_HOME") {
-            Ok(cache_home)
-                if !(cache_home.is_empty()
-                    || (!cache_home.starts_with('/') && !cache_home.starts_with("~/"))) =>
-            {
-                if let Some(path_in_home) = cache_home.strip_prefix("~/") {
-                    format!("{}/{}", user_home(), path_in_home)
-                } else {
-                    cache_home
-                }
-            }
-            _ => {
-                let xdg_cache_home = std::env::var("XDG_CACHE_HOME")
-                    .unwrap_or_else(|_| format!("{}/.cache", user_home()));
-                format!("{}/omni", xdg_cache_home)
-            }
-        };
+pub fn omnipath_env() -> Vec<String> {
+    (*OMNIPATH).clone()
+}
 
-        // Load the omni path while deduplicating
-        let mut omnipath = Vec::new();
-        let mut omnipath_seen = HashSet::new();
-        if let Ok(omnipath_str) = std::env::var("OMNIPATH") {
-            for path in omnipath_str.split(':') {
-                if !path.is_empty() && omnipath_seen.insert(path.to_string()) {
-                    omnipath.push(path.to_string());
-                }
-            }
-        }
+pub fn omni_git_env() -> Option<String> {
+    (*OMNI_GIT).clone()
+}
 
-        // Load the omni org
-        let mut omni_org = Vec::new();
-        if let Ok(omni_org_str) = std::env::var("OMNI_ORG") {
-            for path in omni_org_str.split(',') {
-                if !path.is_empty() {
-                    omni_org.push(OrgConfig::from_str(path));
-                }
-            }
-        }
+pub fn omni_org_env() -> Vec<OrgConfig> {
+    (*OMNI_ORG).clone()
+}
 
-        // Load the command file
-        let mut omni_cmd_file = None;
-        if let Ok(omni_cmd_file_str) = std::env::var("OMNI_CMD_FILE") {
-            if !omni_cmd_file_str.is_empty() {
-                omni_cmd_file = Some(omni_cmd_file_str);
-            }
-        }
+pub fn omni_cmd_file() -> Option<String> {
+    (*OMNI_CMD_FILE).clone()
+}
 
-        Env {
-            cache_home,
-            config_home,
-            data_home,
+pub fn shell_integration_is_loaded() -> bool {
+    omni_cmd_file().is_some()
+}
 
-            xdg_cache_home,
-            xdg_config_home,
-            xdg_data_home,
-
-            interactive_shell: std::io::stdout().is_terminal(),
-
-            git_by_path: GitRepoEnvByPath::new(),
-
-            omnipath,
-            omni_org,
-            omni_cmd_file,
-        }
-    }
+pub fn shell_is_interactive() -> bool {
+    *INTERACTIVE_SHELL
 }
 
 #[derive(Debug, Clone)]
@@ -709,7 +723,7 @@ impl Shell {
         match self {
             Shell::Bash => PathBuf::from(user_home()).join(".bashrc"),
             Shell::Zsh => PathBuf::from(user_home()).join(".zshrc"),
-            Shell::Fish => PathBuf::from(&ENV.xdg_config_home).join("fish/omni.fish"),
+            Shell::Fish => PathBuf::from(xdg_config_home()).join("fish/omni.fish"),
             Shell::Posix => PathBuf::from("/dev/null"),
             Shell::Unknown(_) => PathBuf::from("/dev/null"),
         }

--- a/src/internal/git/org.rs
+++ b/src/internal/git/org.rs
@@ -15,7 +15,8 @@ use walkdir::WalkDir;
 use crate::internal::commands::path::omnipath_entries;
 use crate::internal::config::config;
 use crate::internal::config::OrgConfig;
-use crate::internal::env::ENV;
+use crate::internal::env::omni_org_env;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::format_path;
 use crate::internal::git::package_path_from_handle;
 use crate::internal::git::package_root_path;
@@ -39,7 +40,7 @@ impl OrgLoader {
     pub fn new() -> Self {
         let mut orgs = vec![];
 
-        for org in ENV.omni_org.iter() {
+        for org in omni_org_env() {
             if let Ok(org) = Org::new(org.clone()) {
                 orgs.push(org);
             }
@@ -200,7 +201,7 @@ impl OrgLoader {
         include_packages: bool,
         allow_interactive: bool,
     ) -> Option<PathBuf> {
-        let interactive = allow_interactive && ENV.interactive_shell;
+        let interactive = allow_interactive && shell_is_interactive();
 
         let repo_url = Repo::parse(repo);
         if repo_url.is_err() {

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -14,11 +14,11 @@ use crate::internal::config::config;
 use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::path_entry_config;
 use crate::internal::git_env;
 use crate::internal::self_update;
 use crate::internal::user_interface::StringColor;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
 
@@ -37,7 +37,7 @@ fn should_update() -> bool {
     }
 
     // Check if interactive shell, or skip update
-    if !ENV.interactive_shell {
+    if !shell_is_interactive() {
         return false;
     }
 
@@ -123,7 +123,7 @@ pub fn auto_path_update() {
             repo_id.italic().light_cyan()
         )
         .light_blue();
-        let progress_handler: Box<dyn ProgressHandler + Send> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler + Send> = if shell_is_interactive() {
             let mut spinner =
                 SpinnerProgressHandler::new_with_multi(desc, None, multiprogress.clone());
             spinner.no_newline_on_error();
@@ -244,7 +244,7 @@ fn update_git_branch(
     let progress_handler: Box<&dyn ProgressHandler> =
         if let Some(progress_handler) = progress_handler {
             Box::new(progress_handler)
-        } else if ENV.interactive_shell {
+        } else if shell_is_interactive() {
             spinner = SpinnerProgressHandler::new(desc, None);
             Box::new(&spinner)
         } else {
@@ -345,7 +345,7 @@ fn update_git_tag(
     let progress_handler: Box<&dyn ProgressHandler> =
         if let Some(progress_handler) = progress_handler {
             Box::new(progress_handler)
-        } else if ENV.interactive_shell {
+        } else if shell_is_interactive() {
             spinner = SpinnerProgressHandler::new(desc, None);
             Box::new(&spinner)
         } else {

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -12,16 +12,11 @@ use url::Url;
 
 use crate::internal::config;
 use crate::internal::config::parser::PathEntryConfig;
+use crate::internal::env::data_home;
 use crate::internal::git_env;
-use crate::internal::ENV;
 
 lazy_static! {
-    pub static ref PACKAGE_PATH: String = {
-        let omni_data_home = ENV.data_home.clone();
-        let package_path = format!("{}/packages", omni_data_home);
-
-        package_path
-    };
+    pub static ref PACKAGE_PATH: String = format!("{}/packages", data_home());
 }
 
 const PACKAGE_PATH_FORMAT: &str = "%{host}/%{org}/%{repo}";

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -13,7 +13,6 @@ pub(crate) use env::git_env;
 pub(crate) use env::workdir;
 pub(crate) use env::workdir_flush_cache;
 pub(crate) use env::workdir_or_init;
-pub(crate) use env::ENV;
 
 pub(crate) mod git;
 pub(crate) use git::ORG_LOADER;

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -21,10 +21,10 @@ use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::colors::StringColor;
 use crate::internal::ConfigLoader;
 use crate::internal::ConfigValue;
-use crate::internal::ENV;
 use crate::omni_error;
 
 lazy_static! {
@@ -157,7 +157,7 @@ impl OmniRelease {
         let config = config(".");
 
         let desc = format!("{} update:", "omni".light_cyan()).light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if ENV.interactive_shell {
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, None))
         } else {
             Box::new(PrintProgressHandler::new(desc, None))

--- a/src/internal/user_interface/colors.rs
+++ b/src/internal/user_interface/colors.rs
@@ -1,7 +1,7 @@
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 
-use crate::internal::env::ENV;
+use crate::internal::env::shell_is_interactive;
 
 pub const BLACK: &str = "30";
 pub const RED: &str = "31";
@@ -352,7 +352,7 @@ impl<T: ToString> StringColor for T {
     }
 
     fn normal(&self) -> String {
-        if ENV.interactive_shell {
+        if shell_is_interactive() {
             format!("\x1B[{}m{}", RESET, self.to_string())
         } else {
             self.to_string()

--- a/src/internal/workdir.rs
+++ b/src/internal/workdir.rs
@@ -1,10 +1,10 @@
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::RepositoriesCache;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::git_env;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
-use crate::internal::ENV;
 use crate::omni_error;
 use crate::omni_info;
 
@@ -32,7 +32,7 @@ pub fn is_trusted_or_ask(path: &str, ask: String) -> bool {
         return true;
     }
 
-    if !ENV.interactive_shell {
+    if !shell_is_interactive() {
         return false;
     }
 


### PR DESCRIPTION
This allows to only load the required environment variables when we need them, instead of loading the whole structure anytime any of the variables is needed.

Closes https://github.com/XaF/omni/issues/29