### PR TITLE
feat(up golang): ✨ Add GOPATH isolation for gcalls to go install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-path"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1553,7 @@ dependencies = [
  "libz-sys",
  "machine-uid",
  "node-semver",
+ "normalize-path",
  "once_cell",
  "openssl",
  "package-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ lazy_static = "1.4.0"
 libz-sys = { version = "1.1.12", features = ["static"] }
 machine-uid = "0.5.1"
 node-semver = "2.1.0"
+normalize-path = "0.2.1"
 once_cell = "1.19.0"
 openssl = { version = "0.10", features = ["vendored"] }
 package-json = "0.4.0"

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -3,8 +3,8 @@ use std::io;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use normalize_path::NormalizePath;
 use path_clean::PathClean;
-
 use requestty::question::{completions, Completions};
 
 use crate::internal::env::omni_cmd_file;
@@ -16,7 +16,7 @@ pub fn split_name(string: &str, split_on: &str) -> Vec<String> {
 
 pub fn abs_or_rel_path(path: &str) -> String {
     let current_dir = std::env::current_dir().unwrap();
-    let path = std::path::PathBuf::from(&path);
+    let path = std::path::PathBuf::from(&path).normalize();
     let path = if path.is_absolute() {
         path
     } else {
@@ -44,7 +44,7 @@ pub fn abs_or_rel_path(path: &str) -> String {
 }
 
 pub fn abs_path(path: impl AsRef<Path>) -> PathBuf {
-    let path = path.as_ref();
+    let path = path.as_ref().normalize();
 
     let absolute_path = if path.is_absolute() {
         path.to_path_buf()

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -210,7 +210,7 @@ fn setup_individual_gopath(
         if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
             let mut any_changed = false;
             for dir in &version.dirs {
-                let gopath_dir = data_path_dir_hash(&dir);
+                let gopath_dir = data_path_dir_hash(dir);
 
                 let gopath = data_path
                     .join(&tool)
@@ -221,7 +221,7 @@ fn setup_individual_gopath(
                     &workdir_id,
                     &tool,
                     &version.version,
-                    &dir,
+                    dir,
                     &gopath.to_string_lossy(),
                 ) || any_changed;
             }

--- a/src/internal/config/up/python.rs
+++ b/src/internal/config/up/python.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use blake3::Hasher;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command as TokioCommand;
@@ -9,6 +8,7 @@ use crate::internal::cache::utils::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::asdf_tool_path;
 use crate::internal::config::up::run_progress;
+use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::AsdfToolUpVersion;
 use crate::internal::config::up::ProgressHandler;
@@ -120,15 +120,7 @@ fn setup_python_venv_per_dir(
     };
 
     // Get the hash of the relative path
-    let venv_dir = if dir.is_empty() {
-        "root".to_string()
-    } else {
-        let mut hasher = Hasher::new();
-        hasher.update(dir.as_bytes());
-        let hash_bytes = hasher.finalize();
-        let hash_b62 = base_62::encode(hash_bytes.as_bytes())[..20].to_string();
-        hash_b62
-    };
+    let venv_dir = data_path_dir_hash(&dir);
 
     let venv_path = data_path
         .join("python")

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -1,9 +1,12 @@
 use std::io::Write;
+use std::path::Path;
 
+use blake3::Hasher;
 use indicatif::MultiProgress;
 use indicatif::ProgressBar;
 use indicatif::ProgressDrawTarget;
 use indicatif::ProgressStyle;
+use normalize_path::NormalizePath;
 use regex::Regex;
 use tempfile::NamedTempFile;
 use time::format_description::well_known::Rfc3339;
@@ -510,4 +513,60 @@ impl ProgressHandler for PrintProgressHandler {
     fn show(&self) {
         // do nothing
     }
+}
+
+/// Return the name of the directory to use in the data path
+/// for the given subdirectory of the work directory.
+pub fn data_path_dir_hash(dir: &str) -> String {
+    let dir = Path::new(dir).normalize().to_string_lossy().to_string();
+
+    if dir.is_empty() {
+        "root".to_string()
+    } else {
+        let mut hasher = Hasher::new();
+        hasher.update(dir.as_bytes());
+        let hash_bytes = hasher.finalize();
+        let hash_b62 = base_62::encode(hash_bytes.as_bytes())[..20].to_string();
+        hash_b62
+    }
+}
+
+/// Remove the given directory, even if it contains read-only files.
+/// This will first try to remove the directory normally, and if that
+/// fails with a PermissionDenied error, it will make all files and
+/// directories in the given path writeable, and then try again.
+pub fn force_remove_dir_all<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    let path = path.as_ref();
+    if path.exists() {
+        match std::fs::remove_dir_all(&path) {
+            Ok(_) => {}
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    set_writeable_recursive(&path)?;
+                    std::fs::remove_dir_all(path)?;
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Set all files and directories in the given path to be writeable.
+/// This is useful when we want to remove a directory that contains
+/// read-only files, which would otherwise fail.
+pub fn set_writeable_recursive<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    for entry in walkdir::WalkDir::new(&path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let metadata = entry.metadata()?;
+        let mut permissions = metadata.permissions();
+        if permissions.readonly() {
+            permissions.set_readonly(false);
+            std::fs::set_permissions(entry.path(), permissions)?;
+        }
+    }
+    Ok(())
 }

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -323,7 +323,14 @@ impl DynamicEnv {
 
                         envsetter.set_value("GOROOT", &format!("{}/go", tool_prefix));
                         envsetter.set_value("GOVERSION", &version);
+                        envsetter.prepend_to_list("GOPATH", &format!("{}/go", tool_prefix));
                         envsetter.prepend_to_list("PATH", &format!("{}/go/bin", tool_prefix));
+
+                        // Handle the isolated GOPATH
+                        if let Some(data_path) = &toolversion.data_path {
+                            envsetter.prepend_to_list("GOPATH", data_path);
+                            envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
+                        };
                     }
                     "python" => {
                         let tool_prefix = if let Some(data_path) = &toolversion.data_path {


### PR DESCRIPTION
This follows https://github.com/XaF/omni/pull/277 by making it so the golang up operation also gets an updated GOPATH for calls to `go install`.