### PR TITLE
feat(packages): ✨ use a separate cache of dependencies

### DIFF
--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -336,7 +336,7 @@ impl ConfigPathSwitchCommand {
                 }
             };
 
-            let repo_id = match id_from_git_url(&git_url) {
+            match id_from_git_url(&git_url) {
                 Some(repo_id) => repo_id,
                 None => {
                     omni_error!(format!(
@@ -345,9 +345,7 @@ impl ConfigPathSwitchCommand {
                     ));
                     exit(1);
                 }
-            };
-
-            repo_id
+            }
         });
 
         let worktree_exists = worktree_path.exists();

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -915,12 +915,13 @@ impl UpCommand {
 
     fn suggest_clone_from_config(&self, path: &str) -> HashSet<RepositoryToClone> {
         let git_env = git_env(path);
-        let repo_id = git_env.id();
-        if repo_id.is_none() {
-            omni_error!("Unable to get repository id for path {}", path);
-            return HashSet::new();
-        }
-        let repo_id = repo_id.unwrap();
+        let repo_id = match git_env.id() {
+            Some(repo_id) => repo_id,
+            None => {
+                omni_error!("Unable to get repository id for path {}", path);
+                return HashSet::new();
+            }
+        };
 
         let config = config(path);
 
@@ -1336,12 +1337,13 @@ impl UpCommand {
         }
 
         let git_env = git_env(".");
-        let repo_id = git_env.id();
-        if repo_id.is_none() {
-            omni_error!("Unable to get repository id");
-            exit(1);
-        }
-        let repo_id = repo_id.unwrap();
+        let repo_id = match git_env.id() {
+            Some(repo_id) => repo_id,
+            None => {
+                omni_error!("Unable to get repository id");
+                exit(1);
+            }
+        };
 
         let config = config(".");
         let updated = config.path_repo_updates.update(&repo_id);

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -81,11 +81,10 @@ impl UpConfigHomebrew {
 
     pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
         let workdir = workdir(".");
-        let repo_id = workdir.id();
-        if repo_id.is_none() {
-            return Ok(());
-        }
-        let repo_id = repo_id.unwrap();
+        let repo_id = match workdir.id() {
+            Some(repo_id) => repo_id,
+            None => return Ok(()),
+        };
 
         let mut return_value = Ok(());
 

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -160,17 +160,16 @@ impl DynamicEnv {
             }
 
             // Get the workdir id
-            let repo_id = workdir.id();
-            if repo_id.is_none() {
-                return 0;
-            }
-            let repo_id = repo_id.unwrap();
+            let workdir_id = match workdir.id() {
+                Some(workdir_id) => workdir_id,
+                None => return 0,
+            };
 
             // Get the relative directory
             let dir = workdir.reldir(&path).unwrap_or("".to_string());
 
             // Check if repo is 'up' and should have its environment loaded
-            let up_env = if let Some(up_env) = self.cache.get_env(&repo_id) {
+            let up_env = if let Some(up_env) = self.cache.get_env(&workdir_id) {
                 up_env
             } else {
                 return 0;
@@ -236,8 +235,8 @@ impl DynamicEnv {
         let path = self.path.clone().unwrap_or(".".to_string());
         let workdir = workdir(&path);
         if workdir.in_workdir() {
-            if let Some(repo_id) = workdir.id() {
-                up_env = self.cache.get_env(&repo_id);
+            if let Some(workdir_id) = workdir.id() {
+                up_env = self.cache.get_env(&workdir_id);
             } else {
                 return;
             }

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -288,11 +288,10 @@ pub fn update(
         let mut auth_hosts = HashMap::new();
         for path_entry in &omnipath_entries {
             let git_env = git_env(&path_entry.as_string());
-            let repo_id = git_env.id();
-            if repo_id.is_none() {
-                continue;
-            }
-            let repo_id = repo_id.unwrap();
+            let repo_id = match git_env.id() {
+                Some(repo_id) => repo_id,
+                None => continue,
+            };
             let repo_root = git_env.root().unwrap().to_string();
 
             if let Ok(git_url) = full_git_url_parse(&repo_id) {
@@ -362,11 +361,10 @@ pub fn update(
             let path = path_entry.as_string();
 
             let git_env = git_env(&path).clone();
-            let repo_id = git_env.id();
-            if repo_id.is_none() {
-                continue;
-            }
-            let repo_id = repo_id.unwrap();
+            let repo_id = match git_env.id() {
+                Some(repo_id) => repo_id,
+                None => continue,
+            };
             let repo_root = git_env.root().unwrap().to_string();
 
             // Skip if the path is in the list of paths to skip


### PR DESCRIPTION
Packages can coexist with the worktree directory, and this could lead to development on a directory to override the package dependencies, or the other way around.

Packages should thus have a separate set of dependencies, making sure that dependencies are kept both for the package and worktree versions of a work directory, allowing them to coexist.

This handles that by changing the default id of work directories to be prefixed by `package#` for packages. The trust check is still handled through the simple, package-agnostic work directory id.

Closes https://github.com/XaF/omni/issues/278