### PR TITLE
refactor(base62): ♻️  build in the base 62 encoding function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,18 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-62"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28ebd71b3e708e895b83ec2d35c6e2ef96e34945706bf4d73826354e84f89b2"
-dependencies = [
- "failure",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,28 +681,6 @@ checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
 ]
 
 [[package]]
@@ -1478,9 +1444,9 @@ checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1535,7 +1501,6 @@ dependencies = [
 name = "omnicli"
 version = "0.0.0-git"
 dependencies = [
- "base-62",
  "blake3",
  "clap 4.4.11",
  "duct",
@@ -1553,6 +1518,9 @@ dependencies = [
  "machine-uid",
  "node-semver",
  "normalize-path",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "once_cell",
  "openssl",
  "package-json",
@@ -2387,18 +2355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,12 +2769,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/main.rs"
 time = { version = "0.3.30", features = ["serde-well-known"] }
 
 [dependencies]
-base-62 = "0.1.1"
 blake3 = "1.5.0"
 clap = "4.4.11"
 duct = "0.13.6"
@@ -40,6 +39,9 @@ libz-sys = { version = "1.1.12", features = ["static"] }
 machine-uid = "0.5.1"
 node-semver = "2.1.0"
 normalize-path = "0.2.1"
+num-bigint = "0.4.4"
+num-integer = "0.1.45"
+num-traits = "0.2.17"
 once_cell = "1.19.0"
 openssl = { version = "0.10", features = ["vendored"] }
 package-json = "0.4.0"

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -20,6 +20,7 @@ use tokio::time::Duration;
 
 use crate::internal::config::up::UpError;
 use crate::internal::user_interface::StringColor;
+use crate::internal::utils::base62_encode;
 
 #[derive(Debug, Clone)]
 pub struct RunConfig {
@@ -527,7 +528,7 @@ pub fn data_path_dir_hash(dir: &str) -> String {
         let mut hasher = Hasher::new();
         hasher.update(dir.as_bytes());
         let hash_bytes = hasher.finalize();
-        let hash_b62 = base_62::encode(hash_bytes.as_bytes())[..20].to_string();
+        let hash_b62 = base62_encode(hash_bytes.as_bytes())[..20].to_string();
         hash_b62
     }
 }

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -20,6 +20,7 @@ use crate::internal::dynenv::DynamicEnvExportMode;
 use crate::internal::git::id_from_git_url;
 use crate::internal::git::safe_git_url_parse;
 use crate::internal::user_interface::StringColor;
+use crate::internal::utils::base62_encode;
 use crate::omni_error;
 use crate::omni_warning;
 
@@ -586,7 +587,7 @@ impl WorkDirEnv {
                 let mut hasher = Hasher::new();
                 hasher.update(id.as_bytes());
                 let hash_bytes = hasher.finalize();
-                let hash_b62 = base_62::encode(hash_bytes.as_bytes())[..20].to_string();
+                let hash_b62 = base62_encode(hash_bytes.as_bytes())[..20].to_string();
 
                 let mut data_path = PathBuf::from(data_home());
                 data_path.push("wd");

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod workdir;
 pub(crate) mod user_interface;
 pub(crate) use user_interface::StringColor;
 
+pub(crate) mod utils;
+
 pub(crate) mod dynenv;
 
 pub(crate) mod self_updater;


### PR DESCRIPTION
A few security vulnerabilities are raised from using the `base_62` crate.
Handling base 62 is not very complicated by itself, so this adds the base 62 encoding function as part of the source.