### PR TITLE
fix(homebrew operation)!: 🐛 require explicit `cask` mention

### DIFF
--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -832,6 +832,11 @@ impl HomebrewInstall {
 
         let mut brew_list = std::process::Command::new("brew");
         brew_list.arg("list");
+        if self.is_cask() {
+            brew_list.arg("--cask");
+        } else {
+            brew_list.arg("--formula");
+        }
         brew_list.arg(self.package_id());
         brew_list.stdout(std::process::Stdio::null());
         brew_list.stderr(std::process::Stdio::null());
@@ -999,6 +1004,8 @@ impl HomebrewInstall {
         }
         if self.install_type == HomebrewInstallType::Cask {
             brew_install.arg("--cask");
+        } else {
+            brew_install.arg("--formula");
         }
         brew_install.arg(self.package_id());
 


### PR DESCRIPTION
With `brew` automatically falling back to cask when a formula is not found, this prevented omni to handle operations for casks in a different way than for formulae, for things that only work for formulae (e.g. `brew --prefix`). This changes that by passing an explicit `--formula` or `--cask` when performing actions.

BREAKING CHANGE: casks that did not have the `cask` explicit mention in `up:` operations will stop working. Simple fix is to prefix them by `cask:` if the cask name is provided inline (e.g. `- 1password-cli` should become `- cask: 1password-cli`.