### PR TITLE
feat(dynenv): ✨ show message when 'omni up' should be run

### DIFF
--- a/src/internal/config/loader.rs
+++ b/src/internal/config/loader.rs
@@ -34,6 +34,8 @@ lazy_static! {
     static ref CONFIG_LOADER_GLOBAL: ConfigLoader = ConfigLoader::new();
 }
 
+pub const WORKDIR_CONFIG_FILES: [&str; 2] = [".omni.yaml", ".omni/config.yaml"];
+
 pub fn config_loader(path: &str) -> ConfigLoader {
     let path = std::fs::canonicalize(path)
         .unwrap_or(path.to_owned().into())
@@ -261,8 +263,9 @@ impl ConfigLoader {
         };
 
         let mut workdir_config_files = vec![];
-        workdir_config_files.push(format!("{}/.omni.yaml", wd_root));
-        workdir_config_files.push(format!("{}/.omni/config.yaml", wd_root));
+        for workdir_config_file in WORKDIR_CONFIG_FILES.iter() {
+            workdir_config_files.push(format!("{}/{}", wd_root, workdir_config_file));
+        }
 
         new_config_loader.import_config_files(workdir_config_files, ConfigScope::Workdir);
 

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -265,7 +265,7 @@ impl OmniConfig {
             config_hasher.update(suggest_clone_str.as_bytes());
         }
 
-        return config_hasher.finalize().to_hex()[..16].to_string();
+        config_hasher.finalize().to_hex()[..16].to_string()
     }
 }
 

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -596,5 +596,5 @@ pub fn get_config_mod_times<T: AsRef<str>>(path: T) -> HashMap<String, u64> {
         }
     }
 
-    return mod_times;
+    mod_times
 }

--- a/src/internal/config/up/utils.rs
+++ b/src/internal/config/up/utils.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::path::PathBuf;
+use std::collections::HashMap;
 
 use blake3::Hasher;
 use indicatif::MultiProgress;
@@ -21,6 +23,8 @@ use tokio::time::Duration;
 use crate::internal::config::up::UpError;
 use crate::internal::user_interface::StringColor;
 use crate::internal::utils::base62_encode;
+use crate::internal::workdir;
+use crate::internal::config::loader::WORKDIR_CONFIG_FILES;
 
 #[derive(Debug, Clone)]
 pub struct RunConfig {
@@ -571,4 +575,26 @@ pub fn set_writeable_recursive<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Return the modification time of the configuration files
+/// for the work directory at the given path.
+pub fn get_config_mod_times<T: AsRef<str>>(path: T) -> HashMap<String, u64> {
+    let mut mod_times = HashMap::new();
+
+    if let Some(wdroot) = workdir(path.as_ref()).root() {
+        for config_file in WORKDIR_CONFIG_FILES {
+            let wd_config_path = PathBuf::from(wdroot).join(config_file);
+            if let Ok(metadata) = std::fs::metadata(&wd_config_path) {
+                if let Ok(modified) = metadata.modified() {
+                    if let Ok(modified) = modified.duration_since(std::time::UNIX_EPOCH) {
+                        let modified = modified.as_secs();
+                        mod_times.insert(config_file.to_string(), modified);
+                    }
+                }
+            }
+        }
+    }
+
+    return mod_times;
 }

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -98,7 +98,7 @@ fn check_workdir_config_updated(
                 }
             }
         }
-    } else if notify_available && modtimes.len() > 0 {
+    } else if notify_available && !modtimes.is_empty() {
         notify_change = true;
         change_type = "set up";
     }
@@ -119,7 +119,7 @@ fn check_workdir_config_updated(
     // Check if we have, in the environment, a variable that
     // indicates that the user has already been notified
     // about the config file being updated
-    if let Some(env_var) = std::env::var_os(&WD_CONFIG_MODTIME_VAR) {
+    if let Some(env_var) = std::env::var_os(WD_CONFIG_MODTIME_VAR) {
         if let Ok(env_var) = env_var.into_string() {
             if env_var == hashed {
                 return;

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -10,11 +10,15 @@ Configuration related to the `omni up` command.
 
 | Parameter       | Type      | Description                                         |
 |-----------------|-----------|-----------------------------------------------------|
-| `auto_bootstrap` | boolean | whether or not to automatically infer the `--bootstrap` parameter when running `omni up`, if changes to the configuration suggestions from the work directory are detected |
+| `auto_bootstrap` | boolean | whether or not to automatically infer the `--bootstrap` parameter when running `omni up`, if changes to the configuration suggestions from the work directory are detected *(default: true)* |
+| `notify_workdir_config_updated` | boolean | whether or not to print a message on the prompt if the `up` configuration of the work directory has been updated since the last `omni up` *(default: true)* |
+| `notify_workdir_config_available` | boolean | whether or not to print a message on the prompt if the current work directory has an available `up` configuration but `omni up` has not been run yet *(default: true)* |
 
 ## Example
 
 ```yaml
 up_command:
   auto_bootstrap: true
+  notify_workdir_config_updated: true
+  notify_workdir_config_available: true
 ```


### PR DESCRIPTION
This allows users to know when the current work directory has an updated `up` configuration since `omni up` was last run, or has it available but `omni up` was never run yet.

The notifications will come as the prompt will print, the same way the dynamic environment update notifications appear, and use the configuration file(s) modification times but also a hash of the parameters that are pertinent for the up configuration, such that changing any other parameters in the configuration will not trigger a notification. The only parameters considered at this time are `up`,
`suggest_config` and `suggest_clone`.

This also comes with two configuration options to be able to disable any of those messages if desired:
- `notify_workdir_config_updated` to enable/disable notifications when `omni up` has already been run but we detected an update to the `up` configuration
- `notify_workdir_config_available` to enable/disable notifications when an `up` configuration is available but `omni up` has never been run.

Closes https://github.com/XaF/omni/issues/346