### PR TITLE
fix(self update): 🐛 show error message when failing to update

### DIFF
--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -228,11 +228,13 @@ impl OmniRelease {
             self.download(progress_handler.as_ref())
         };
 
-        if updated.is_err() {
-            progress_handler.error_with_message("Failed to update".to_string());
-            return;
-        }
-        let updated = updated.unwrap();
+        let updated = match updated {
+            Ok(updated) => updated,
+            Err(err) => {
+                progress_handler.error_with_message(format!("failed to update: {}", err));
+                return;
+            }
+        };
 
         if updated {
             progress_handler


### PR DESCRIPTION
This was only showing that the update failed, this should show the error message.