### PR TITLE
feat(config commands): ✨ trust the global-scoped configuration commands

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -344,6 +344,10 @@ impl Command {
         std::env::set_var("OMNI_SUBCOMMAND", name.clone());
 
         match self {
+            Command::FromConfig(cmd) if cmd.is_trusted() => {
+                // If the configuration command is not provided by a workdir,
+                // we can trust it right away
+            }
             Command::FromPath(_) | Command::FromConfig(_) | Command::FromMakefile(_) => {
                 // Check if the workdir where the command is located is trusted
                 if !is_trusted_or_ask(

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -34,6 +34,7 @@ use crate::internal::config::up::UpOptions;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::ConfigExtendOptions;
 use crate::internal::config::ConfigLoader;
+use crate::internal::config::ConfigScope;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::shell_is_interactive;
@@ -412,7 +413,9 @@ impl UpCommand {
         let mut suggest_config_updated = false;
         let config_loader = config_loader(".");
         if self.is_up() {
-            if let Some(git_repo_config) = config_loader.raw_config.select_label("git_repo") {
+            if let Some(git_repo_config) =
+                config_loader.raw_config.select_scope(&ConfigScope::Workdir)
+            {
                 if let Some(suggestion) = git_repo_config.get("suggest_config") {
                     if suggestion.is_table() {
                         if self.should_suggest_config() {
@@ -634,8 +637,7 @@ impl UpCommand {
         let result = ConfigLoader::edit_main_user_config_file(|config_value| {
             let before = config_value.clone();
 
-            let mut suggest_config = suggest_config.clone();
-            suggest_config.add_label("suggest_config");
+            let suggest_config = suggest_config.clone();
             let mut after = config_value.clone();
             after.extend(suggest_config.clone(), ConfigExtendOptions::new(), vec![]);
 

--- a/src/internal/commands/fromconfig.rs
+++ b/src/internal/commands/fromconfig.rs
@@ -11,6 +11,7 @@ use crate::internal::commands::utils::split_name;
 use crate::internal::config::config;
 use crate::internal::config::CommandDefinition;
 use crate::internal::config::CommandSyntax;
+use crate::internal::config::ConfigScope;
 use crate::internal::config::ConfigSource;
 use crate::internal::user_interface::colors::StringColor;
 use crate::omni_error;
@@ -116,6 +117,11 @@ impl ConfigCommand {
         }
 
         aliases
+    }
+
+    pub fn is_trusted(&self) -> bool {
+        // User scope or better is trusted
+        self.details.scope <= ConfigScope::User
     }
 
     pub fn source(&self) -> String {

--- a/src/internal/config/mod.rs
+++ b/src/internal/config/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod config_value;
 pub(crate) use config_value::ConfigExtendOptions;
 pub(crate) use config_value::ConfigExtendStrategy;
+pub(crate) use config_value::ConfigScope;
 pub(crate) use config_value::ConfigSource;
 pub(crate) use config_value::ConfigValue;
 


### PR DESCRIPTION
This adds logic to automatically trust a configuration command if it is not setup in a work directory but in a broader-scope configuration file, such as the user home configuration file.

Closes https://github.com/XaF/omni/issues/246