### PR TITLE
feat(python operation): ✨ Add support for pip install

### DIFF
--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -178,7 +178,9 @@ fn extract_version_from_gomod_file(
 
 fn setup_individual_gopath(
     progress_handler: &dyn ProgressHandler,
+    _config_value: Option<ConfigValue>,
     tool: String,
+    _requested_version: String,
     versions: Vec<AsdfToolUpVersion>,
 ) -> Result<(), UpError> {
     if tool != "golang" {

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -21,7 +21,7 @@ pub fn update_dynamic_env(export_mode: DynamicEnvExportMode) {
     update_dynamic_env_with_path(export_mode, None);
 }
 
-pub fn update_dynamic_env_for_command(path: &str) {
+pub fn update_dynamic_env_for_command<T: ToString>(path: T) {
     update_dynamic_env_with_path(DynamicEnvExportMode::Env, Some(path.to_string()));
 }
 

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-python.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-python.md
@@ -16,7 +16,8 @@ The following parameters can be used:
 
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
-| `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
+| `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the python version; each specified directory will have its own virtual environment. |
+| `pip` | path | Relative path (or list of relative paths) to the requirements files to be used as parameter to `pip install -r` for installing dependencies; if using the word `auto`, omni will try to install the `requirements.txt` file in each specified `dir` (or in each discovered directory with `version: auto`) if it exists |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
 
 ### Version handling
@@ -35,7 +36,7 @@ The following strings can be used to specify the version:
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
 | `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `latest`  | Latest release (default) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.python-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.
@@ -73,6 +74,28 @@ up:
   - python:
       version: 3.11.4
       dir: some/sub/dir
+
+  # This will install python 3.11.4 and run
+  # pip install -r req.txt
+  - python:
+      version: 3.11.4
+      pip: req.txt
+
+  # This will install python 3.11.4 and run
+  # pip install -r requirements.txt for each of dir1 and dir2
+  - python:
+      version: 3.11.4
+      dir:
+        - dir1
+        - dir2
+      pip: auto
+
+  # Let omni lookup for version files in the project,
+  # and run `pip install -r requirements.txt` in each
+  # of the directories identified with a version file
+  - python:
+      version: auto
+      pip: auto
 ```
 
 ## Dynamic environment
@@ -82,3 +105,5 @@ The following variables will be set as part of the [dynamic environment](/refere
 | Environment variable | Operation | Description |
 |----------------------|-----------|-------------|
 | `PATH` | prepend | The `bin` directory for the loaded version of python |
+| `PYTHONHOME` | unset | |
+| `VIRTUAL_ENV` | set | The path to the python virtual environment |


### PR DESCRIPTION
This supports specifying one or more requirements files to be installed with `pip install -r` along with the python installation.

If the python installation is for multiple, isolated directories, each venv will get the `pip install -r` calls for each of the files.

If `auto` is passed to the `pip:` parameter, the default `requirements.txt` file will be looked for in each matching directory.

If the python version is `auto` and no `pip` parameter is specified, the `requirements.txt` file will be looked for in each matching directory.

Closes https://github.com/XaF/omni/issues/279