### PR TITLE
feat(homebrew operation): ✨ update PATH with installed formulae

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -24,6 +24,7 @@ use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::data_home;
 use crate::internal::env::shell_is_interactive;
@@ -265,7 +266,11 @@ impl UpConfigAsdfBase {
         }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn up(
+        &self,
+        _options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
         let desc = format!("{} ({}):", self.tool, self.version).light_blue();
         let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
             Box::new(SpinnerProgressHandler::new(desc, progress))
@@ -461,7 +466,11 @@ impl UpConfigAsdfBase {
         Ok(())
     }
 
-    pub fn down(&self, _progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn down(
+        &self,
+        _options: &UpOptions,
+        _progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
         Ok(())
     }
 

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -6,6 +6,7 @@ use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::dynenv::update_dynamic_env_for_command;
 use crate::internal::user_interface::colors::StringColor;
@@ -106,7 +107,7 @@ impl UpConfig {
         }
     }
 
-    pub fn up(&self) -> Result<(), UpError> {
+    pub fn up(&self, options: &UpOptions) -> Result<(), UpError> {
         // Get current directory
         let current_dir = std::env::current_dir().expect("Failed to get current directory");
 
@@ -135,7 +136,7 @@ impl UpConfig {
             // the command can consider it right away
             update_dynamic_env_for_command(".");
 
-            step.up(Some((idx + 1, num_steps)))?
+            step.up(&options, Some((idx + 1, num_steps)))?
         }
 
         // This is a special case, as we could have multiple versions of a single
@@ -146,7 +147,7 @@ impl UpConfig {
         Ok(())
     }
 
-    pub fn down(&self) -> Result<(), UpError> {
+    pub fn down(&self, options: &UpOptions) -> Result<(), UpError> {
         // Filter the steps to only the available ones
         let steps = self
             .steps
@@ -162,7 +163,7 @@ impl UpConfig {
             // the command can consider it right away
             update_dynamic_env_for_command(".");
 
-            step.down(Some((idx + 1, num_steps)))?
+            step.down(&options, Some((idx + 1, num_steps)))?
         }
 
         UpConfigAsdfBase::cleanup_unused(Vec::new(), Some((num_steps, num_steps)))?;

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -136,7 +136,7 @@ impl UpConfig {
             // the command can consider it right away
             update_dynamic_env_for_command(".");
 
-            step.up(&options, Some((idx + 1, num_steps)))?
+            step.up(options, Some((idx + 1, num_steps)))?
         }
 
         // This is a special case, as we could have multiple versions of a single
@@ -163,7 +163,7 @@ impl UpConfig {
             // the command can consider it right away
             update_dynamic_env_for_command(".");
 
-            step.down(&options, Some((idx + 1, num_steps)))?
+            step.down(options, Some((idx + 1, num_steps)))?
         }
 
         UpConfigAsdfBase::cleanup_unused(Vec::new(), Some((num_steps, num_steps)))?;

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -50,7 +50,7 @@ impl UpConfigGolang {
     }
 
     pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base()?.up(&options, progress)
+        self.asdf_base()?.up(options, progress)
     }
 
     pub fn down(
@@ -58,7 +58,7 @@ impl UpConfigGolang {
         options: &UpOptions,
         progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
-        self.asdf_base()?.down(&options, progress)
+        self.asdf_base()?.down(options, progress)
     }
 
     pub fn asdf_base(&self) -> Result<&UpConfigAsdfBase, UpError> {

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::internal::commands::utils::abs_path;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::ConfigValue;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -48,12 +49,16 @@ impl UpConfigGolang {
         }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base()?.up(progress)
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base()?.up(&options, progress)
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base()?.down(progress)
+    pub fn down(
+        &self,
+        options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
+        self.asdf_base()?.down(&options, progress)
     }
 
     pub fn asdf_base(&self) -> Result<&UpConfigAsdfBase, UpError> {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use duct::cmd;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
@@ -7,12 +9,14 @@ use tokio::process::Command as TokioCommand;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::HomebrewInstalled;
 use crate::internal::cache::HomebrewOperationCache;
+use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
@@ -36,7 +40,7 @@ impl UpConfigHomebrew {
         UpConfigHomebrew { install, tap }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         let desc = "install homebrew dependencies:".light_blue();
         let main_progress_handler = PrintProgressHandler::new(desc, progress);
         main_progress_handler.progress("".to_string());
@@ -51,7 +55,7 @@ impl UpConfigHomebrew {
 
         let num_installs = self.install.len();
         for (idx, install) in self.install.iter().enumerate() {
-            if let Err(err) = install.up(progress, Some((idx + 1, num_installs))) {
+            if let Err(err) = install.up(&options, progress, Some((idx + 1, num_installs))) {
                 main_progress_handler.error();
                 return Err(err);
             }
@@ -75,7 +79,11 @@ impl UpConfigHomebrew {
         Ok(())
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn down(
+        &self,
+        options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
         let workdir = workdir(".");
         let repo_id = workdir.id();
         if repo_id.is_none() {
@@ -105,7 +113,8 @@ impl UpConfigHomebrew {
 
             let num_uninstalls = to_uninstall.len();
             for (idx, (rmidx, install)) in to_uninstall.iter().enumerate() {
-                if let Err(err) = install.down(progress, Some((idx + 1, num_uninstalls))) {
+                if let Err(err) = install.down(&options, progress, Some((idx + 1, num_uninstalls)))
+                {
                     main_progress_handler.error();
                     return_value = Err(err);
                     return updated;
@@ -593,7 +602,7 @@ impl HomebrewInstall {
         }
     }
 
-    fn update_cache(&self, progress_handler: Option<&dyn ProgressHandler>) {
+    fn update_cache(&self, options: &UpOptions, progress_handler: Option<&dyn ProgressHandler>) {
         let workdir = workdir(".");
         let workdir_id = workdir.id();
         if workdir_id.is_none() {
@@ -605,7 +614,7 @@ impl HomebrewInstall {
             progress_handler.progress("updating cache".to_string())
         }
 
-        let result = HomebrewOperationCache::exclusive(|brew_cache| {
+        if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
             brew_cache.add_install(
                 &workdir_id,
                 &self.name,
@@ -613,19 +622,40 @@ impl HomebrewInstall {
                 self.is_cask(),
                 self.was_handled(),
             )
-        });
-
-        if let Err(err) = result {
+        }) {
             if let Some(progress_handler) = progress_handler {
                 progress_handler.progress(format!("failed to update cache: {}", err))
             }
-        } else if let Some(progress_handler) = progress_handler {
+            return;
+        }
+
+        let bin_path = self.bin_path(&options);
+        let brew_bin_path = self.brew_bin_path(&options);
+        if bin_path.is_some() || brew_bin_path.is_some() {
+            if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
+                if let Some(bin_path) = bin_path {
+                    up_env.add_path(&workdir_id, bin_path);
+                }
+                if let Some(brew_bin_path) = brew_bin_path {
+                    up_env.add_path(&workdir_id, brew_bin_path);
+                }
+                true
+            }) {
+                if let Some(progress_handler) = progress_handler {
+                    progress_handler.progress(format!("failed to update cache: {}", err))
+                }
+                return;
+            }
+        }
+
+        if let Some(progress_handler) = progress_handler {
             progress_handler.progress("updated cache".to_string())
         }
     }
 
     fn up(
         &self,
+        options: &UpOptions,
         main_progress: Option<(usize, usize)>,
         sub_progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
@@ -656,36 +686,39 @@ impl HomebrewInstall {
         };
         let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
 
-        let installed = self.is_installed();
+        let installed = self.is_installed(&options);
         if installed && self.version.is_some() {
-            self.update_cache(progress_handler);
+            self.update_cache(&options, progress_handler);
             if let Some(progress_handler) = progress_handler {
                 progress_handler.success_with_message("already installed".light_black())
             }
             return Ok(());
         }
 
-        if let Err(err) = self.install(progress_handler, installed) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error_with_message(err.to_string());
+        match self.install(&options, progress_handler, installed) {
+            Ok(did_something) => {
+                self.update_cache(&options, progress_handler);
+                if let Some(progress_handler) = progress_handler {
+                    progress_handler.success_with_message(match (installed, did_something) {
+                        (true, true) => "updated".light_green(),
+                        (true, false) => "up to date (cached)".light_black(),
+                        (false, _) => "installed".light_green(),
+                    })
+                }
+                Ok(())
             }
-            return Err(err);
+            Err(err) => {
+                if let Some(progress_handler) = progress_handler {
+                    progress_handler.error_with_message(err.to_string());
+                }
+                Err(err)
+            }
         }
-
-        self.update_cache(progress_handler);
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.success_with_message(
-                if installed { "up to date" } else { "installed" }
-                    .to_string()
-                    .light_green(),
-            );
-        }
-
-        Ok(())
     }
 
     fn down(
         &self,
+        options: &UpOptions,
         main_progress: Option<(usize, usize)>,
         sub_progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
@@ -716,7 +749,7 @@ impl HomebrewInstall {
         };
         let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
 
-        let installed = self.is_installed();
+        let installed = self.is_installed(&options);
         if !installed {
             if let Some(progress_handler) = progress_handler {
                 progress_handler.success_with_message("not installed".light_black())
@@ -787,12 +820,14 @@ impl HomebrewInstall {
         self.install_type == HomebrewInstallType::Cask
     }
 
-    fn is_installed(&self) -> bool {
-        if !HomebrewOperationCache::get().should_check_install(
-            &self.name,
-            self.version.clone(),
-            self.is_cask(),
-        ) {
+    fn is_installed(&self, options: &UpOptions) -> bool {
+        if options.cache_enabled
+            && !HomebrewOperationCache::get().should_check_install(
+                &self.name,
+                self.version.clone(),
+                self.is_cask(),
+            )
+        {
             return true;
         }
 
@@ -817,6 +852,88 @@ impl HomebrewInstall {
         }
 
         false
+    }
+
+    fn brew_bin_path(&self, options: &UpOptions) -> Option<PathBuf> {
+        if options.cache_enabled {
+            if let Some(bin_path) = HomebrewOperationCache::get().homebrew_bin_path() {
+                if !bin_path.is_empty() {
+                    return Some(bin_path.into());
+                }
+            }
+        }
+
+        let mut brew_list = std::process::Command::new("brew");
+        brew_list.arg("--prefix");
+        brew_list.stdout(std::process::Stdio::piped());
+        brew_list.stderr(std::process::Stdio::null());
+
+        if let Ok(output) = brew_list.output() {
+            if output.status.success() {
+                let bin_path =
+                    PathBuf::from(String::from_utf8(output.stdout).unwrap().trim()).join("bin");
+                if bin_path.exists() {
+                    _ = HomebrewOperationCache::exclusive(|cache| {
+                        cache.set_homebrew_bin_path(bin_path.to_string_lossy().to_string());
+                        true
+                    });
+
+                    return Some(bin_path);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn bin_path(&self, options: &UpOptions) -> Option<PathBuf> {
+        if self.is_cask() {
+            // brew --prefix doesn't work for casks
+            return None;
+        }
+
+        if options.cache_enabled {
+            if let Some(bin_path) = HomebrewOperationCache::get().homebrew_install_bin_path(
+                &self.name,
+                self.version.clone(),
+                self.is_cask(),
+            ) {
+                if !bin_path.is_empty() {
+                    return Some(bin_path.into());
+                }
+            }
+        }
+
+        let mut brew_list = std::process::Command::new("brew");
+        brew_list.arg("--prefix");
+        brew_list.arg("--installed");
+        brew_list.arg(self.package_id());
+        brew_list.stdout(std::process::Stdio::piped());
+        brew_list.stderr(std::process::Stdio::null());
+
+        if let Ok(output) = brew_list.output() {
+            if output.status.success() {
+                let bin_path =
+                    PathBuf::from(String::from_utf8(output.stdout).unwrap().trim()).join("bin");
+                let bin_path = if bin_path.exists() {
+                    bin_path
+                } else {
+                    PathBuf::from("")
+                };
+
+                _ = HomebrewOperationCache::exclusive(|cache| {
+                    cache.set_homebrew_install_bin_path(
+                        &self.name,
+                        self.version.clone(),
+                        self.is_cask(),
+                        bin_path.to_string_lossy().to_string(),
+                    );
+                    true
+                });
+            }
+        }
+
+        None
     }
 
     fn is_in_local_tap(&self) -> bool {
@@ -855,36 +972,39 @@ impl HomebrewInstall {
 
     fn install(
         &self,
+        options: &UpOptions,
         progress_handler: Option<&dyn ProgressHandler>,
         installed: bool,
-    ) -> Result<(), UpError> {
+    ) -> Result<bool, UpError> {
         if !installed {
-            self.extract_package(progress_handler)?;
-        } else if !HomebrewOperationCache::get().should_update_install(
-            &self.name,
-            self.version.clone(),
-            self.is_cask(),
-        ) {
+            self.extract_package(&options, progress_handler)?;
+        } else if options.cache_enabled
+            && !HomebrewOperationCache::get().should_update_install(
+                &self.name,
+                self.version.clone(),
+                self.is_cask(),
+            )
+        {
             if let Some(progress_handler) = progress_handler {
                 progress_handler.progress("already up to date".light_black())
             }
 
-            return Ok(());
+            return Ok(false);
         }
 
-        let mut brew_tap = TokioCommand::new("brew");
+        let mut brew_install = TokioCommand::new("brew");
         if installed {
-            brew_tap.arg("upgrade");
+            brew_install.arg("upgrade");
         } else {
-            brew_tap.arg("install");
+            brew_install.arg("install");
         }
         if self.install_type == HomebrewInstallType::Cask {
-            brew_tap.arg("--cask");
+            brew_install.arg("--cask");
         }
-        brew_tap.arg(self.package_id());
+        brew_install.arg(self.package_id());
 
-        brew_tap.stdout(std::process::Stdio::piped());
-        brew_tap.stderr(std::process::Stdio::piped());
+        brew_install.stdout(std::process::Stdio::piped());
+        brew_install.stderr(std::process::Stdio::piped());
 
         if let Some(progress_handler) = progress_handler {
             progress_handler.progress(if installed {
@@ -894,20 +1014,24 @@ impl HomebrewInstall {
             })
         }
 
-        let result = run_progress(&mut brew_tap, progress_handler, RunConfig::default());
-        if result.is_ok() && self.was_handled.set(true).is_err() {
-            unreachable!();
-        }
+        match run_progress(&mut brew_install, progress_handler, RunConfig::default()) {
+            Ok(_) => {
+                if self.was_handled.set(true).is_err() {
+                    unreachable!();
+                }
 
-        // Update the cache
-        if let Err(err) = HomebrewOperationCache::exclusive(|cache| {
-            cache.updated_install(&self.name, self.version.clone(), self.is_cask());
-            true
-        }) {
-            return Err(UpError::Cache(err.to_string()));
-        }
+                // Update the cache
+                if let Err(err) = HomebrewOperationCache::exclusive(|cache| {
+                    cache.updated_install(&self.name, self.version.clone(), self.is_cask());
+                    true
+                }) {
+                    return Err(UpError::Cache(err.to_string()));
+                }
 
-        result
+                Ok(true)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn uninstall(&self, progress_handler: Option<&dyn ProgressHandler>) -> Result<(), UpError> {
@@ -934,6 +1058,7 @@ impl HomebrewInstall {
 
     fn extract_package(
         &self,
+        options: &UpOptions,
         progress_handler: Option<&dyn ProgressHandler>,
     ) -> Result<(), UpError> {
         if self.version.is_none() {
@@ -1002,7 +1127,7 @@ impl HomebrewInstall {
         // }
         // }
 
-        if HomebrewOperationCache::get().should_update_homebrew() {
+        if !options.cache_enabled || HomebrewOperationCache::get().should_update_homebrew() {
             let mut update_brew_cache = false;
             let brew_updated = BREW_UPDATED.get_or_init(|| {
                 if let Some(progress_handler) = progress_handler {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -55,7 +55,7 @@ impl UpConfigHomebrew {
 
         let num_installs = self.install.len();
         for (idx, install) in self.install.iter().enumerate() {
-            if let Err(err) = install.up(&options, progress, Some((idx + 1, num_installs))) {
+            if let Err(err) = install.up(options, progress, Some((idx + 1, num_installs))) {
                 main_progress_handler.error();
                 return Err(err);
             }
@@ -113,8 +113,7 @@ impl UpConfigHomebrew {
 
             let num_uninstalls = to_uninstall.len();
             for (idx, (rmidx, install)) in to_uninstall.iter().enumerate() {
-                if let Err(err) = install.down(&options, progress, Some((idx + 1, num_uninstalls)))
-                {
+                if let Err(err) = install.down(options, progress, Some((idx + 1, num_uninstalls))) {
                     main_progress_handler.error();
                     return_value = Err(err);
                     return updated;
@@ -629,8 +628,8 @@ impl HomebrewInstall {
             return;
         }
 
-        let bin_path = self.bin_path(&options);
-        let brew_bin_path = self.brew_bin_path(&options);
+        let bin_path = self.bin_path(options);
+        let brew_bin_path = self.brew_bin_path(options);
         if bin_path.is_some() || brew_bin_path.is_some() {
             if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
                 if let Some(bin_path) = bin_path {
@@ -686,18 +685,18 @@ impl HomebrewInstall {
         };
         let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
 
-        let installed = self.is_installed(&options);
+        let installed = self.is_installed(options);
         if installed && self.version.is_some() {
-            self.update_cache(&options, progress_handler);
+            self.update_cache(options, progress_handler);
             if let Some(progress_handler) = progress_handler {
                 progress_handler.success_with_message("already installed".light_black())
             }
             return Ok(());
         }
 
-        match self.install(&options, progress_handler, installed) {
+        match self.install(options, progress_handler, installed) {
             Ok(did_something) => {
-                self.update_cache(&options, progress_handler);
+                self.update_cache(options, progress_handler);
                 if let Some(progress_handler) = progress_handler {
                     progress_handler.success_with_message(match (installed, did_something) {
                         (true, true) => "updated".light_green(),
@@ -749,7 +748,7 @@ impl HomebrewInstall {
         };
         let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
 
-        let installed = self.is_installed(&options);
+        let installed = self.is_installed(options);
         if !installed {
             if let Some(progress_handler) = progress_handler {
                 progress_handler.success_with_message("not installed".light_black())
@@ -977,7 +976,7 @@ impl HomebrewInstall {
         installed: bool,
     ) -> Result<bool, UpError> {
         if !installed {
-            self.extract_package(&options, progress_handler)?;
+            self.extract_package(options, progress_handler)?;
         } else if options.cache_enabled
             && !HomebrewOperationCache::get().should_update_install(
                 &self.name,

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -1,33 +1,35 @@
-pub mod base;
-pub use base::UpConfig;
+pub(crate) mod base;
+pub(crate) use base::UpConfig;
 
-pub mod tool;
-pub use tool::UpConfigTool;
+pub(crate) mod options;
+pub(crate) use options::UpOptions;
 
-pub mod bundler;
-pub use bundler::UpConfigBundler;
+pub(crate) mod tool;
+pub(crate) use tool::UpConfigTool;
 
-pub mod custom;
-pub use custom::UpConfigCustom;
+pub(crate) mod bundler;
+pub(crate) use bundler::UpConfigBundler;
 
-pub mod golang;
-pub use golang::UpConfigGolang;
+pub(crate) mod custom;
+pub(crate) use custom::UpConfigCustom;
 
-pub mod nodejs;
-pub use nodejs::UpConfigNodejs;
+pub(crate) mod golang;
+pub(crate) use golang::UpConfigGolang;
 
-pub mod homebrew;
-pub use homebrew::UpConfigHomebrew;
+pub(crate) mod nodejs;
+pub(crate) use nodejs::UpConfigNodejs;
 
-pub mod asdf_base;
-pub use asdf_base::UpConfigAsdfBase;
-pub use asdf_base::ASDF_BIN;
-pub use asdf_base::ASDF_PATH;
+pub(crate) mod homebrew;
+pub(crate) use homebrew::UpConfigHomebrew;
 
-pub mod error;
-pub use error::UpError;
+pub(crate) mod asdf_base;
+pub(crate) use asdf_base::UpConfigAsdfBase;
+pub(crate) use asdf_base::ASDF_PATH;
 
-pub mod utils;
-pub use utils::run_progress;
-pub use utils::ProgressHandler;
-pub use utils::SpinnerProgressHandler;
+pub(crate) mod error;
+pub(crate) use error::UpError;
+
+pub(crate) mod utils;
+pub(crate) use utils::run_progress;
+pub(crate) use utils::ProgressHandler;
+pub(crate) use utils::SpinnerProgressHandler;

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -25,7 +25,7 @@ impl UpConfigNodejs {
     }
 
     pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.up(&options, progress)
+        self.asdf_base.up(options, progress)
     }
 
     pub fn down(
@@ -33,7 +33,7 @@ impl UpConfigNodejs {
         options: &UpOptions,
         progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
-        self.asdf_base.down(&options, progress)
+        self.asdf_base.down(options, progress)
     }
 }
 

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::ConfigValue;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -23,12 +24,16 @@ impl UpConfigNodejs {
         Self { asdf_base }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.up(progress)
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base.up(&options, progress)
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.down(progress)
+    pub fn down(
+        &self,
+        options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
+        self.asdf_base.down(&options, progress)
     }
 }
 

--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpOptions {
+    pub cache_enabled: bool,
+}
+
+impl UpOptions {
+    pub fn new() -> Self {
+        Self {
+            cache_enabled: true,
+        }
+    }
+
+    pub fn cache(mut self, cache_enabled: bool) -> Self {
+        self.cache_enabled = cache_enabled;
+        self
+    }
+}
+
+impl Default for UpOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -8,6 +8,7 @@ use crate::internal::config::up::UpConfigGolang;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigNodejs;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -73,33 +74,37 @@ impl UpConfigTool {
         }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         match self {
-            UpConfigTool::Bash(config) => config.up(progress),
+            UpConfigTool::Bash(config) => config.up(&options, progress),
             UpConfigTool::Bundler(config) => config.up(progress),
             UpConfigTool::Custom(config) => config.up(progress),
-            UpConfigTool::Go(config) => config.up(progress),
-            UpConfigTool::Homebrew(config) => config.up(progress),
-            UpConfigTool::Nodejs(config) => config.up(progress),
-            UpConfigTool::Python(config) => config.up(progress),
-            UpConfigTool::Ruby(config) => config.up(progress),
-            UpConfigTool::Rust(config) => config.up(progress),
-            UpConfigTool::Terraform(config) => config.up(progress),
+            UpConfigTool::Go(config) => config.up(&options, progress),
+            UpConfigTool::Homebrew(config) => config.up(&options, progress),
+            UpConfigTool::Nodejs(config) => config.up(&options, progress),
+            UpConfigTool::Python(config) => config.up(&options, progress),
+            UpConfigTool::Ruby(config) => config.up(&options, progress),
+            UpConfigTool::Rust(config) => config.up(&options, progress),
+            UpConfigTool::Terraform(config) => config.up(&options, progress),
         }
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn down(
+        &self,
+        options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
         match self {
-            UpConfigTool::Bash(config) => config.down(progress),
+            UpConfigTool::Bash(config) => config.down(&options, progress),
             UpConfigTool::Bundler(config) => config.down(progress),
             UpConfigTool::Custom(config) => config.down(progress),
-            UpConfigTool::Go(config) => config.down(progress),
-            UpConfigTool::Homebrew(config) => config.down(progress),
-            UpConfigTool::Nodejs(config) => config.down(progress),
-            UpConfigTool::Python(config) => config.down(progress),
-            UpConfigTool::Ruby(config) => config.down(progress),
-            UpConfigTool::Rust(config) => config.down(progress),
-            UpConfigTool::Terraform(config) => config.down(progress),
+            UpConfigTool::Go(config) => config.down(&options, progress),
+            UpConfigTool::Homebrew(config) => config.down(&options, progress),
+            UpConfigTool::Nodejs(config) => config.down(&options, progress),
+            UpConfigTool::Python(config) => config.down(&options, progress),
+            UpConfigTool::Ruby(config) => config.down(&options, progress),
+            UpConfigTool::Rust(config) => config.down(&options, progress),
+            UpConfigTool::Terraform(config) => config.down(&options, progress),
         }
     }
 

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -76,16 +76,16 @@ impl UpConfigTool {
 
     pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         match self {
-            UpConfigTool::Bash(config) => config.up(&options, progress),
+            UpConfigTool::Bash(config) => config.up(options, progress),
             UpConfigTool::Bundler(config) => config.up(progress),
             UpConfigTool::Custom(config) => config.up(progress),
-            UpConfigTool::Go(config) => config.up(&options, progress),
-            UpConfigTool::Homebrew(config) => config.up(&options, progress),
-            UpConfigTool::Nodejs(config) => config.up(&options, progress),
-            UpConfigTool::Python(config) => config.up(&options, progress),
-            UpConfigTool::Ruby(config) => config.up(&options, progress),
-            UpConfigTool::Rust(config) => config.up(&options, progress),
-            UpConfigTool::Terraform(config) => config.up(&options, progress),
+            UpConfigTool::Go(config) => config.up(options, progress),
+            UpConfigTool::Homebrew(config) => config.up(options, progress),
+            UpConfigTool::Nodejs(config) => config.up(options, progress),
+            UpConfigTool::Python(config) => config.up(options, progress),
+            UpConfigTool::Ruby(config) => config.up(options, progress),
+            UpConfigTool::Rust(config) => config.up(options, progress),
+            UpConfigTool::Terraform(config) => config.up(options, progress),
         }
     }
 
@@ -95,16 +95,16 @@ impl UpConfigTool {
         progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
         match self {
-            UpConfigTool::Bash(config) => config.down(&options, progress),
+            UpConfigTool::Bash(config) => config.down(options, progress),
             UpConfigTool::Bundler(config) => config.down(progress),
             UpConfigTool::Custom(config) => config.down(progress),
-            UpConfigTool::Go(config) => config.down(&options, progress),
-            UpConfigTool::Homebrew(config) => config.down(&options, progress),
-            UpConfigTool::Nodejs(config) => config.down(&options, progress),
-            UpConfigTool::Python(config) => config.down(&options, progress),
-            UpConfigTool::Ruby(config) => config.down(&options, progress),
-            UpConfigTool::Rust(config) => config.down(&options, progress),
-            UpConfigTool::Terraform(config) => config.down(&options, progress),
+            UpConfigTool::Go(config) => config.down(options, progress),
+            UpConfigTool::Homebrew(config) => config.down(options, progress),
+            UpConfigTool::Nodejs(config) => config.down(options, progress),
+            UpConfigTool::Python(config) => config.down(options, progress),
+            UpConfigTool::Ruby(config) => config.down(options, progress),
+            UpConfigTool::Rust(config) => config.down(options, progress),
+            UpConfigTool::Terraform(config) => config.down(options, progress),
         }
     }
 

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -198,6 +198,12 @@ impl DynamicEnv {
                 hasher.update(DATA_SEPARATOR.as_bytes());
             }
 
+            // Add the requested paths to the hash
+            for path in up_env.paths.iter().rev() {
+                hasher.update(path.to_str().unwrap().as_bytes());
+                hasher.update(DATA_SEPARATOR.as_bytes());
+            }
+
             // Go over the tool versions in the up environment cache
             for toolversion in up_env.versions_for_dir(&dir).iter() {
                 hasher.update(toolversion.tool.as_bytes());
@@ -240,6 +246,11 @@ impl DynamicEnv {
             }
             for (key, value) in up_env.env_vars.iter() {
                 envsetter.set_value(key, value);
+            }
+
+            // Add the requested paths
+            for path in up_env.paths.iter().rev() {
+                envsetter.prepend_to_list("PATH", path.to_str().unwrap());
             }
 
             // Go over the tool versions in the up environment cache

--- a/website/contents/reference/02-builtin-commands/0250-up.md
+++ b/website/contents/reference/02-builtin-commands/0250-up.md
@@ -18,6 +18,7 @@ Running this command will also refresh the [dynamic environment](/reference/dyna
 
 | Parameter       | Required | Value type | Description                                         |
 |-----------------|----------|------------|-----------------------------------------------------|
+| `--no-cache` | no | `null` | If provided, the `up` cache will not be used for that run (this can make operations slower, but allows to avoid potentially stale data) |
 | `--bootstrap` | no | `null` | Same as using `--update-user-config --clone-suggested`; if any of the options are directly provided, they will take precedence over the default values of the options |
 | `--clone-suggested` | no | enum: `yes`, `ask` or `no` | Whether we should clone the suggested repositories, if any declared in the `suggest_clone` configuration of the repository *(default: no)* |
 | `--trust` | no | enum: `always`, `yes`, or `no` | Define how to trust the repository to run the command *(defaults to ask the user)* |


### PR DESCRIPTION
This allows to make sure that any tool installed for a given repository is made available in the context of that repository. Prior to this change, it was expected that the homebrew bin path was loaded in the PATH environment variable by the user.

This slightly changes the update cache format to store the formulae bin paths. A new `--no-cache` parameter has been added to `omni up` in order to allow running `omni up` without taking the cache into account. This option only works for homebrew for now.

Closes https://github.com/XaF/omni/issues/256