### PR TITLE
feat(config commands): ✨ add support for `dir` parameter

### DIFF
--- a/.omni.yaml
+++ b/.omni.yaml
@@ -44,9 +44,8 @@ commands:
 
       This opens up a browser window once the server is started.
       Most changes are reflected live without having to restart the server.
+    dir: website
     run: |
-      cd website
-      eval "$(omni hook env 2>/dev/null)"
       yarn start
 
   cargo-package:

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -159,6 +159,21 @@ impl Command {
         }
     }
 
+    pub fn exec_dir(&self) -> String {
+        match self {
+            Command::FromConfig(command) => command
+                .exec_dir()
+                .map_err(|err| {
+                    omni_error!(err.to_string());
+                    exit(1);
+                })
+                .expect("Failed to get exec dir")
+                .to_string_lossy()
+                .to_string(),
+            _ => self.source_dir(),
+        }
+    }
+
     pub fn help_source(&self) -> String {
         let source = self.source();
         if !source.starts_with('/') {
@@ -317,7 +332,7 @@ impl Command {
 
     pub fn exec(&self, argv: Vec<String>, called_as: Option<Vec<String>>) {
         // Load the dynamic environment for that command
-        update_dynamic_env_for_command(&self.source_dir());
+        update_dynamic_env_for_command(&self.exec_dir());
 
         // Set the general execution environment
         let name = if let Some(ref called_as) = called_as {

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -229,6 +229,7 @@ pub struct CommandDefinition {
     pub aliases: Vec<String>,
     pub syntax: Option<CommandSyntax>,
     pub category: Option<Vec<String>>,
+    pub dir: Option<String>,
     pub subcommands: Option<HashMap<String, CommandDefinition>>,
     pub source: ConfigSource,
 }
@@ -288,6 +289,9 @@ impl CommandDefinition {
             aliases,
             syntax,
             category,
+            dir: config_value
+                .get_as_str("dir")
+                .map(|value| value.to_string()),
             subcommands,
             source: config_value.get_source().clone(),
         }

--- a/website/contents/reference/01-configuration/0102-parameters/010250-commands.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-commands.md
@@ -15,6 +15,8 @@ Any command defined in a global configuration file will be available throughout 
 | `aliases` | string (list) | list of aliases for that command |
 | `desc` | string | the description of the command that will be used in `omni help`. This can be on multiple lines, in which case the first paragraph (until the first empty line) will be shown in `omni help`, while the rest of the help message will be shown when calling `omni help <command>`. |
 | `run` | multiline string | the command to run when the command is being called. This will be called through `bash -c` and can thus receive any kind of bash scripting, or call to an executable file. |
+| `category` | string (list) | comma-separated or actual list of categories, organized hierarchically from the least significative to the most significative |
+| `dir` | string | path to the directory from which to execute the command, relative to the location of the configuration file, and needs to be a subdirectory |
 | `subcommands` | [`commands`](commands) (map) | Subcommands of that command; the name of those commands will be prefixed by the name of the current command (e.g. command `main` and subcommand `sub` would create a command `main sub`) |
 | `syntax` | [`syntax`](#syntax) | Define the parameters that the command can take. This will be used when calling `omni help <command>`. |
 


### PR DESCRIPTION
This is working similarly to the `dir` parameter of the custom operations when running `omni up`. This will execute the config command from the specified directory instead of from the directory of the configuration file.

For security reasons, the following constraints are applied:
- `dir` needs to be a path relative to the configuration file directory
- the joined path from the configuration file directory and `dir` must lead to a path contained inside the current directory

Closes https://github.com/XaF/omni/issues/245