### PR TITLE
feat(commands): ✨ Add support for shadow aliases

### DIFF
--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -207,6 +207,21 @@ impl HelpCommand {
             eprintln!("\n{}", wrap_blocks(&help, max_width).join("\n"));
         }
 
+        let is_shadow_name = command
+            .all_names()
+            .iter()
+            .any(|name| name.join(" ") == called_as.join(" "));
+        if !is_shadow_name {
+            eprintln!(
+                "\n{}",
+                format!(
+                    "\u{26A0}\u{FE0F}  '{}' is a shadow alias of '{}';\n   you should use the latter instead, as shadow\n   aliases can be overriden by any command at any time.",
+                    called_as.join(" "),
+                    command.name().join(" "),
+                ).light_yellow(),
+            );
+        }
+
         eprintln!(
             "\n{} {}",
             "Usage:".italic().bold(),

--- a/src/internal/commands/fromconfig.rs
+++ b/src/internal/commands/fromconfig.rs
@@ -19,6 +19,7 @@ use crate::omni_error;
 #[derive(Debug, Clone)]
 pub struct ConfigCommand {
     name: Vec<String>,
+    orig_name: Option<Vec<String>>,
     details: CommandDefinition,
 }
 
@@ -74,6 +75,7 @@ impl ConfigCommand {
         let mut name = vec![name];
 
         name = name.into_iter().flat_map(|n| split_name(&n, " ")).collect();
+        let orig_name = name.clone();
 
         if config(".").config_commands.split_on_dash {
             name = name.into_iter().flat_map(|n| split_name(&n, "-")).collect();
@@ -82,11 +84,25 @@ impl ConfigCommand {
             name = name.into_iter().flat_map(|n| split_name(&n, "/")).collect();
         }
 
-        ConfigCommand { name, details }
+        let orig_name = if name != orig_name {
+            Some(orig_name)
+        } else {
+            None
+        };
+
+        ConfigCommand {
+            name,
+            orig_name,
+            details,
+        }
     }
 
     pub fn name(&self) -> Vec<String> {
         self.name.clone()
+    }
+
+    pub fn orig_name(&self) -> Option<Vec<String>> {
+        self.orig_name.clone()
     }
 
     pub fn aliases(&self) -> Vec<Vec<String>> {

--- a/src/internal/commands/frommakefile.rs
+++ b/src/internal/commands/frommakefile.rs
@@ -17,6 +17,7 @@ use crate::internal::workdir;
 #[derive(Debug, Clone)]
 pub struct MakefileCommand {
     name: Vec<String>,
+    orig_name: Option<String>,
     category: Option<String>,
     desc: Option<String>,
     target: String,
@@ -139,8 +140,15 @@ impl MakefileCommand {
             name = name.into_iter().flat_map(|n| split_name(&n, "/")).collect();
         }
 
+        let orig_name = if name.len() > 1 || name[0] != target {
+            Some(target.clone())
+        } else {
+            None
+        };
+
         MakefileCommand {
             name,
+            orig_name,
             category,
             desc,
             target,
@@ -155,6 +163,10 @@ impl MakefileCommand {
 
     pub fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
+    }
+
+    pub fn orig_name(&self) -> Option<String> {
+        self.orig_name.clone()
     }
 
     pub fn source(&self) -> String {

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -136,12 +136,26 @@ impl CommandLoader {
         let mut command: Option<&Command> = None;
         let mut cur_match_len = 0;
 
+        let mut shadow_command: Option<&Command> = None;
+        let mut shadow_cur_match_len = 0;
+
         for command_candidate in &self.commands {
             let match_len = command_candidate.serves(argv);
             if match_len > 0 && (command.is_none() || match_len > cur_match_len) {
                 command = Some(command_candidate);
                 cur_match_len = match_len;
             }
+
+            let shadow_match_len = command_candidate.shadow_serves(argv);
+            if shadow_match_len > shadow_cur_match_len {
+                shadow_command = Some(command_candidate);
+                shadow_cur_match_len = shadow_match_len;
+            }
+        }
+
+        if shadow_cur_match_len > cur_match_len {
+            command = shadow_command;
+            cur_match_len = shadow_cur_match_len;
         }
 
         if let Some(command) = command {


### PR DESCRIPTION
This creates aliases with the original name of a command read from either the configuration or a makefile, before any change was applied such as splitting on dashes or slashes. This allows to call a command with its original name.

Closes https://github.com/XaF/omni/issues/228
Closes https://github.com/XaF/omni/issues/45