### PR TITLE
fix(go dynenv): 🐛 do not set GOPATH to GOROOT

### DIFF
--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -333,7 +333,6 @@ impl DynamicEnv {
 
                         envsetter.set_value("GOROOT", &format!("{}/go", tool_prefix));
                         envsetter.set_value("GOVERSION", &version);
-                        envsetter.prepend_to_list("GOPATH", &format!("{}/go", tool_prefix));
                         envsetter.prepend_to_list("PATH", &format!("{}/go/bin", tool_prefix));
 
                         // Handle the isolated GOPATH


### PR DESCRIPTION
This leads to a golang warning and should be avoided.

Fixes https://github.com/XaF/omni/issues/331