### PR TITLE
feat(autocompletion): ✨ consider parent commands

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -440,41 +440,52 @@ impl Command {
         }
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) {
+    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
         match self {
             Command::FromPath(_) | Command::FromConfig(_) | Command::FromMakefile(_) => {
                 // Check if the workdir where the command is located is trusted
                 if !is_trusted(&self.source_dir()) {
-                    exit(1);
+                    return Err(());
                 }
             }
             _ => {}
         }
 
         match self {
-            Command::BuiltinCd(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinClone(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinConfigBootstrap(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinConfigPathSwitch(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinHelp(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinHook(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinHookEnv(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinHookInit(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinHookUuid(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinScope(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinStatus(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinTidy(command) => command.autocomplete(comp_cword, argv),
-            Command::BuiltinUp(command) => command.autocomplete(comp_cword, argv),
+            Command::BuiltinCd(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinClone(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinConfigBootstrap(command) => {
+                return command.autocomplete(comp_cword, argv)
+            }
+            Command::BuiltinConfigPathSwitch(command) => {
+                return command.autocomplete(comp_cword, argv)
+            }
+            Command::BuiltinHelp(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinHook(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinHookEnv(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinHookInit(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinHookUuid(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinScope(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinStatus(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinTidy(command) => return command.autocomplete(comp_cword, argv),
+            Command::BuiltinUp(command) => return command.autocomplete(comp_cword, argv),
             Command::FromPath(command) => {
                 // Load the dynamic environment for that command
                 update_dynamic_env_for_command(self.source_dir());
 
-                command.autocomplete(comp_cword, argv)
+                let result = command.autocomplete(comp_cword, argv);
+
+                // Reset the dynamic environment
+                update_dynamic_env_for_command(".");
+
+                return result;
             }
             Command::FromConfig(_command) => {}
             Command::FromMakefile(_command) => {}
             Command::Void(_) => {}
         }
+
+        Err(())
     }
 
     fn command_type_sort_order(&self) -> usize {

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -209,9 +209,9 @@ impl CdCommand {
         true
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) {
+    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
         if comp_cword > 0 {
-            exit(0);
+            return Ok(());
         }
 
         let repo = if !argv.is_empty() {
@@ -261,7 +261,7 @@ impl CdCommand {
             }
         }
 
-        exit(0);
+        Ok(())
     }
 
     fn cd_main_org(&self) {

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -229,8 +229,8 @@ impl CloneCommand {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
-        // noop
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
     }
 
     pub fn lookup_repo_handle(

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -229,11 +229,13 @@ impl ConfigBootstrapCommand {
         true
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         println!("--organizations");
         println!("--repo-path-format");
         println!("--shell");
         println!("--worktree");
+
+        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -497,5 +497,7 @@ impl ConfigPathSwitchCommand {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {}
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
+    }
 }

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -178,8 +178,8 @@ impl HelpCommand {
         true
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) {
-        command_loader(".").complete(comp_cword, argv, false);
+    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+        command_loader(".").complete(comp_cword, argv, false)
     }
 
     fn help_global(&self) {

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -1,5 +1,3 @@
-use std::process::exit;
-
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 
@@ -49,12 +47,13 @@ impl HookCommand {
         false
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, _argv: Vec<String>) {
+    pub fn autocomplete(&self, comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         if comp_cword == 0 {
             println!("env");
             println!("init");
             println!("uuid");
         }
-        exit(0);
+
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -74,7 +74,7 @@ impl HookEnvCommand {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
-        exit(0);
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
     }
 }

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -273,8 +273,8 @@ impl HookInitCommand {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
-        exit(0);
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
     }
 }
 

--- a/src/internal/commands/builtin/hook/uuid.rs
+++ b/src/internal/commands/builtin/hook/uuid.rs
@@ -50,7 +50,7 @@ impl HookUuidCommand {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
-        exit(0);
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
     }
 }

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -261,7 +261,7 @@ impl ScopeCommand {
                 let result = command_loader.complete(comp_cword - 1, argv.to_vec(), true);
 
                 // Restore current scope
-                if std::env::set_current_dir(&curdir).is_err() {
+                if std::env::set_current_dir(curdir).is_err() {
                     return Err(());
                 }
 

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -6,6 +6,7 @@ use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::command_loader;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::env::current_dir;
 use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
@@ -189,11 +190,16 @@ impl ScopeCommand {
             unreachable!();
         }
 
-        self.switch_scope(
-            &self.cli_args().scope,
-            self.cli_args().include_packages,
-            false,
-        );
+        if self
+            .switch_scope(
+                &self.cli_args().scope,
+                self.cli_args().include_packages,
+                false,
+            )
+            .is_err()
+        {
+            exit(1);
+        }
 
         let argv = self.cli_args().command.clone();
         let command_loader = command_loader(".");
@@ -221,7 +227,7 @@ impl ScopeCommand {
         true
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) {
+    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
         match comp_cword.cmp(&0) {
             std::cmp::Ordering::Equal => {
                 let repo = if !argv.is_empty() {
@@ -229,33 +235,43 @@ impl ScopeCommand {
                 } else {
                     "".to_string()
                 };
-                self.autocomplete_repo(repo);
+                self.autocomplete_repo(repo)
             }
             std::cmp::Ordering::Greater => {
                 if argv.is_empty() {
                     // Unsure why we would get here, but if we try to complete
                     // a command but a repository is not provided, we can't, so
                     // let's simply skip it
-                    exit(0);
+                    return Ok(());
                 }
 
                 // We want to switch context to the repository, so we can offer
                 // completion of the commands for that specific repository
                 let mut argv = argv.clone();
                 let repo = argv.remove(0);
+
+                let curdir = current_dir();
                 // TODO: use the previous arguments to know if we should include packages or not
-                self.switch_scope(&repo, true, true);
+                if self.switch_scope(&repo, true, true).is_err() {
+                    return Err(());
+                }
 
                 // Finally, we can try completing the command
                 let command_loader = command_loader(".");
-                command_loader.complete(comp_cword - 1, argv.to_vec(), true);
+                let result = command_loader.complete(comp_cword - 1, argv.to_vec(), true);
+
+                // Restore current scope
+                if std::env::set_current_dir(&curdir).is_err() {
+                    return Err(());
+                }
+
+                result
             }
-            std::cmp::Ordering::Less => {}
+            std::cmp::Ordering::Less => Err(()),
         }
-        exit(0);
     }
 
-    fn autocomplete_repo(&self, repo: String) {
+    fn autocomplete_repo(&self, repo: String) -> Result<(), ()> {
         // Figure out if this is a path, so we can avoid the expensive repository search
         let path_only = repo.starts_with('/')
             || repo.starts_with('.')
@@ -296,9 +312,16 @@ impl ScopeCommand {
                 println!("{}{}", match_repo, add_space);
             }
         }
+
+        Ok(())
     }
 
-    fn switch_scope(&self, repo: &str, include_packages: bool, silent_failure: bool) {
+    fn switch_scope(
+        &self,
+        repo: &str,
+        include_packages: bool,
+        silent_failure: bool,
+    ) -> Result<(), ()> {
         if let Ok(repo_path) = std::fs::canonicalize(repo) {
             if let Err(err) = std::env::set_current_dir(&repo_path) {
                 if !silent_failure {
@@ -308,9 +331,9 @@ impl ScopeCommand {
                         format!("{}", err).red()
                     ));
                 }
-                exit(1);
+                return Err(());
             }
-            return;
+            return Ok(());
         }
 
         if let Some(repo_path) = ORG_LOADER.find_repo(repo, include_packages, true) {
@@ -322,14 +345,15 @@ impl ScopeCommand {
                         format!("{}", err).red()
                     ));
                 }
-                exit(1);
+                return Err(());
             }
-            return;
+            return Ok(());
         }
 
         if !silent_failure {
             omni_error!(format!("{}: No such repository", repo.yellow()));
         }
-        exit(1);
+
+        Err(())
     }
 }

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -235,7 +235,7 @@ impl StatusCommand {
         true
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, argv: Vec<String>) {
+    pub fn autocomplete(&self, _comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
         for arg in &[
             "--shell-integration",
             "--config",
@@ -249,7 +249,7 @@ impl StatusCommand {
             }
         }
 
-        exit(0);
+        Ok(())
     }
 
     fn print_shell_integration(&self) {

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -430,7 +430,7 @@ impl TidyCommand {
         true
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         // TODO: if the last parameter before completion is `search-path`,
         // TODO: we should autocomplete with the file system paths
         println!("--search-path");
@@ -439,7 +439,8 @@ impl TidyCommand {
         println!("--up-all");
         println!("-h");
         println!("--help");
-        exit(0);
+
+        Ok(())
     }
 
     fn list_repositories(&self) -> Vec<TidyGitRepo> {

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -567,13 +567,14 @@ impl UpCommand {
         true
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) {
+    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         println!("--bootstrap");
         println!("--clone-suggested");
         println!("--trust");
         println!("--update-repository");
         println!("--update-user-config");
-        exit(0);
+
+        Ok(())
     }
 
     fn subcommand(&self) -> String {

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -181,14 +181,19 @@ impl PathCommand {
             .unwrap_or(false)
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) {
+    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
         let mut command = ProcessCommand::new(self.source.clone());
         command.arg("--complete");
         command.args(argv);
         command.env("COMP_CWORD", comp_cword.to_string());
-        command.exec();
 
-        panic!("Something went wrong");
+        match command.output() {
+            Ok(output) => {
+                println!("{}", String::from_utf8_lossy(&output.stdout));
+                Ok(())
+            }
+            Err(_) => Err(()),
+        }
     }
 
     fn file_details(&self) -> Option<&PathCommandFileDetails> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,9 +126,10 @@ fn complete_omni_subcommand(argv: &[String]) {
         .map(|s| s.parse().unwrap_or(0) - 1)
         .unwrap_or(0);
 
-    let command_loader = command_loader(".");
-    command_loader.complete(comp_cword, argv.to_vec(), true);
-    exit(0);
+    match command_loader(".").complete(comp_cword, argv.to_vec(), true) {
+        Ok(_) => exit(0),
+        Err(_) => exit(1),
+    }
 }
 
 fn run_omni_subcommand(parsed: &MainArgs) {


### PR DESCRIPTION
Autocompletion in special cases where we had a subcommand was not completing for the parent command unless it was clear that we are not in the path of the subcommand.

For instance, adding an `omni cd blah` command was leading `omni cd <tab>` to always autocomplete by `blah`, since it would find the subcommand.

This makes it so, as long as we are not sure we are in the subcommand path, the parent command gets a chance to autocomplete too. This is done by calling the autocompletion on the parent command if found that we are in the process of autocompleting "one element after" the parent command.

Closes https://github.com/XaF/omni/issues/342