### PR TITLE
fix(homebrew): 🐛 Enable cache write

### DIFF
--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -11,7 +11,7 @@ impl UpOptions {
     pub fn new() -> Self {
         Self {
             read_cache: true,
-            write_cache: false,
+            write_cache: true,
         }
     }
 


### PR DESCRIPTION
The homebrew operation cache was added but the writes were disabled, this enable the writes so that those operations can go faster when the cache is being used.