### PR TITLE
fix(shell integration): 🐛 arg parsing for fish auto-complete

### DIFF
--- a/shell_integration/omni.fish.tmpl
+++ b/shell_integration/omni.fish.tmpl
@@ -74,7 +74,7 @@ function _omni_complete_fish
 
     {% endif -%}
     # Remove the first element (command) from cmdline
-    set -l args (string join -- " " $cmdline[2..-1])
+    set -l args $cmdline[2..-1]
 
     set -f opts (env COMP_CWORD=$cword OMNI_SHELL=fish $autocomplete $args)
     string join \n -- $opts


### PR DESCRIPTION
Fixes https://github.com/XaF/omni/issues/128.

The `args` parsing code was sending the arguments as a single string, rather than as an array.

If you typed `omni config path <TAB>` then `["config path"]` was passed as args into `omni --complete` instead of the expected `["config", "path"]`.