### PR TITLE
fix(homebrew operation): 🐛 make sure to clean up the install cache

### DIFF
--- a/src/internal/cache/homebrew_operation.rs
+++ b/src/internal/cache/homebrew_operation.rs
@@ -352,6 +352,16 @@ impl HomebrewOperationUpdateCache {
         }
     }
 
+    pub fn removed_homebrew_install(
+        &mut self,
+        install_name: &str,
+        install_version: Option<String>,
+        is_cask: bool,
+    ) {
+        let key = self.install_key(install_name, install_version, is_cask);
+        self.install.remove(&key);
+    }
+
     pub fn should_update_homebrew_install(
         &self,
         install_name: &str,

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -522,14 +522,13 @@ impl UpCommand {
 
         // If it has an up configuration, handle it
         if has_up_config {
-            let options = UpOptions::new().cache(self.cli_args().cache_enabled);
-
             let up_config = up_config.unwrap();
             if self.is_up() {
+                let options = UpOptions::new().cache(self.cli_args().cache_enabled);
                 if let Err(err) = up_config.up(&options) {
                     omni_error!(format!("issue while setting repo up: {}", err));
                 }
-            } else if let Err(err) = up_config.down(&options) {
+            } else if let Err(err) = up_config.down() {
                 omni_error!(format!("issue while tearing repo down: {}", err));
             }
         }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -466,11 +466,7 @@ impl UpConfigAsdfBase {
         Ok(())
     }
 
-    pub fn down(
-        &self,
-        _options: &UpOptions,
-        _progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
+    pub fn down(&self, _progress: Option<(usize, usize)>) -> Result<(), UpError> {
         Ok(())
     }
 

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -147,7 +147,7 @@ impl UpConfig {
         Ok(())
     }
 
-    pub fn down(&self, options: &UpOptions) -> Result<(), UpError> {
+    pub fn down(&self) -> Result<(), UpError> {
         // Filter the steps to only the available ones
         let steps = self
             .steps
@@ -163,7 +163,7 @@ impl UpConfig {
             // the command can consider it right away
             update_dynamic_env_for_command(".");
 
-            step.down(options, Some((idx + 1, num_steps)))?
+            step.down(Some((idx + 1, num_steps)))?
         }
 
         UpConfigAsdfBase::cleanup_unused(Vec::new(), Some((num_steps, num_steps)))?;

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -53,12 +53,8 @@ impl UpConfigGolang {
         self.asdf_base()?.up(options, progress)
     }
 
-    pub fn down(
-        &self,
-        options: &UpOptions,
-        progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
-        self.asdf_base()?.down(options, progress)
+    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base()?.down(progress)
     }
 
     pub fn asdf_base(&self) -> Result<&UpConfigAsdfBase, UpError> {

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -28,12 +28,8 @@ impl UpConfigNodejs {
         self.asdf_base.up(options, progress)
     }
 
-    pub fn down(
-        &self,
-        options: &UpOptions,
-        progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
-        self.asdf_base.down(options, progress)
+    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base.down(progress)
     }
 }
 

--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -3,18 +3,26 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpOptions {
-    pub cache_enabled: bool,
+    pub read_cache: bool,
+    pub write_cache: bool,
 }
 
 impl UpOptions {
     pub fn new() -> Self {
         Self {
-            cache_enabled: true,
+            read_cache: true,
+            write_cache: false,
         }
     }
 
-    pub fn cache(mut self, cache_enabled: bool) -> Self {
-        self.cache_enabled = cache_enabled;
+    pub fn cache(mut self, read_cache: bool) -> Self {
+        self.read_cache = read_cache;
+        self
+    }
+
+    pub fn cache_disabled(mut self) -> Self {
+        self.read_cache = false;
+        self.write_cache = false;
         self
     }
 }

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -89,22 +89,18 @@ impl UpConfigTool {
         }
     }
 
-    pub fn down(
-        &self,
-        options: &UpOptions,
-        progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
+    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         match self {
-            UpConfigTool::Bash(config) => config.down(options, progress),
+            UpConfigTool::Bash(config) => config.down(progress),
             UpConfigTool::Bundler(config) => config.down(progress),
             UpConfigTool::Custom(config) => config.down(progress),
-            UpConfigTool::Go(config) => config.down(options, progress),
-            UpConfigTool::Homebrew(config) => config.down(options, progress),
-            UpConfigTool::Nodejs(config) => config.down(options, progress),
-            UpConfigTool::Python(config) => config.down(options, progress),
-            UpConfigTool::Ruby(config) => config.down(options, progress),
-            UpConfigTool::Rust(config) => config.down(options, progress),
-            UpConfigTool::Terraform(config) => config.down(options, progress),
+            UpConfigTool::Go(config) => config.down(progress),
+            UpConfigTool::Homebrew(config) => config.down(progress),
+            UpConfigTool::Nodejs(config) => config.down(progress),
+            UpConfigTool::Python(config) => config.down(progress),
+            UpConfigTool::Ruby(config) => config.down(progress),
+            UpConfigTool::Rust(config) => config.down(progress),
+            UpConfigTool::Terraform(config) => config.down(progress),
         }
     }
 


### PR DESCRIPTION
Since we are now using a cache to avoid checking that a given homebrew formula/cask is already installed or updated, or to resolve its homebrew path, let's simply clean things up when we uninstall a formula/cask so that on the next call it does not hit the cache.

Closes https://github.com/XaF/omni/issues/265