### PR TITLE
fix(go dynenv): 🐛 consider empty GOPATH the same as unset GOPATH

### DIFF
--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -323,8 +323,8 @@ impl DynamicEnv {
                         if std::env::var_os("GOMODCACHE").is_none() {
                             let gopath = match std::env::var_os("GOPATH") {
                                 Some(gopath) => match gopath.to_str() {
+                                    Some("") | None => format!("{}/go", user_home()),
                                     Some(gopath) => gopath.to_string(),
-                                    None => format!("{}/go", user_home()),
                                 },
                                 None => format!("{}/go", user_home()),
                             };


### PR DESCRIPTION
Go seems to consider an unset `GOPATH` the same as an empty-set `GOPATH`. This can be observed with:

```
$ GOPATH= && go env | grep GOPATH
GOPATH='/Users/xaf/go'
$ unset GOPATH && go env | grep GOPATH
GOPATH='/Users/xaf/go'
```

This changes the dynamic environment to behave the same way when setting the value of `GOMODCACHE`.