### PR TITLE
feat(updates): ✨ add support for background updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tera",
+ "term_cursor",
  "term_size",
  "time",
  "tokio",
@@ -2359,6 +2360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_cursor"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e225e1afb8bf56aa077366fced39df360db6ec09af1d9fb0b0591843e8482629"
+dependencies = [
+ "termios",
+ "winapi",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ strsim = "0.10.0"
 tar = "0.4.40"
 tempfile = "3.8.1"
 tera = "1.19.1"
+term_cursor = "0.2.1"
 term_size = "0.3.2"
 time = { version = "0.3.30", features = ["serde-well-known"] }
 tokio = { version = "1.34.0", features = ["full"] }

--- a/src/internal/cache/omnipath.rs
+++ b/src/internal/cache/omnipath.rs
@@ -24,6 +24,8 @@ pub struct OmniPathCache {
     pub updated_at: OffsetDateTime,
     #[serde(default = "utils::origin_of_time", with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
+    #[serde(default = "String::new", skip_serializing_if = "String::is_empty")]
+    pub update_error_log: String,
 }
 
 impl OmniPathCache {
@@ -36,6 +38,22 @@ impl OmniPathCache {
         self.updated_at = OffsetDateTime::now_utc();
         self.expires_at =
             self.updated_at + Duration::seconds(config(".").path_repo_updates.interval);
+    }
+
+    pub fn update_errored(&self) -> bool {
+        !self.update_error_log.is_empty()
+    }
+
+    pub fn update_error(&mut self, update_error_log: String) {
+        self.update_error_log = update_error_log;
+    }
+
+    pub fn clear_update_error(&mut self) {
+        self.update_error_log = "".to_string();
+    }
+
+    pub fn update_error_log(&self) -> String {
+        self.update_error_log.clone()
     }
 }
 
@@ -51,6 +69,7 @@ impl CacheObject for OmniPathCache {
             updated: false,
             updated_at: utils::origin_of_time(),
             expires_at: utils::origin_of_time(),
+            update_error_log: "".to_string(),
         }
     }
 

--- a/src/internal/cache/omnipath.rs
+++ b/src/internal/cache/omnipath.rs
@@ -36,8 +36,14 @@ impl OmniPathCache {
     pub fn update(&mut self) {
         self.updated = true;
         self.updated_at = OffsetDateTime::now_utc();
-        self.expires_at =
-            self.updated_at + Duration::seconds(config(".").path_repo_updates.interval);
+        self.expires_at = self.updated_at
+            + Duration::seconds(
+                config(".")
+                    .path_repo_updates
+                    .interval
+                    .try_into()
+                    .unwrap_or(43200),
+            );
     }
 
     pub fn update_errored(&self) -> bool {

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -111,12 +111,10 @@ impl Command {
     }
 
     pub fn has_source(&self) -> bool {
-        match self {
-            Command::FromPath(_) => true,
-            Command::FromConfig(_) => true,
-            Command::FromMakefile(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Command::FromPath(_) | Command::FromConfig(_) | Command::FromMakefile(_)
+        )
     }
 
     pub fn source(&self) -> String {

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -110,6 +110,15 @@ impl Command {
             .collect()
     }
 
+    pub fn has_source(&self) -> bool {
+        match self {
+            Command::FromPath(_) => true,
+            Command::FromConfig(_) => true,
+            Command::FromMakefile(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn source(&self) -> String {
         match self {
             Command::BuiltinCd(_) => "builtin".to_string(),

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -445,7 +445,9 @@ impl CloneCommand {
                 |_stdout, _stderr| {
                     // Do nothing
                 },
-                RunConfig::with_timeout(config(".").clone.ls_remote_timeout_seconds),
+                RunConfig::new()
+                    .without_ctrl_chars()
+                    .with_timeout(config(".").clone.ls_remote_timeout_seconds),
             );
 
             if result.is_err() {

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 use crate::internal::config::CommandSyntax;
 use crate::internal::dynenv::update_dynamic_env;
 use crate::internal::env::Shell;
+use crate::internal::git::report_update_error;
 use crate::internal::StringColor;
 
 #[derive(Debug, Clone)]
@@ -54,6 +55,7 @@ impl HookEnvCommand {
         match shell_type.dynenv_export_mode() {
             Some(export_mode) => {
                 update_dynamic_env(export_mode);
+                report_update_error();
                 exit(0);
             }
             None => {

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -1,8 +1,6 @@
 use std::env;
-use std::path::PathBuf;
 use std::process::exit;
 
-use lazy_static::lazy_static;
 use serde::Serialize;
 use shell_escape::escape;
 use tera::Context;
@@ -12,19 +10,9 @@ use crate::internal::commands::HelpCommand;
 use crate::internal::config::global_config;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::current_exe;
 use crate::internal::user_interface::StringColor;
 use crate::omni_error;
-
-lazy_static! {
-    static ref CURRENT_EXE: PathBuf = {
-        let current_exe = std::env::current_exe();
-        if current_exe.is_err() {
-            omni_error!("failed to get current executable path", "hook init");
-            exit(1);
-        }
-        current_exe.unwrap()
-    };
-}
 
 #[derive(Debug, Clone)]
 struct HookInitCommandArgs {
@@ -296,7 +284,9 @@ fn dump_integration(args: HookInitCommandArgs, integration: &[u8]) {
     let mut context = Context::new();
     context.insert(
         "OMNI_BIN",
-        &escape(std::borrow::Cow::Borrowed(CURRENT_EXE.to_str().unwrap())),
+        &escape(std::borrow::Cow::Borrowed(
+            current_exe().to_string_lossy().as_ref(),
+        )),
     );
     context.insert("OMNI_ALIASES", &args.aliases);
     context.insert("OMNI_COMMAND_ALIASES", &args.command_aliases);

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -151,6 +151,7 @@ path_repo_updates:
   enabled: true
   self_update: ask
   background_updates: true
+  background_updates_timeout: 3600 # 1 hour
   interval: 43200 # 12 hours
   ref_type: "branch" # branch or tag
   ref_match: null # regex or null

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -150,6 +150,7 @@ path:
 path_repo_updates:
   enabled: true
   self_update: ask
+  background_updates: true
   interval: 43200 # 12 hours
   ref_type: "branch" # branch or tag
   ref_match: null # regex or null

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -711,13 +711,7 @@ impl PathRepoUpdatesConfig {
         };
 
         Self {
-            enabled: {
-                let mut val = None;
-                if let Some(value) = config_value.get_as_bool("enabled") {
-                    val = Some(value);
-                }
-                val.unwrap_or(true)
-            },
+            enabled: config_value.get_as_bool("enabled").unwrap_or(true),
             self_update: match (
                 config_value.get_as_str("self_update"),
                 config_value.get_as_bool("self_update"),
@@ -735,47 +729,19 @@ impl PathRepoUpdatesConfig {
                 },
                 (None, None) => PathRepoUpdatesSelfUpdateEnum::Ask,
             },
-            background_updates: {
-                let mut val = None;
-                if let Some(value) = config_value.get_as_bool("background_updates") {
-                    val = Some(value);
-                }
-                val.unwrap_or(true)
-            },
-            background_updates_timeout: {
-                let mut val = None;
-                if let Some(value) =
-                    config_value.get_as_unsigned_integer("background_updates_timeout")
-                {
-                    if let Ok(value) = value.try_into() {
-                        val = Some(value);
-                    }
-                }
-                val.unwrap_or(3600)
-            },
-            interval: {
-                let mut val = None;
-                if let Some(value) = config_value.get_as_unsigned_integer("interval") {
-                    if let Ok(value) = value.try_into() {
-                        val = Some(value);
-                    }
-                }
-                val.unwrap_or(12 * 60 * 60)
-            },
-            ref_type: {
-                let mut val = None;
-                if let Some(value) = config_value.get_as_str("ref_type") {
-                    val = Some(value);
-                }
-                val.unwrap_or("branch".to_string())
-            },
-            ref_match: {
-                let mut val = None;
-                if let Some(value) = config_value.get_as_str("ref_match") {
-                    val = Some(value);
-                }
-                val
-            },
+            background_updates: config_value
+                .get_as_bool("background_updates")
+                .unwrap_or(true),
+            background_updates_timeout: config_value
+                .get_as_unsigned_integer("background_updates_timeout")
+                .unwrap_or(3600),
+            interval: config_value
+                .get_as_unsigned_integer("interval")
+                .unwrap_or(12 * 60 * 60),
+            ref_type: config_value
+                .get_as_str("ref_type")
+                .unwrap_or("branch".to_string()),
+            ref_match: config_value.get_as_str("ref_match"),
             per_repo_config,
         }
     }

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -768,10 +768,7 @@ impl PathRepoUpdatesConfig {
             return false;
         }
 
-        match update_git_repo(repo_id, ref_type, ref_match, None, None) {
-            Ok(updated) => updated,
-            Err(_) => false,
-        }
+        update_git_repo(repo_id, ref_type, ref_match, None, None).unwrap_or(false)
     }
 }
 

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -644,6 +644,14 @@ impl PathEntryConfig {
         PathBuf::from(&self.full_path).starts_with(&path_entry.full_path)
     }
 
+    pub fn includes_path(&self, path: PathBuf) -> bool {
+        if !self.is_valid() {
+            return false;
+        }
+
+        PathBuf::from(&path).starts_with(&self.full_path)
+    }
+
     pub fn replace(&mut self, path_from: &PathEntryConfig, path_to: &PathEntryConfig) -> bool {
         if self.starts_with(path_from) {
             let new_full_path = format!(
@@ -682,6 +690,7 @@ impl PathEntryConfig {
 pub struct PathRepoUpdatesConfig {
     pub enabled: bool,
     pub self_update: PathRepoUpdatesSelfUpdateEnum,
+    pub background_updates: bool,
     pub interval: i64,
     pub ref_type: String,
     pub ref_match: Option<String>,
@@ -722,6 +731,10 @@ impl PathRepoUpdatesConfig {
                 },
                 (None, None) => PathRepoUpdatesSelfUpdateEnum::Ask,
             },
+            background_updates: match config_value.get("background_updates") {
+                Some(value) => value.as_bool().unwrap(),
+                None => true,
+            },
             interval: match config_value.get("interval") {
                 Some(value) => value.as_integer().unwrap(),
                 None => 12 * 60 * 60,
@@ -755,7 +768,10 @@ impl PathRepoUpdatesConfig {
             return false;
         }
 
-        update_git_repo(repo_id, ref_type, ref_match, None, None)
+        match update_git_repo(repo_id, ref_type, ref_match, None, None) {
+            Ok(updated) => updated,
+            Err(_) => false,
+        }
     }
 }
 

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -20,5 +20,4 @@ pub(crate) use updater::auto_update_sync;
 pub(crate) use updater::exec_update;
 pub(crate) use updater::exec_update_and_log_on_error;
 pub(crate) use updater::report_update_error;
-pub(crate) use updater::trigger_background_update;
 pub(crate) use updater::update_git_repo;

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -15,5 +15,10 @@ pub(crate) use utils::safe_git_url_parse;
 pub(crate) use utils::safe_normalize_url;
 
 mod updater;
-pub(crate) use updater::auto_path_update;
+pub(crate) use updater::auto_update_async;
+pub(crate) use updater::auto_update_sync;
+pub(crate) use updater::exec_update;
+pub(crate) use updater::exec_update_and_log_on_error;
+pub(crate) use updater::report_update_error;
+pub(crate) use updater::trigger_background_update;
 pub(crate) use updater::update_git_repo;

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -255,7 +255,7 @@ pub fn update(
                 .to_str()
                 .unwrap()
                 .split(':')
-                .map(|path| PathBuf::from(path))
+                .map(PathBuf::from)
                 .collect()
         } else {
             vec![]
@@ -483,11 +483,11 @@ pub fn update(
         trigger_background_update(
             skip_update_path
                 .iter()
-                .map(|path| path.clone())
+                .cloned()
                 .chain(
                     updates_per_path
                         .keys()
-                        .map(|path| PathBuf::from(path))
+                        .map(PathBuf::from)
                         .collect::<Vec<_>>(),
                 )
                 .collect(),

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -1,26 +1,38 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::io::Write;
+use std::path::PathBuf;
 use std::process::exit;
+use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
 use indicatif::MultiProgress;
+use tempfile::NamedTempFile;
+use time::format_description::well_known::Rfc3339;
+use tokio::process::Command as TokioCommand;
 
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::OmniPathCache;
 use crate::internal::commands::path::global_omnipath_entries;
-use crate::internal::config::config;
+use crate::internal::config::global_config;
+use crate::internal::config::up::utils::run_command_with_handler;
 use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::env::current_exe;
 use crate::internal::env::shell_is_interactive;
 use crate::internal::git::path_entry_config;
 use crate::internal::git_env;
 use crate::internal::self_update;
+use crate::internal::user_interface::ensure_newline;
 use crate::internal::user_interface::StringColor;
 use crate::omni_error;
 use crate::omni_info;
+use crate::omni_print;
+use crate::omni_warning;
 
 fn should_update() -> bool {
     // Check if OMNI_SKIP_UPDATE is set
@@ -60,158 +72,377 @@ fn should_update() -> bool {
     require_update
 }
 
-pub fn auto_path_update() {
+pub fn auto_update_async(current_command_path: Option<PathBuf>) {
+    update(
+        false,
+        true,
+        if let Some(current_command_path) = current_command_path {
+            vec![current_command_path]
+        } else {
+            vec![]
+        },
+    );
+}
+
+pub fn auto_update_sync() -> bool {
+    let (updated, _errored) = update(false, false, vec![]);
+    !updated.is_empty()
+}
+
+pub fn exec_update() {
+    let (_updated, errored) = update(true, false, vec![]);
+    exit(if !errored.is_empty() { 1 } else { 0 });
+}
+
+pub fn exec_update_and_log_on_error() {
+    let mut cmd = TokioCommand::new(current_exe());
+    cmd.arg("--update");
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let log_file_prefix = format!(
+        "omni-update.{}.",
+        time::OffsetDateTime::now_utc()
+            .replace_nanosecond(0)
+            .unwrap()
+            .format(&Rfc3339)
+            .expect("failed to format date")
+            .replace(['-', ':'], ""), // Remove the dashes in the date and the colons in the time
+    );
+    let mut log_file = match NamedTempFile::with_prefix(log_file_prefix.as_str()) {
+        Ok(file) => file,
+        Err(err) => {
+            omni_error!(format!("failed to create temporary file: {}", err));
+            exit(1);
+        }
+    };
+
+    omni_info!("running update in the background");
+
+    // Make a simple handler to append to the log file
+    let handler_fn = |stdout: Option<String>, stderr: Option<String>| {
+        if let Some(s) = stdout {
+            log_file.write_all(s.as_bytes()).unwrap();
+            log_file.write_all(b"\n").unwrap();
+        }
+        if let Some(s) = stderr {
+            log_file.write_all(s.as_bytes()).unwrap();
+            log_file.write_all(b"\n").unwrap();
+        }
+    };
+
+    let result = run_command_with_handler(
+        &mut cmd,
+        handler_fn,
+        // TODO: make this configurable
+        RunConfig::new().with_timeout(3600), // Timeout after 1 hour
+    );
+
+    match result {
+        Ok(_) => {
+            // Get rid of the log file
+            match log_file.close() {
+                Ok(_) => {
+                    omni_info!("update successful");
+                }
+                Err(err) => {
+                    omni_warning!(format!("failed to close log file: {}", err));
+                }
+            };
+        }
+        Err(err) => {
+            omni_error!(format!("update failed: {}", err));
+            match log_file.keep() {
+                Ok((_file, path)) => {
+                    omni_info!(format!("log file kept at {}", path.display()));
+                    if let Err(err) = OmniPathCache::exclusive(|omnipath| {
+                        omnipath.update_error(path.to_string_lossy().to_string());
+                        true
+                    }) {
+                        omni_error!(format!("failed to update cache: {}", err));
+                    }
+                }
+                Err(err) => {
+                    omni_error!(format!("failed to keep log file: {}", err));
+                }
+            };
+            exit(1);
+        }
+    }
+
+    exit(0);
+}
+
+pub fn report_update_error() {
+    if shell_is_interactive() && OmniPathCache::get().update_errored() {
+        if let Err(err) = OmniPathCache::exclusive(|omnipath| {
+            if omnipath.update_errored() {
+                omni_print!(format!(
+                    "background update failed; log is available at {}",
+                    omnipath.update_error_log()
+                )
+                .light_red());
+                omnipath.clear_update_error();
+                true
+            } else {
+                false
+            }
+        }) {
+            omni_error!(format!("failed to update cache: {}", err));
+        }
+    }
+}
+
+pub fn trigger_background_update() -> bool {
+    let mut command = Command::new(current_exe());
+    command.arg("--update-and-log-on-error");
+    command.stdin(std::process::Stdio::null());
+    command.stdout(std::process::Stdio::null());
+    command.stderr(std::process::Stdio::null());
+
+    match command.spawn() {
+        Ok(_child) => true,
+        Err(_err) => false,
+    }
+}
+
+pub fn update(
+    force_update: bool,
+    allow_background_update: bool,
+    force_sync: Vec<PathBuf>,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
     // Get the configuration
-    let config = config(".");
+    let config = global_config();
 
     // Get the omnipath
     let omnipath_entries = global_omnipath_entries();
+
+    // Nothing to do if nothing is in the omnipath and we don't
+    // check for omni updates
     if omnipath_entries.is_empty() && config.path_repo_updates.self_update.do_not_check() {
-        // Nothing to do if nothing is in the omnipath and we
-        // don't check for omni updates
-        return;
+        return (vec![], vec![]);
     }
 
-    if !should_update() {
-        return;
+    if !force_update && !should_update() {
+        return (vec![], vec![]);
     }
 
     self_update();
 
     if omnipath_entries.is_empty() {
-        return;
+        return (vec![], vec![]);
     }
 
-    // Let's do all the git updates in parallel since we don't require
-    // switching directory for that
-    let multiprogress = MultiProgress::new();
-    let mut threads = Vec::new();
-    let (sender, receiver) = mpsc::channel();
-    let mut seen = HashSet::new();
+    // Override allow_background_update if the configuration does not allow it
+    let allow_background_update = if !config.path_repo_updates.background_updates {
+        false
+    } else {
+        allow_background_update
+    };
 
-    for path_entry in omnipath_entries {
-        let path = path_entry.as_string();
+    let mut count_left_to_update = 0;
+    let mut updates_per_path = HashMap::new();
+    if allow_background_update && force_sync.is_empty() {
+        count_left_to_update = omnipath_entries.len();
+    } else {
+        // Let's do all the git updates in parallel since we don't require
+        // switching directory for that
+        let multiprogress = MultiProgress::new();
+        let mut threads = Vec::new();
+        let (sender, receiver) = mpsc::channel();
+        let mut seen = HashSet::new();
 
-        let git_env = git_env(&path).clone();
-        let repo_id = git_env.id();
-        if repo_id.is_none() {
-            continue;
-        }
-        let repo_id = repo_id.unwrap();
-        let repo_root = git_env.root().unwrap().to_string();
+        for path_entry in omnipath_entries {
+            let path = path_entry.as_string();
 
-        // Avoid updating the same repository multiple times
-        if !seen.insert(repo_root.clone()) {
-            continue;
-        }
+            let git_env = git_env(&path).clone();
+            let repo_id = git_env.id();
+            if repo_id.is_none() {
+                continue;
+            }
 
-        // Get the configuration for that repository
-        let (enabled, ref_type, ref_match) = config.path_repo_updates.update_config(&repo_id);
+            // Check if we want to update this repository synchronously
+            // or if we can delegate it to the background update
+            if allow_background_update
+                && !force_sync
+                    .iter()
+                    .any(|force_sync_path| path_entry.includes_path(force_sync_path.clone()))
+            {
+                count_left_to_update += 1;
+                continue;
+            }
 
-        if !enabled {
-            // Skipping repository if updates are not enabled for it
-            continue;
-        }
+            let repo_id = repo_id.unwrap();
+            let repo_root = git_env.root().unwrap().to_string();
 
-        let desc = format!(
-            "Updating {} {}:",
-            if path_entry.is_package() {
-                "📦"
+            // Avoid updating the same repository multiple times
+            if !seen.insert(repo_root.clone()) {
+                continue;
+            }
+
+            // Get the configuration for that repository
+            let (enabled, ref_type, ref_match) = config.path_repo_updates.update_config(&repo_id);
+
+            if !enabled {
+                // Skipping repository if updates are not enabled for it
+                continue;
+            }
+
+            let desc = format!(
+                "Updating {} {}:",
+                if path_entry.is_package() {
+                    "📦"
+                } else {
+                    "🌳"
+                },
+                repo_id.italic().light_cyan()
+            )
+            .light_blue();
+            let progress_handler: Box<dyn ProgressHandler + Send> = if shell_is_interactive() {
+                let mut spinner =
+                    SpinnerProgressHandler::new_with_multi(desc, None, multiprogress.clone());
+                spinner.no_newline_on_error();
+                Box::new(spinner)
             } else {
-                "🌳"
-            },
-            repo_id.italic().light_cyan()
-        )
-        .light_blue();
-        let progress_handler: Box<dyn ProgressHandler + Send> = if shell_is_interactive() {
-            let mut spinner =
-                SpinnerProgressHandler::new_with_multi(desc, None, multiprogress.clone());
-            spinner.no_newline_on_error();
-            Box::new(spinner)
-        } else {
-            Box::new(PrintProgressHandler::new(desc, None))
-        };
+                Box::new(PrintProgressHandler::new(desc, None))
+            };
 
-        let _multiprogress = multiprogress.clone();
-        let sender = sender.clone();
-        threads.push(thread::spawn(move || {
-            let result = update_git_repo(
-                &repo_id,
-                ref_type,
-                ref_match,
-                Some(&repo_root.clone()),
-                Some(progress_handler.as_ref()),
-            );
+            let _multiprogress = multiprogress.clone();
+            let sender = sender.clone();
+            threads.push(thread::spawn(move || {
+                let result = update_git_repo(
+                    &repo_id,
+                    ref_type,
+                    ref_match,
+                    Some(&repo_root.clone()),
+                    Some(progress_handler.as_ref()),
+                );
 
-            sender.send((repo_root, result)).unwrap();
-        }));
-    }
-
-    for thread in threads {
-        let _ = thread.join();
-    }
-
-    let mut results = HashMap::new();
-    while let Ok((path, updated)) = receiver.recv_timeout(Duration::from_millis(10)) {
-        if updated {
-            results.insert(path, updated);
-        }
-    }
-
-    // multiprogress.clear().unwrap();
-
-    if results.is_empty() {
-        return;
-    }
-
-    let current_exe = std::env::current_exe();
-    if current_exe.is_err() {
-        omni_error!("failed to get current executable path", "updater");
-        exit(1);
-    }
-    let current_exe = current_exe.unwrap();
-
-    for (repo_path, _updated) in results.iter() {
-        let path_entry = path_entry_config(repo_path);
-        if !path_entry.is_valid() {
-            continue;
+                sender.send((repo_root, result)).unwrap();
+            }));
         }
 
-        let location = match path_entry.package {
-            Some(ref package) => format!("{}:{}", "package".underline(), package.light_cyan(),),
-            None => path_entry.as_string().light_cyan(),
-        };
+        for thread in threads {
+            let _ = thread.join();
+        }
 
-        omni_info!(format!(
-            "running {} in {}",
-            "omni up".light_yellow(),
-            location,
-        ));
+        let mut results = HashMap::new();
+        while let Ok((path, updated)) = receiver.recv_timeout(Duration::from_millis(10)) {
+            updates_per_path.insert(path.clone(), updated.clone());
+            if let Ok(true) = updated {
+                results.insert(path, true);
+            }
+        }
 
-        let mut omni_up_command = std::process::Command::new(current_exe.clone());
-        omni_up_command.arg("up");
-        omni_up_command.current_dir(repo_path);
-        omni_up_command.env_remove("OMNI_FORCE_UPDATE");
-        omni_up_command.env("OMNI_SKIP_UPDATE", "1");
+        // multiprogress.clear().unwrap();
 
-        let child = omni_up_command.spawn();
-        match child {
-            Ok(mut child) => {
-                let status = child.wait();
-                match status {
-                    Ok(_status) => {}
+        if !results.is_empty() {
+            let current_exe = std::env::current_exe();
+            if current_exe.is_err() {
+                omni_error!("failed to get current executable path", "updater");
+                exit(1);
+            }
+            let current_exe = current_exe.unwrap();
+
+            for (repo_path, _updated) in results.iter() {
+                let path_entry = path_entry_config(repo_path);
+                if !path_entry.is_valid() {
+                    continue;
+                }
+
+                let location = match path_entry.package {
+                    Some(ref package) => {
+                        format!("{}:{}", "package".underline(), package.light_cyan(),)
+                    }
+                    None => path_entry.as_string().light_cyan(),
+                };
+
+                omni_info!(format!(
+                    "running {} in {}",
+                    "omni up".light_yellow(),
+                    location,
+                ));
+
+                let mut omni_up_command = std::process::Command::new(current_exe.clone());
+                omni_up_command.arg("up");
+                omni_up_command.current_dir(repo_path);
+                omni_up_command.env_remove("OMNI_FORCE_UPDATE");
+                omni_up_command.env("OMNI_SKIP_UPDATE", "1");
+
+                let child = omni_up_command.spawn();
+                match child {
+                    Ok(mut child) => {
+                        let status = child.wait();
+                        match status {
+                            Ok(_status) => {}
+                            Err(err) => {
+                                omni_error!(format!("failed to wait on process: {}", err));
+                            }
+                        }
+                    }
                     Err(err) => {
-                        omni_error!(format!("failed to wait on process: {}", err));
+                        omni_error!(format!("failed to spawn process: {}", err));
                     }
                 }
             }
-            Err(err) => {
-                omni_error!(format!("failed to spawn process: {}", err));
-            }
         }
     }
 
-    omni_info!("done!".light_green());
+    let updated_paths = updates_per_path
+        .iter()
+        .filter_map(|(path, updated)| {
+            if let Ok(true) = updated {
+                Some(PathBuf::from(path))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let errored_paths = updates_per_path
+        .iter()
+        .filter_map(|(path, updated)| {
+            if let Err(_) = updated {
+                Some(PathBuf::from(path))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // If we need to update in the background, let's do that now
+    ensure_newline();
+    if allow_background_update && count_left_to_update > 0 {
+        trigger_background_update();
+        omni_info!(format!(
+            "{}{}",
+            if !errored_paths.is_empty() {
+                "error! ".light_red()
+            } else if updated_paths.is_empty() {
+                "".to_string()
+            } else {
+                "done! ".light_green()
+            },
+            format!(
+                "{} {} {}",
+                "updating".light_black(),
+                count_left_to_update.to_string().light_yellow(),
+                format!(
+                    "path{} in the background",
+                    if count_left_to_update > 1 { "s" } else { "" }
+                )
+                .light_black(),
+            )
+            .italic(),
+        ));
+    } else if !errored_paths.is_empty() {
+        omni_info!("error!".light_red());
+    } else {
+        omni_info!("done!".light_green());
+    }
+
+    // Return the list of updated paths
+    (updated_paths, errored_paths)
 }
 
 pub fn update_git_repo(
@@ -220,13 +451,24 @@ pub fn update_git_repo(
     ref_match: Option<String>,
     repo_path: Option<&str>,
     progress_handler: Option<&dyn ProgressHandler>,
-) -> bool {
+) -> Result<bool, String> {
+    // let progress_handler: Box<&dyn ProgressHandler> =
+    // if let Some(progress_handler) = progress_handler {
+    // Box::new(progress_handler)
+    // } else if shell_is_interactive() {
+    // spinner = SpinnerProgressHandler::new(desc, None);
+    // Box::new(&spinner)
+    // } else {
+    // printer = PrintProgressHandler::new(desc, None);
+    // Box::new(&printer)
+    // };
+
     match ref_type.as_str() {
         "branch" => update_git_branch(repo_id, ref_match, repo_path, progress_handler),
         "tag" => update_git_tag(repo_id, ref_match, repo_path, progress_handler),
         _ => {
             omni_error!("invalid ref type: {}", ref_type.light_red());
-            false
+            Err(format!("invalid ref type: {}", ref_type))
         }
     }
 }
@@ -236,7 +478,7 @@ fn update_git_branch(
     ref_match: Option<String>,
     repo_path: Option<&str>,
     progress_handler: Option<&dyn ProgressHandler>,
-) -> bool {
+) -> Result<bool, String> {
     let desc = format!("Updating {}:", repo_id.italic().light_cyan()).light_blue();
     let spinner;
     let printer;
@@ -266,18 +508,18 @@ fn update_git_branch(
 
     let output = git_branch_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git branch failed".to_string());
-        return false;
+        let msg = "git branch failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let git_branch = String::from_utf8(output.unwrap().stdout)
         .unwrap()
         .trim()
         .to_string();
     if git_branch.is_empty() {
-        progress_handler.error_with_message(
-            "not currently checked out on a branch; skipping update".to_string(),
-        );
-        return false;
+        let msg = "not currently checked out on a branch; skipping update".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     let regex = match ref_match {
@@ -285,20 +527,19 @@ fn update_git_branch(
         None => regex::Regex::new(".*"),
     };
     if regex.is_err() {
-        progress_handler.error_with_message(format!(
-            "invalid ref match: {}",
-            ref_match.unwrap().light_red()
-        ));
-        return false;
+        let msg = format!("invalid ref match: {}", ref_match.unwrap());
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     if !regex.unwrap().is_match(&git_branch) {
-        progress_handler.error_with_message(format!(
+        let msg = format!(
             "current branch {} does not match {}; skipping update",
-            git_branch.light_red(),
-            ref_match.unwrap().light_red()
-        ));
-        return false;
+            git_branch,
+            ref_match.unwrap()
+        );
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     progress_handler.progress("pulling latest changes".to_string());
@@ -314,18 +555,20 @@ fn update_git_branch(
 
     match git_pull_cmd.output() {
         Err(err) => {
-            progress_handler.error_with_message(format!("git pull failed: {}", err));
-            false
+            let msg = format!("git pull failed: {}", err);
+            progress_handler.error_with_message(msg.clone());
+            Err(msg)
         }
         Ok(output) if !output.status.success() => {
-            progress_handler.error_with_message(format!(
+            let msg = format!(
                 "git pull failed: {}",
                 String::from_utf8(output.stderr)
                     .unwrap()
                     .replace('\n', " ")
-                    .trim(),
-            ));
-            false
+                    .trim()
+            );
+            progress_handler.error_with_message(msg.clone());
+            Err(msg)
         }
         Ok(output) => {
             let output = String::from_utf8(output.stdout).unwrap().trim().to_string();
@@ -333,10 +576,10 @@ fn update_git_branch(
 
             if output_lines.len() == 1 && output_lines[0].contains("Already up to date.") {
                 progress_handler.success_with_message("already up to date".light_black());
-                false
+                Ok(false)
             } else {
                 progress_handler.success_with_message("updated".light_green());
-                true
+                Ok(true)
             }
         }
     }
@@ -347,7 +590,7 @@ fn update_git_tag(
     ref_match: Option<String>,
     repo_path: Option<&str>,
     progress_handler: Option<&dyn ProgressHandler>,
-) -> bool {
+) -> Result<bool, String> {
     let desc = format!("Updating {}:", repo_id.italic().light_cyan()).light_blue();
     let spinner;
     let printer;
@@ -376,17 +619,18 @@ fn update_git_tag(
 
     let output = git_branch_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git branch failed".to_string());
-        return false;
+        let msg = "git branch failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let git_branch = String::from_utf8(output.unwrap().stdout)
         .unwrap()
         .trim()
         .to_string();
     if !git_branch.is_empty() {
-        progress_handler
-            .error_with_message("currently checked out on a branch; skipping update".to_string());
-        return false;
+        let msg = "currently checked out on a branch; skipping update".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     // Check which tag we are currently checked out on, if any
@@ -404,17 +648,18 @@ fn update_git_tag(
 
     let output = git_tag_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git tag failed".to_string());
-        return false;
+        let msg = "git tag failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let git_tag = String::from_utf8(output.unwrap().stdout)
         .unwrap()
         .trim()
         .to_string();
     if git_tag.is_empty() {
-        progress_handler
-            .error_with_message("not currently checked out on a tag; skipping update".to_string());
-        return false;
+        let msg = "not currently checked out on a tag; skipping update".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     // Consider the latest tag built on this commit to be the current tag
@@ -433,8 +678,9 @@ fn update_git_tag(
 
     let output = git_fetch_tags_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git fetch failed".to_string());
-        return false;
+        let msg = "git fetch failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     // Check if there was any new tags fetched
@@ -444,7 +690,7 @@ fn update_git_tag(
     if fetched_out.trim().is_empty() && fetched_err.trim().is_empty() {
         // If no new tags, nothing more to do!
         progress_handler.success_with_message("no new tags, nothing to do".light_black());
-        return false;
+        return Ok(false);
     }
 
     // If any new tags, we need to check what is the most recent tag
@@ -461,16 +707,18 @@ fn update_git_tag(
 
     let output = git_tag_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git tag failed".to_string());
-        return false;
+        let msg = "git tag failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let git_tags = String::from_utf8(output.unwrap().stdout)
         .unwrap()
         .trim()
         .to_string();
     if git_tags.is_empty() {
-        progress_handler.error_with_message("no tags found; skipping update".to_string());
-        return false;
+        let msg = "no tags found; skipping update".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     // Find the most recent git tag in git_tags that matches
@@ -480,22 +728,24 @@ fn update_git_tag(
         None => regex::Regex::new(".*"),
     };
     if regex.is_err() {
-        progress_handler.error_with_message("invalid tag regex".to_string());
-        return false;
+        let msg = "invalid tag regex".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let regex = regex.unwrap();
 
     let target_tag = git_tags.lines().find(|git_tag| regex.is_match(git_tag));
     if target_tag.is_none() {
-        progress_handler.error_with_message("no matching tags found; skipping update".to_string());
-        return false;
+        let msg = "no matching tags found; skipping update".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
     let target_tag = target_tag.unwrap().trim().to_string();
 
     // If the current tag is the same as the target tag, nothing more to do!
     if current_tag == target_tag {
         progress_handler.success_with_message("already on latest matching tag".light_black());
-        return false;
+        return Ok(false);
     }
 
     // Check out the target tag
@@ -512,11 +762,12 @@ fn update_git_tag(
 
     let output = git_checkout_cmd.output();
     if output.is_err() || !output.as_ref().unwrap().status.success() {
-        progress_handler.error_with_message("git checkout failed".to_string());
-        return false;
+        let msg = "git checkout failed".to_string();
+        progress_handler.error_with_message(msg.clone());
+        return Err(msg);
     }
 
     progress_handler.success_with_message("updated".light_green());
 
-    true
+    Ok(true)
 }

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -402,7 +402,7 @@ pub fn update(
     let errored_paths = updates_per_path
         .iter()
         .filter_map(|(path, updated)| {
-            if let Err(_) = updated {
+            if updated.is_err() {
                 Some(PathBuf::from(path))
             } else {
                 None

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -374,14 +374,29 @@ pub fn update(
                     Ok(mut child) => {
                         let status = child.wait();
                         match status {
-                            Ok(_status) => {}
+                            Ok(status) => {
+                                if !status.success() {
+                                    updates_per_path.insert(
+                                        repo_path.clone(),
+                                        Err("omni up failed".to_string()),
+                                    );
+                                }
+                            }
                             Err(err) => {
-                                omni_error!(format!("failed to wait on process: {}", err));
+                                let msg = format!("failed to wait on process: {}", err);
+                                omni_error!(msg.clone());
+                                updates_per_path.insert(
+                                    repo_path.clone(),
+                                    Err(format!("omni up failed: {}", msg)),
+                                );
                             }
                         }
                     }
                     Err(err) => {
-                        omni_error!(format!("failed to spawn process: {}", err));
+                        let msg = format!("failed to spawn process: {}", err);
+                        omni_error!(msg.clone());
+                        updates_per_path
+                            .insert(repo_path.clone(), Err(format!("omni up failed: {}", msg)));
                     }
                 }
             }

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -241,6 +241,11 @@ impl OmniRelease {
             // Replace current process with the new binary
             ProcessCommand::new(std::env::current_exe().unwrap())
                 .args(std::env::args().skip(1))
+                // We want to force the update, since by replacing the current
+                // process, we're going to skip the rest of the updates otherwise
+                .env("OMNI_FORCE_UPDATE", "1")
+                // We want to skip the self-update, since we're already doing it
+                // here, and we don't want to do it again when the new binary starts
                 .env("OMNI_SKIP_SELF_UPDATE", "1")
                 .exec();
 

--- a/src/internal/user_interface/mod.rs
+++ b/src/internal/user_interface/mod.rs
@@ -2,6 +2,7 @@ pub mod colors;
 pub use colors::StringColor;
 
 pub mod print;
+pub use print::ensure_newline;
 pub use print::term_width;
 pub use print::wrap_blocks;
 pub use print::wrap_text;

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use term_size;
 
+use crate::internal::env::shell_is_interactive;
+
 #[macro_export]
 macro_rules! omni_header {
     () => {
@@ -34,7 +36,7 @@ macro_rules! omni_info {
         eprintln!(
             "{}",
             format!("{}{} {}", "omni:".light_cyan(), cmd, $message)
-        );
+        )
     };
     ($message:expr, $cmd:expr) => {
         let cmd = if $cmd != "" {
@@ -182,4 +184,14 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
     lines.push(line);
 
     lines
+}
+
+pub fn ensure_newline() {
+    if shell_is_interactive() {
+        if let Ok((x, _y)) = term_cursor::get_pos() {
+            if x > 0 {
+                eprintln!();
+            }
+        }
+    }
 }

--- a/src/internal/workdir.rs
+++ b/src/internal/workdir.rs
@@ -41,20 +41,19 @@ pub fn is_trusted_or_ask(path: &str, ask: String) -> bool {
 
     let mut choices = vec![('y', "Yes, this time (and ask me everytime)"), ('n', "No")];
 
-    let repo_mention = if repo_id.is_some() {
+    if repo_id.is_some() {
         choices.insert(0, ('a', "Yes, always (add to trusted directories)"));
-        format!("The directory {}", repo_id.clone().unwrap().light_blue())
+        omni_info!(format!(
+            "The directory {} is not in your trusted directories.",
+            repo_id.clone().unwrap().light_blue()
+        ));
+        omni_info!(format!(
+            "{} all repositories in a trusted organization are automatically trusted.",
+            "Tip:".bold()
+        ));
     } else {
-        "This directory".to_string()
+        omni_info!(format!("The path {} is not trusted.", path.light_blue()));
     };
-    omni_info!(format!(
-        "{} is not in your trusted directories.",
-        repo_mention
-    ));
-    omni_info!(format!(
-        "{} repositories in your organizations are automatically trusted.",
-        "Tip:".bold()
-    ));
 
     let question = requestty::Question::expand("trust_repo")
         .ask_if_answered(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use internal::git::auto_update_async;
 use internal::git::auto_update_sync;
 use internal::git::exec_update;
 use internal::git::exec_update_and_log_on_error;
-use internal::git::trigger_background_update;
 use internal::StringColor;
 
 #[derive(Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,126 @@ use internal::commands::HookEnvCommand;
 use internal::commands::HookInitCommand;
 use internal::commands::HookUuidCommand;
 use internal::config::ensure_bootstrap;
-use internal::git::auto_path_update;
+use internal::git::auto_update_async;
+use internal::git::auto_update_sync;
+use internal::git::exec_update;
+use internal::git::exec_update_and_log_on_error;
+use internal::git::trigger_background_update;
 use internal::StringColor;
+
+#[derive(Debug, Clone)]
+struct MainArgs {
+    only_check_exists: bool,
+    args: Vec<String>,
+}
+
+impl MainArgs {
+    fn parse(argv: Vec<String>) -> Self {
+        let mut parse_argv = vec!["".to_string()];
+        parse_argv.extend(argv);
+
+        let matches = clap::Command::new("")
+            .disable_help_subcommand(true)
+            .disable_help_flag(true)
+            .version(env!("CARGO_PKG_VERSION"))
+            .arg(
+                clap::Arg::new("help")
+                    .long("help")
+                    .short('h')
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("update")
+                    .long("update")
+                    .conflicts_with("args")
+                    .conflicts_with("exists")
+                    .conflicts_with("help")
+                    .conflicts_with("update-and-log-on-error")
+                    .conflicts_with("version")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("update-and-log-on-error")
+                    .long("update-and-log-on-error")
+                    .conflicts_with("args")
+                    .conflicts_with("exists")
+                    .conflicts_with("help")
+                    .conflicts_with("update")
+                    .conflicts_with("version")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("exists")
+                    .long("exists")
+                    .short('e')
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("args")
+                    .action(clap::ArgAction::Append)
+                    .allow_hyphen_values(true),
+            )
+            .try_get_matches_from(&parse_argv);
+
+        let matches = match matches {
+            Ok(matches) => matches,
+            Err(err) => match err.kind() {
+                clap::error::ErrorKind::DisplayVersion => {
+                    println!("omni version {}", env!("CARGO_PKG_VERSION"));
+                    exit(0);
+                }
+                // clap::error::ErrorKind::DisplayHelp
+                // | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+                // unreachable!("help flag is disabled");
+                // }
+                _ => {
+                    let err_str = format!("{}", err);
+                    let err_str = err_str
+                        .split('\n')
+                        .take_while(|line| !line.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let err_str = err_str.trim_start_matches("error: ");
+                    omni_error!(err_str);
+                    exit(1);
+                }
+            },
+        };
+
+        if *matches.get_one::<bool>("update").unwrap_or(&false) {
+            exec_update();
+        } else if *matches
+            .get_one::<bool>("update-and-log-on-error")
+            .unwrap_or(&false)
+        {
+            exec_update_and_log_on_error();
+        }
+
+        let mut args: Vec<_> = matches
+            .get_many::<String>("args")
+            .map(|args| args.map(|arg| arg.to_string()).collect())
+            .unwrap_or_default();
+
+        if *matches.get_one::<bool>("help").unwrap_or(&false) {
+            args.insert(0, "help".to_string());
+        }
+
+        if args.is_empty() {
+            args.push("help".to_string());
+        }
+
+        // TODO: remove this, wip
+        if args[0] == "--test" {
+            trigger_background_update();
+            exit(0);
+        }
+
+        Self {
+            only_check_exists: *matches.get_one::<bool>("exists").unwrap_or(&false),
+            args,
+        }
+    }
+}
 
 fn complete_omni_subcommand(argv: &[String]) {
     let comp_cword = env::var("COMP_CWORD")
@@ -20,33 +138,27 @@ fn complete_omni_subcommand(argv: &[String]) {
     exit(0);
 }
 
-fn run_omni_subcommand(argv: &[String]) {
-    let mut argv = if argv.is_empty() {
-        vec!["help".to_owned()]
-    } else {
-        argv.to_vec()
-    };
-
-    if argv[0] == "hook" {
+fn run_omni_subcommand(parsed: &MainArgs) {
+    if parsed.args[0] == "hook" {
         // For hooks, we want a fast path that doesn't load all the commands;
         // we want to make sure that we don't add any extraneous delay to the
         // shell. We also don't check arguments more than we need to, so that
         // things can be handled faster.
-        if argv.len() > 1 {
-            match argv[1].as_ref() {
+        if parsed.args.len() > 1 {
+            match parsed.args[1].as_ref() {
                 "env" => {
                     let command = HookEnvCommand::new();
-                    command.exec(argv[2..].to_vec());
+                    command.exec(parsed.args[2..].to_vec());
                     panic!("exec returned");
                 }
                 "uuid" => {
                     let command = HookUuidCommand::new();
-                    command.exec(argv[2..].to_vec());
+                    command.exec(parsed.args[2..].to_vec());
                     panic!("exec returned");
                 }
                 "init" => {
                     let command = HookInitCommand::new();
-                    command.exec(argv[2..].to_vec());
+                    command.exec(parsed.args[2..].to_vec());
                     panic!("exec returned");
                 }
                 _ => {}
@@ -58,56 +170,56 @@ fn run_omni_subcommand(argv: &[String]) {
             "{} {} {}",
             "omni:".light_cyan(),
             "command not found:".red(),
-            argv.join(" ")
+            parsed.args.join(" ")
         );
         exit(1);
-    } else if argv.len() == 1 && (argv[0] == "--version" || argv[0] == "-v") {
-        println!("omni version {}", env!("CARGO_PKG_VERSION"));
-        exit(0);
-    } else if argv[0] == "--help" || argv[0] == "-h" {
-        argv[0] = "help".to_owned();
     }
 
-    let only_check_exists = if argv[0] == "--exists" || argv[0] == "-e" {
-        argv = argv[1..].to_vec();
-        true
-    } else {
-        false
-    };
-
-    if !only_check_exists {
+    if !parsed.only_check_exists {
         // Ensures that omni has been bootstrapped
         ensure_bootstrap();
-
-        // Update the path if necessary
-        auto_path_update();
     }
 
     let command_loader = command_loader(".");
-    if let Some((omni_cmd, called_as, argv)) = command_loader.to_serve(&argv) {
-        if only_check_exists {
+    if let Some((omni_cmd, called_as, argv)) = command_loader.to_serve(&parsed.args) {
+        if parsed.only_check_exists {
             exit(match argv.len() {
                 0 => 0,
                 _ => 1,
             });
         }
 
+        auto_update_async(if omni_cmd.has_source() {
+            Some(omni_cmd.source().into())
+        } else {
+            None
+        });
+
         omni_cmd.exec(argv, Some(called_as));
         panic!("exec returned");
     }
 
-    if only_check_exists {
+    if parsed.only_check_exists {
         exit(1);
+    }
+
+    // We didn't find the command, so let's try to update synchronously
+    if auto_update_sync() {
+        // If any updates were done, let's check again if we can serve the command
+        if let Some((omni_cmd, called_as, argv)) = command_loader.to_serve(&parsed.args) {
+            omni_cmd.exec(argv, Some(called_as));
+            panic!("exec returned");
+        }
     }
 
     eprintln!(
         "{} {} {}",
         "omni:".light_cyan(),
         "command not found:".red(),
-        argv.join(" ")
+        parsed.args.join(" ")
     );
 
-    if let Some((omni_cmd, called_as, argv)) = command_loader.find_command(&argv) {
+    if let Some((omni_cmd, called_as, argv)) = command_loader.find_command(&parsed.args) {
         omni_cmd.exec(argv, Some(called_as));
         panic!("exec returned");
     }
@@ -122,5 +234,6 @@ fn main() {
         complete_omni_subcommand(&args[1..]);
     }
 
-    run_omni_subcommand(&args);
+    let main_args = MainArgs::parse(args.clone());
+    run_omni_subcommand(&main_args);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,12 +115,6 @@ impl MainArgs {
             args.push("help".to_string());
         }
 
-        // TODO: remove this, wip
-        if args[0] == "--test" {
-            trigger_background_update();
-            exit(0);
-        }
-
         Self {
             only_check_exists: *matches.get_one::<bool>("exists").unwrap_or(&false),
             args,

--- a/website/contents/reference/01-configuration/0102-parameters/010250-path_repo_updates/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-path_repo_updates/010250-self.md
@@ -13,6 +13,8 @@ Configuration for the automated updates of the repositories in omni path.
 |------------|----------------|---------------------------------------------------|
 | `enabled` | boolean | whether or not automated updates are enabled *(default: true)* |
 | `self_update` | enum: `true`, `false`, `ask`, `nocheck` | whether to update omni if a new release is found (`false` will check for release but only show a message, `true` will automatically install any new release, `ask` will ask the user and `nocheck` will entirely skip checking for updates |
+| `background_updates` | boolean | whether or not to allow background updates of the repositories *(default: true)* |
+| `background_updates_timeout` | integer | the number of seconds after which a background update timeouts *(default: 3600)* |
 | `interval` | integer | the number of seconds to wait between two updates of the repositories *(default: 43200)* |
 | `ref_type` | enum: `branch` or `tag` | the type of ref that is being used for updates *(default: branch)* |
 | `ref_match` | regex |  a string representing the regular expression to match the ref name when doing an update; using `null` is equivalent to matching everything *(default: null)* |


### PR DESCRIPTION
This will make it smoother to use omni as only the required updates will be done synchronously (i.e. if the command being run is from the path to be updated), while other updates will be done asynchronously in the background.

For asynchronous updates, the log file will be saved in case of any error, and printed the next time the `env` hook is being called.

Closes https://github.com/XaF/omni/issues/170