### PR TITLE
fix(omni up): 🐛 return code should be 1 on error

### DIFF
--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -528,9 +528,11 @@ impl UpCommand {
             if self.is_up() {
                 if let Err(err) = up_config.up(&options) {
                     omni_error!(format!("issue while setting repo up: {}", err));
+                    exit(1);
                 }
             } else if let Err(err) = up_config.down(&options) {
                 omni_error!(format!("issue while tearing repo down: {}", err));
+                exit(1);
             }
         }
 


### PR DESCRIPTION
The `omni up` command was simply returning exit code `0` on error to set things up, instead of erroring out properly.

This is now fixed.