### PR TITLE
feat(python): ✨🐍 add venv support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-62"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28ebd71b3e708e895b83ec2d35c6e2ef96e34945706bf4d73826354e84f89b2"
+dependencies = [
+ "failure",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +694,28 @@ checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -1438,6 +1472,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1530,7 @@ dependencies = [
 name = "omnicli"
 version = "0.0.0-git"
 dependencies = [
+ "base-62",
  "blake3",
  "clap 4.4.11",
  "duct",
@@ -2334,6 +2390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2816,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 time = { version = "0.3.30", features = ["serde-well-known"] }
 
 [dependencies]
+base-62 = "0.1.1"
 blake3 = "1.5.0"
 clap = "4.4.11"
 duct = "0.13.6"

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -102,15 +102,32 @@ impl UpEnvironmentsCache {
         };
 
         for dir in dirs {
-            wd_up_env.versions.push(UpVersion {
-                tool: tool.to_string(),
-                version: version.to_string(),
-                dir: dir.to_string(),
-            });
+            wd_up_env.versions.push(UpVersion::new(tool, version, &dir));
         }
 
         self.updated();
         true
+    }
+
+    pub fn add_version_data_path(
+        &mut self,
+        workdir_id: &str,
+        tool: &str,
+        version: &str,
+        dir: &str,
+        data_path: &str,
+    ) -> bool {
+        if let Some(wd_up_env) = self.env.get_mut(workdir_id) {
+            for exists in wd_up_env.versions.iter_mut() {
+                if exists.tool == tool && exists.version == version && exists.dir == dir {
+                    exists.data_path = Some(data_path.to_string());
+                    self.updated();
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     pub fn contains(&self, workdir_id: &str) -> bool {
@@ -217,4 +234,17 @@ pub struct UpVersion {
     pub version: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_path: Option<String>,
+}
+
+impl UpVersion {
+    pub fn new(tool: &str, version: &str, dir: &str) -> Self {
+        Self {
+            tool: tool.to_string(),
+            version: version.to_string(),
+            dir: dir.to_string(),
+            data_path: None,
+        }
+    }
 }

--- a/src/internal/config/up/error.rs
+++ b/src/internal/config/up/error.rs
@@ -15,16 +15,16 @@ pub enum UpError {
     StepFailed(String, Option<(usize, usize)>),
 }
 
-impl UpError {
-    // fn error_type(&self) -> String {
-    // match self {
-    // UpError::Config(_) => "configuration error".to_string(),
-    // UpError::Exec(_) => "execution error".to_string(),
-    // UpError::Timeout(_) => "timeout".to_string(),
-    // UpError::HomebrewTapInUse => "tap in use".to_string(),
-    // }
-    // }
-}
+// impl UpError {
+// fn error_type(&self) -> String {
+// match self {
+// UpError::Config(_) => "configuration error".to_string(),
+// UpError::Exec(_) => "execution error".to_string(),
+// UpError::Timeout(_) => "timeout".to_string(),
+// UpError::HomebrewTapInUse => "tap in use".to_string(),
+// }
+// }
+// }
 
 impl Display for UpError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -19,12 +19,16 @@ pub(crate) use golang::UpConfigGolang;
 pub(crate) mod nodejs;
 pub(crate) use nodejs::UpConfigNodejs;
 
+pub(crate) mod python;
+pub(crate) use python::UpConfigPython;
+
 pub(crate) mod homebrew;
 pub(crate) use homebrew::UpConfigHomebrew;
 
 pub(crate) mod asdf_base;
+pub(crate) use asdf_base::asdf_tool_path;
+pub(crate) use asdf_base::AsdfToolUpVersion;
 pub(crate) use asdf_base::UpConfigAsdfBase;
-pub(crate) use asdf_base::ASDF_PATH;
 
 pub(crate) mod error;
 pub(crate) use error::UpError;

--- a/src/internal/config/up/python.rs
+++ b/src/internal/config/up/python.rs
@@ -1,0 +1,312 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use blake3::Hasher;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command as TokioCommand;
+
+use crate::internal::cache::utils::CacheObject;
+use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::config::up::asdf_tool_path;
+use crate::internal::config::up::run_progress;
+use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::AsdfToolUpVersion;
+use crate::internal::config::up::ProgressHandler;
+use crate::internal::config::up::UpConfigAsdfBase;
+use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
+use crate::internal::env::current_dir;
+use crate::internal::env::workdir;
+use crate::internal::ConfigValue;
+
+const MIN_VERSION_VENV: Version = Version::new(3, 3, 0);
+// const MIN_VERSION_VIRTUALENV: Version = Version::new(2, 6, 0);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpConfigPython {
+    #[serde(skip)]
+    pub asdf_base: UpConfigAsdfBase,
+}
+
+impl UpConfigPython {
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        let mut asdf_base = UpConfigAsdfBase::from_config_value("python", config_value);
+        asdf_base.add_post_install_func(setup_python_venv);
+
+        Self { asdf_base }
+    }
+
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base.up(options, progress)
+    }
+
+    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        self.asdf_base.down(progress)
+    }
+}
+
+fn setup_python_venv(
+    progress_handler: &dyn ProgressHandler,
+    tool: String,
+    versions: Vec<AsdfToolUpVersion>,
+) -> Result<(), UpError> {
+    if tool != "python" {
+        panic!("setup_python_venv called with wrong tool: {}", tool);
+    }
+
+    // Handle each version individually
+    for version in &versions {
+        setup_python_venv_per_version(progress_handler, version.clone())?;
+    }
+
+    // Go over all the versions in the data path, and remove those
+    // that are not in the set of expected versions
+    progress_handler.progress("cleaning up venv python versions".to_string());
+
+    let wd = workdir(".");
+    let data_path = wd.data_path().ok_or_else(|| {
+        UpError::Exec(format!(
+            "failed to get data path for {}",
+            current_dir().display()
+        ))
+    })?;
+
+    let python_root_path = data_path.join("python");
+    if python_root_path.exists() {
+        let versions_str = versions
+            .iter()
+            .map(|v| v.version.clone())
+            .collect::<HashSet<String>>();
+
+        let python_dirs = std::fs::read_dir(python_root_path.clone()).or_else(|_| {
+            Err(UpError::Exec(format!(
+                "failed to read python directory {}",
+                python_root_path.display()
+            )))
+        })?;
+
+        for python_dir in python_dirs {
+            let python_dir = python_dir.or_else(|_| {
+                Err(UpError::Exec(format!(
+                    "failed to read python directory {}",
+                    python_root_path.display()
+                )))
+            })?;
+
+            let python_dir_name = python_dir.file_name().to_string_lossy().to_string();
+
+            if versions_str.contains(&python_dir_name) {
+                continue;
+            }
+
+            let python_dir_path = python_dir.path();
+            progress_handler.progress(format!("removing all venv for python {}", python_dir_name,));
+            std::fs::remove_dir_all(&python_dir_path).or_else(|_| {
+                Err(UpError::Exec(format!(
+                    "failed to remove python directory {}",
+                    python_dir_path.display(),
+                )))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn setup_python_venv_per_version(
+    progress_handler: &dyn ProgressHandler,
+    version: AsdfToolUpVersion,
+) -> Result<(), UpError> {
+    // Check if we care about that version
+    match Version::parse(&version.version) {
+        Ok(version) => {
+            if version < MIN_VERSION_VENV {
+                progress_handler.progress(format!(
+                    "skipping venv setup for python {} < {}",
+                    version, MIN_VERSION_VENV
+                ));
+                return Ok(());
+            }
+        }
+        Err(_) => {
+            progress_handler.progress(format!(
+                "skipping venv setup for python {} (unsupported version)",
+                version.version
+            ));
+            return Ok(());
+        }
+    }
+
+    let mut expected_venv_dirs = HashSet::new();
+
+    for dir in version.dirs {
+        let venv_dir = setup_python_venv_per_dir(progress_handler, version.version.clone(), dir)?;
+
+        // Add the venv dir to the set of expected venv dirs
+        expected_venv_dirs.insert(venv_dir);
+    }
+
+    // Go over all venv dirs in the data path, and remove those
+    // that are not in the set of expected venv dirs
+    progress_handler.progress(format!(
+        "cleaning up venv directories for python {}",
+        version.version
+    ));
+
+    let wd = workdir(".");
+    let data_path = wd.data_path().ok_or_else(|| {
+        UpError::Exec(format!(
+            "failed to get data path for {}",
+            current_dir().display()
+        ))
+    })?;
+
+    let venv_root_path = data_path.join("python").join(version.version.clone());
+    if venv_root_path.exists() {
+        let venv_dirs = std::fs::read_dir(venv_root_path.clone()).or_else(|_| {
+            Err(UpError::Exec(format!(
+                "failed to read venv directory {}",
+                venv_root_path.display()
+            )))
+        })?;
+
+        for venv_dir in venv_dirs {
+            let venv_dir = venv_dir.or_else(|_| {
+                Err(UpError::Exec(format!(
+                    "failed to read venv directory {}",
+                    venv_root_path.display()
+                )))
+            })?;
+
+            let venv_dir_name = venv_dir.file_name().to_string_lossy().to_string();
+            if !expected_venv_dirs.contains(&venv_dir_name) {
+                let venv_dir_path = venv_dir.path();
+                progress_handler.progress(format!(
+                    "removing venv {} for python {}",
+                    venv_dir_name, version.version,
+                ));
+                std::fs::remove_dir_all(&venv_dir_path).or_else(|_| {
+                    Err(UpError::Exec(format!(
+                        "failed to remove venv directory {}",
+                        venv_dir_path.display()
+                    )))
+                })?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn setup_python_venv_per_dir(
+    progress_handler: &dyn ProgressHandler,
+    version: String,
+    dir: String,
+) -> Result<String, UpError> {
+    // Get the data path for the work directory
+    let workdir = workdir(".");
+
+    let workdir_id = if let Some(workdir_id) = workdir.id() {
+        workdir_id
+    } else {
+        return Err(UpError::Exec(format!(
+            "failed to get workdir id for {}",
+            current_dir().display()
+        )));
+    };
+
+    let data_path = if let Some(data_path) = workdir.data_path() {
+        data_path
+    } else {
+        return Err(UpError::Exec(format!(
+            "failed to get data path for {}",
+            current_dir().display()
+        )));
+    };
+
+    // Get the hash of the relative path
+    let venv_dir = if dir == "" {
+        "root".to_string()
+    } else {
+        let mut hasher = Hasher::new();
+        hasher.update(dir.as_bytes());
+        let hash_bytes = hasher.finalize();
+        let hash_b62 = base_62::encode(hash_bytes.as_bytes())[..20].to_string();
+        hash_b62
+    };
+
+    let venv_path = data_path
+        .join("python")
+        .join(version.clone())
+        .join(venv_dir.clone());
+
+    // Check if we need to install, or if the virtual env is already there
+    let already_setup = if venv_path.exists() {
+        if venv_path.join("pyvenv.cfg").exists() {
+            progress_handler.progress(format!("venv already exists for python {}", version));
+            true
+        } else {
+            // Remove the directory since it exists but is not a venv,
+            // so we clean it up and replace it by a clean venv
+            std::fs::remove_dir_all(&venv_path).or_else(|_| {
+                Err(UpError::Exec(format!(
+                    "failed to remove existing venv directory {}",
+                    venv_path.display()
+                )))
+            })?;
+            false
+        }
+    } else {
+        false
+    };
+
+    // Only create the new venv if it doesn't exist
+    if !already_setup {
+        let python_version_path = asdf_tool_path("python", &version);
+        let python_bin = PathBuf::from(python_version_path)
+            .join("bin")
+            .join("python");
+
+        std::fs::create_dir_all(&venv_path).or_else(|_| {
+            Err(UpError::Exec(format!(
+                "failed to create venv directory {}",
+                venv_path.display()
+            )))
+        })?;
+
+        let mut venv_create = TokioCommand::new(python_bin);
+        venv_create.arg("-m");
+        venv_create.arg("venv");
+        venv_create.arg(venv_path.to_string_lossy().to_string());
+        venv_create.stdout(std::process::Stdio::piped());
+        venv_create.stderr(std::process::Stdio::piped());
+
+        run_progress(
+            &mut venv_create,
+            Some(progress_handler),
+            RunConfig::default(),
+        )?;
+
+        progress_handler.progress(format!("venv created for python {} in {}", version, dir,));
+    }
+
+    // Update the cache
+    if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
+        up_env.add_version_data_path(
+            &workdir_id,
+            "python",
+            &version,
+            &dir,
+            &venv_path.to_string_lossy().to_string(),
+        )
+    }) {
+        progress_handler.progress(format!("failed to update tool cache: {}", err));
+        return Err(UpError::Cache(format!(
+            "failed to update tool cache: {}",
+            err
+        )));
+    }
+
+    Ok(venv_dir)
+}

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -7,6 +7,7 @@ use crate::internal::config::up::UpConfigCustom;
 use crate::internal::config::up::UpConfigGolang;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigNodejs;
+use crate::internal::config::up::UpConfigPython;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
@@ -24,7 +25,7 @@ pub enum UpConfigTool {
     // TODO: Kotlin(UpConfigAsdfBase), // KOTLIN_HOME
     Nodejs(UpConfigNodejs),
     // TODO: Pacman(UpConfigPacman),
-    Python(UpConfigAsdfBase),
+    Python(UpConfigPython),
     Ruby(UpConfigAsdfBase),
     Rust(UpConfigAsdfBase),
     Terraform(UpConfigAsdfBase),
@@ -55,8 +56,7 @@ impl UpConfigTool {
             "nodejs" | "node" => Some(UpConfigTool::Nodejs(UpConfigNodejs::from_config_value(
                 config_value,
             ))),
-            "python" => Some(UpConfigTool::Python(UpConfigAsdfBase::from_config_value(
-                "python",
+            "python" => Some(UpConfigTool::Python(UpConfigPython::from_config_value(
                 config_value,
             ))),
             "ruby" => Some(UpConfigTool::Ruby(UpConfigAsdfBase::from_config_value(
@@ -122,7 +122,7 @@ impl UpConfigTool {
                 }
             }
             UpConfigTool::Nodejs(config) => Some(&config.asdf_base),
-            UpConfigTool::Python(config) => Some(config),
+            UpConfigTool::Python(config) => Some(&config.asdf_base),
             UpConfigTool::Ruby(config) => Some(config),
             UpConfigTool::Rust(config) => Some(config),
             UpConfigTool::Terraform(config) => Some(config),


### PR DESCRIPTION
When running `omni up`, this will now create a virtual environment for any Python version greater or equal to 3.3, using the Python `venv` module.

This will ensure that different work directories, as well as different directories of a same work directory (if specified), can have conflicting dependencies, and still work properly.

Thanks to @idletea for the initial pull request and investigation to make this happen.

Closes https://github.com/XaF/omni/issues/268
Closes https://github.com/XaF/omni/issues/124