### PR TITLE
feat(golang operation): ✨ improve golang isolation to maintain shared…

### DIFF
--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -10,6 +10,7 @@ use shell_escape::escape;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::asdf_tool_path;
+use crate::internal::env::user_home;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 
@@ -318,6 +319,17 @@ impl DynamicEnv {
                                 "PATH",
                                 &format!("{}/bin", goroot.to_str().unwrap()),
                             );
+                        }
+
+                        if std::env::var_os("GOMODCACHE").is_none() {
+                            let gopath = match std::env::var_os("GOPATH") {
+                                Some(gopath) => match gopath.to_str() {
+                                    Some(gopath) => gopath.to_string(),
+                                    None => format!("{}/go", user_home()),
+                                },
+                                None => format!("{}/go", user_home()),
+                            };
+                            envsetter.set_value("GOMODCACHE", &format!("{}/pkg/mod", gopath));
                         }
 
                         envsetter.set_value("GOROOT", &format!("{}/go", tool_prefix));


### PR DESCRIPTION
… cache

In the previous commit, the isolation was not taking into account the go mod cache location, which is by default going to gopath[0]/pkg/mod (with gopath defaulting to ~/go if unset). This means that the cache was being duplicated as many times as repositories.

This takes care of that by either:
- maintaining the GOMODCACHE env var as already set, or
- setting the GOMODCACHE env var to gopath[0]/pkg/mod if gopath is set or ~/go/pkg/mod otherwise

This makes sure that the go mod cache stays shared while keeping isolation between working directories, allowing `go install` to have a different target per isolation, which means that incompatible versions of the same binary can be installed by separate working directories.