### PR TITLE
feat: ✨ save log files when subprocesses fail

### DIFF
--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -94,7 +94,7 @@ impl UpConfigCustom {
             if let Some(progress_handler) = progress_handler {
                 progress_handler.error_with_message(format!("{}", err).light_red())
             }
-            return Err(err);
+            return Err(UpError::StepFailed(name, progress));
         }
 
         if let Some(progress_handler) = progress_handler {

--- a/src/internal/config/up/error.rs
+++ b/src/internal/config/up/error.rs
@@ -12,6 +12,7 @@ pub enum UpError {
     Timeout(String),
     Cache(String),
     HomebrewTapInUse,
+    StepFailed(String, Option<(usize, usize)>),
 }
 
 impl UpError {
@@ -33,6 +34,13 @@ impl Display for UpError {
             UpError::Timeout(message) => write!(f, "timeout: {}", message),
             UpError::Cache(message) => write!(f, "cache error: {}", message),
             UpError::HomebrewTapInUse => write!(f, "tap in use"),
+            UpError::StepFailed(name, progress) => {
+                if let Some((step, total)) = progress {
+                    write!(f, "step {}/{} '{}' failed", step, total, name)
+                } else {
+                    write!(f, "step '{}' failed", name)
+                }
+            }
         }
     }
 }

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -109,8 +109,8 @@ where
                 .unwrap()
                 .format(&Rfc3339)
                 .expect("failed to format date")
-                .replace("-", "") // Remove the dashes in the date
-                .replace(":", ""), // Remove the colons in the time
+                .replace('-', "") // Remove the dashes in the date
+                .replace(':', ""), // Remove the colons in the time
         );
         let mut log_file = match NamedTempFile::with_prefix(log_file_prefix.as_str()) {
             Ok(file) => file,
@@ -199,7 +199,7 @@ where
                     Err(err) => Err(UpError::Exec(format!(
                         "process exited with status {}; failed to keep log file: {}",
                         exit_status.code().unwrap_or(-42),
-                        err.to_string(),
+                        err,
                     ))),
                 }
             }

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -109,8 +109,7 @@ where
                 .unwrap()
                 .format(&Rfc3339)
                 .expect("failed to format date")
-                .replace('-', "") // Remove the dashes in the date
-                .replace(':', ""), // Remove the colons in the time
+                .replace(['-', ':'], ""), // Remove the dashes in the date and the colons in the time
         );
         let mut log_file = match NamedTempFile::with_prefix(log_file_prefix.as_str()) {
             Ok(file) => file,

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -322,7 +322,7 @@ fn update_git_branch(
                 "git pull failed: {}",
                 String::from_utf8(output.stderr)
                     .unwrap()
-                    .replace("\n", " ")
+                    .replace('\n', " ")
                     .trim(),
             ));
             false

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -310,26 +310,36 @@ fn update_git_branch(
     git_pull_cmd.arg("pull");
     git_pull_cmd.arg("--ff-only");
     git_pull_cmd.stdout(std::process::Stdio::piped());
-    git_pull_cmd.stderr(std::process::Stdio::null());
+    git_pull_cmd.stderr(std::process::Stdio::piped());
 
-    let output = git_pull_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git pull failed".to_string());
-        return false;
+    match git_pull_cmd.output() {
+        Err(err) => {
+            progress_handler.error_with_message(format!("git pull failed: {}", err));
+            false
+        }
+        Ok(output) if !output.status.success() => {
+            progress_handler.error_with_message(format!(
+                "git pull failed: {}",
+                String::from_utf8(output.stderr)
+                    .unwrap()
+                    .replace("\n", " ")
+                    .trim(),
+            ));
+            false
+        }
+        Ok(output) => {
+            let output = String::from_utf8(output.stdout).unwrap().trim().to_string();
+            let output_lines = output.lines().collect::<Vec<&str>>();
+
+            if output_lines.len() == 1 && output_lines[0].contains("Already up to date.") {
+                progress_handler.success_with_message("already up to date".light_black());
+                false
+            } else {
+                progress_handler.success_with_message("updated".light_green());
+                true
+            }
+        }
     }
-    let output = String::from_utf8(output.unwrap().stdout)
-        .unwrap()
-        .trim()
-        .to_string();
-    let output_lines = output.lines().collect::<Vec<&str>>();
-    if output_lines.len() == 1 && output_lines[0].contains("Already up to date.") {
-        progress_handler.success_with_message("already up to date".light_black());
-        return false;
-    }
-
-    progress_handler.success_with_message("updated".light_green());
-
-    true
 }
 
 fn update_git_tag(


### PR DESCRIPTION
For some operations such as `custom` operations when calling `omni up`, the previous message was a bit cryptic. It will now print simply the exit code and a path to a saved log file. Most subprocesses that are called in the background for a better UX will hence have their logs saved in a way that makes it easier to understand what happened when an execution failed.