### PR TITLE
fix(path commands): 🐛 make the exec path accurate

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -320,8 +320,8 @@ impl Command {
         update_dynamic_env_for_command(&self.source_dir());
 
         // Set the general execution environment
-        let name = if let Some(called_as) = called_as {
-            called_as
+        let name = if let Some(ref called_as) = called_as {
+            called_as.clone()
         } else {
             self.name().clone()
         };
@@ -361,7 +361,7 @@ impl Command {
             Command::BuiltinStatus(command) => command.exec(argv),
             Command::BuiltinTidy(command) => command.exec(argv),
             Command::BuiltinUp(command) => command.exec(argv),
-            Command::FromPath(command) => command.exec(argv),
+            Command::FromPath(command) => command.exec(argv, called_as),
             Command::FromConfig(command) => command.exec(argv),
             Command::FromMakefile(command) => command.exec(argv),
             Command::Void(_) => {}

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -162,7 +162,7 @@ impl PathCommand {
         let source = called_as.map_or(self.source.clone(), |called_as| {
             self.aliases
                 .get(&called_as)
-                .map(|source| source.clone())
+                .cloned()
                 .unwrap_or(self.source.clone())
         });
 


### PR DESCRIPTION
With the handling of aliases for symlinks, the execution path was lost and the first encountered path was the one being executed for any of the aliases to one command. This prevented being able to use `$0` in bash scripts for instance, or any equivalent in any language when writing an omni command.

This fixes that problem by making sure that aliases that have their own execution path, which is the case for symlinks, are being executed from that path, making `$0` (and equivalents) usable.

Fixes https://github.com/XaF/omni/issues/161