### PR TITLE
feat(env): ✨ better handling of `up` environment variables

### DIFF
--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -15,6 +15,7 @@ use once_cell::sync::OnceCell;
 use serde::Serialize;
 use tokio::process::Command as TokioCommand;
 
+use crate::internal::cache::utils::Empty;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::RepositoriesCache;
 use crate::internal::cache::UpEnvironmentsCache;
@@ -516,7 +517,7 @@ impl UpCommand {
                 let wd = workdir(".");
                 if let Some(workdir_id) = wd.id() {
                     if let Some(env_vars) = env_vars.clone() {
-                        up_env.set_env_vars(&workdir_id, env_vars.clone());
+                        up_env.set_env_vars(&workdir_id, env_vars.into());
                     }
                     up_env.set_config_hash(&workdir_id);
                     up_env.set_config_modtimes(&workdir_id);

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -46,6 +46,13 @@ pub fn abs_or_rel_path(path: &str) -> String {
 }
 
 pub fn abs_path(path: impl AsRef<Path>) -> PathBuf {
+    abs_path_from_path(path, None)
+}
+
+pub fn abs_path_from_path<T>(path: T, frompath: Option<T>) -> PathBuf
+where
+    T: AsRef<Path>,
+{
     let path = path.as_ref().normalize();
 
     let absolute_path = if path.is_absolute() {
@@ -55,7 +62,12 @@ pub fn abs_path(path: impl AsRef<Path>) -> PathBuf {
         let path = path.strip_prefix("~").expect("Failed to strip prefix");
         PathBuf::from(home_dir).join(path)
     } else {
-        std::env::current_dir().unwrap().join(path)
+        match frompath {
+            Some(frompath) => frompath.as_ref().join(path),
+            None => std::env::current_dir()
+                .expect("Failed to determine current directory")
+                .join(path),
+        }
     }
     .clean();
 

--- a/src/internal/config/config_value.rs
+++ b/src/internal/config/config_value.rs
@@ -271,6 +271,10 @@ impl ConfigValue {
         None
     }
 
+    pub fn get_scope(&self) -> ConfigScope {
+        self.scope.clone()
+    }
+
     pub fn current_scope(&self) -> ConfigScope {
         match self.scopes().iter().max() {
             Some(scope) => scope.clone(),

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -1,14 +1,17 @@
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Mutex;
 
 use humantime::parse_duration;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::cache::utils::Empty;
+use crate::internal::commands::utils::abs_path_from_path;
 use crate::internal::config::config_loader;
 use crate::internal::config::config_value::ConfigData;
 use crate::internal::config::flush_config_loader;
@@ -143,8 +146,8 @@ pub struct OmniConfig {
     pub path: PathConfig,
     pub path_repo_updates: PathRepoUpdatesConfig,
     pub repo_path_format: String,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "EnvConfig::is_empty")]
+    pub env: EnvConfig,
     pub cd: CdConfig,
     pub clone: CloneConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,13 +183,6 @@ impl OmniConfig {
             }
         }
 
-        let mut env_config = HashMap::new();
-        if let Some(value) = config_value.get("env") {
-            for (key, value) in value.as_table().unwrap() {
-                env_config.insert(key.to_string(), value.as_str().unwrap().to_string());
-            }
-        }
-
         Self {
             worktree: config_value
                 .get_as_str("worktree")
@@ -214,7 +210,7 @@ impl OmniConfig {
                 .get_as_str("repo_path_format")
                 .unwrap_or(Self::DEFAULT_REPO_PATH_FORMAT.to_string())
                 .to_string(),
-            env: env_config,
+            env: EnvConfig::from_config_value(config_value.get("env")),
             cd: CdConfig::from_config_value(config_value.get("cd")),
             clone: CloneConfig::from_config_value(config_value.get("clone")),
             up: UpConfig::from_config_value(config_value.get("up")),
@@ -1186,6 +1182,316 @@ impl PathRepoUpdatesPerRepoConfig {
             ref_match: config_value
                 .get("ref_match")
                 .map(|value| value.as_str().unwrap().to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct EnvConfig {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub operations: Vec<EnvOperationConfig>,
+}
+
+impl Deref for EnvConfig {
+    type Target = Vec<EnvOperationConfig>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.operations
+    }
+}
+
+impl Into<Vec<EnvOperationConfig>> for EnvConfig {
+    fn into(self) -> Vec<EnvOperationConfig> {
+        self.operations
+    }
+}
+
+impl Serialize for EnvConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.is_empty() {
+            serializer.serialize_none()
+        } else {
+            self.operations.serialize(serializer)
+        }
+    }
+}
+
+impl Empty for EnvConfig {
+    fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+impl EnvConfig {
+    fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let operations = if let Some(config_value) = config_value {
+            let operations_array = if let Some(array) = config_value.as_array() {
+                array
+            } else if let Some(table) = config_value.as_table() {
+                // If this is a map, create individual maps for each key/value pair,
+                // sorted by key for deterministic output.
+                table
+                    .iter()
+                    .sorted_by_key(|(key, _)| key.to_string())
+                    .map(|(key, value)| {
+                        let mut map = HashMap::new();
+                        map.insert(key.to_string(), value.clone());
+                        ConfigValue::new(
+                            config_value.get_source().clone(),
+                            config_value.get_scope().clone(),
+                            Some(Box::new(ConfigData::Mapping(map))),
+                        )
+                    })
+                    .collect::<Vec<ConfigValue>>()
+            } else {
+                // Unsupported type
+                vec![]
+            };
+
+            operations_array
+                .iter()
+                .map(|value| EnvOperationConfig::from_config_value(value))
+                .flatten()
+                .collect()
+        } else {
+            vec![]
+        };
+
+        Self { operations }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct EnvOperationConfig {
+    pub name: String,
+    pub value: Option<String>,
+    pub operation: EnvOperationEnum,
+}
+
+impl EnvOperationConfig {
+    fn from_config_value_multi(
+        name: &str,
+        config_value: &ConfigValue,
+        operation: EnvOperationEnum,
+    ) -> Vec<Self> {
+        if let Some(array) = config_value.as_array() {
+            array
+                .iter()
+                .map(|config_value| match config_value.as_table() {
+                    Some(table) => table,
+                    None => {
+                        let mut table = HashMap::new();
+                        table.insert("value".to_string(), config_value.clone());
+
+                        table
+                    }
+                })
+                .filter_map(|table| Self::from_table(name, table, operation))
+                .collect()
+        } else if let Some(table) = config_value.as_table() {
+            if let Some(value) = Self::from_table(name, table, operation) {
+                vec![value]
+            } else {
+                vec![]
+            }
+        } else {
+            let mut table = HashMap::new();
+            table.insert("value".to_string(), config_value.clone());
+
+            if let Some(value) = Self::from_table(name, table, operation) {
+                vec![value]
+            } else {
+                vec![]
+            }
+        }
+    }
+
+    fn from_table(
+        name: &str,
+        table: HashMap<String, ConfigValue>,
+        operation: EnvOperationEnum,
+    ) -> Option<Self> {
+        let value_type = match table.get("type") {
+            Some(value_type) => match value_type.as_str() {
+                Some(value_type) => match value_type.as_str() {
+                    "text" | "path" => value_type,
+                    _ => return None,
+                },
+                None => return None,
+            },
+            None => "text".to_string(),
+        };
+
+        let value = if let Some(config_value) = table.get("value") {
+            if let Some(value) = config_value.as_str_forced() {
+                // If the value type is "path", we want to expand the path
+                // before returning it. We can use the value ConfigSource
+                // to determine the current scope.
+                if value_type == "path" {
+                    match config_value.get_source() {
+                        ConfigSource::File(path) => Some(
+                            abs_path_from_path(&value, Some(&path))
+                                .to_string_lossy()
+                                .to_string(),
+                        ),
+                        // Unsupported source type for the "path" value type
+                        _ => Some(value.to_string()),
+                    }
+                } else {
+                    Some(value.to_string())
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if value.is_none() && operation != EnvOperationEnum::Set {
+            return None;
+        }
+
+        Some(Self {
+            name: name.to_string(),
+            value,
+            operation,
+        })
+    }
+
+    fn from_config_value(config_value: &ConfigValue) -> Vec<Self> {
+        // The config_value should be a table.
+        let table = if let Some(table) = config_value.as_table() {
+            table
+        } else {
+            return vec![];
+        };
+
+        // There should be exactly one key/value pair in the table.
+        if table.len() != 1 {
+            return vec![];
+        }
+
+        // Get the unique key, value pair; we can unwrap here because we know
+        // there is exactly one pair.
+        let (name, value) = table.iter().next().unwrap();
+
+        // Now we can try and figure out how to parse the value
+        if let Some(table) = value.as_table() {
+            if let Some(config_value) = table.get("set") {
+                return if let Some(value) =
+                    Self::from_config_value_multi(name, config_value, EnvOperationEnum::Set).pop()
+                {
+                    vec![value]
+                } else {
+                    vec![]
+                };
+            }
+
+            let mut operations = vec![];
+            let mut matched_any = false;
+
+            if let Some(config_value) = table.get("remove") {
+                matched_any = true;
+                operations.extend(Self::from_config_value_multi(
+                    name,
+                    config_value,
+                    EnvOperationEnum::Remove,
+                ))
+            }
+
+            if let Some(config_value) = table.get("prepend") {
+                matched_any = true;
+                operations.extend(Self::from_config_value_multi(
+                    name,
+                    config_value,
+                    EnvOperationEnum::Prepend,
+                ))
+            }
+
+            if let Some(config_value) = table.get("append") {
+                matched_any = true;
+                operations.extend(Self::from_config_value_multi(
+                    name,
+                    config_value,
+                    EnvOperationEnum::Append,
+                ))
+            }
+
+            if matched_any {
+                return operations;
+            }
+
+            if let Some(value) = Self::from_table(name, table, EnvOperationEnum::Set) {
+                vec![value]
+            } else {
+                vec![]
+            }
+        } else if let Some(value) =
+            Self::from_config_value_multi(name, value, EnvOperationEnum::Set).pop()
+        {
+            vec![value]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Serialize for EnvOperationConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.operation {
+            EnvOperationEnum::Set => {
+                let mut env_var = HashMap::new();
+                env_var.insert(self.name.clone(), self.value.clone());
+                env_var.serialize(serializer)
+            }
+            EnvOperationEnum::Prepend | EnvOperationEnum::Append | EnvOperationEnum::Remove => {
+                let mut env_var_wrapped = HashMap::new();
+                env_var_wrapped.insert(self.operation.to_string(), self.value.clone());
+
+                let mut env_var = HashMap::new();
+                env_var.insert(self.name.clone(), env_var_wrapped);
+                env_var.serialize(serializer)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy)]
+pub enum EnvOperationEnum {
+    #[serde(rename = "set")]
+    Set,
+    #[serde(rename = "prepend")]
+    Prepend,
+    #[serde(rename = "append")]
+    Append,
+    #[serde(rename = "remove")]
+    Remove,
+}
+
+impl ToString for EnvOperationEnum {
+    fn to_string(&self) -> String {
+        match self {
+            EnvOperationEnum::Set => "set".to_string(),
+            EnvOperationEnum::Prepend => "prepend".to_string(),
+            EnvOperationEnum::Append => "append".to_string(),
+            EnvOperationEnum::Remove => "remove".to_string(),
+        }
+    }
+}
+
+impl EnvOperationEnum {
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            EnvOperationEnum::Set => b"set",
+            EnvOperationEnum::Prepend => b"prepend",
+            EnvOperationEnum::Append => b"append",
+            EnvOperationEnum::Remove => b"remove",
         }
     }
 }

--- a/src/internal/config/parser.rs
+++ b/src/internal/config/parser.rs
@@ -1200,9 +1200,9 @@ impl Deref for EnvConfig {
     }
 }
 
-impl Into<Vec<EnvOperationConfig>> for EnvConfig {
-    fn into(self) -> Vec<EnvOperationConfig> {
-        self.operations
+impl From<EnvConfig> for Vec<EnvOperationConfig> {
+    fn from(env_config: EnvConfig) -> Self {
+        env_config.operations
     }
 }
 
@@ -1231,8 +1231,8 @@ impl EnvConfig {
             let operations_array = if let Some(array) = config_value.as_array() {
                 array
             } else if let Some(table) = config_value.as_table() {
-                // If this is a map, create individual maps for each key/value pair,
-                // sorted by key for deterministic output.
+                // If this is a map, create a list of individual maps for each
+                // key/value pair, sorted by key for deterministic output.
                 table
                     .iter()
                     .sorted_by_key(|(key, _)| key.to_string())
@@ -1253,8 +1253,7 @@ impl EnvConfig {
 
             operations_array
                 .iter()
-                .map(|value| EnvOperationConfig::from_config_value(value))
-                .flatten()
+                .flat_map(EnvOperationConfig::from_config_value)
                 .collect()
         } else {
             vec![]
@@ -1333,7 +1332,7 @@ impl EnvOperationConfig {
                 if value_type == "path" {
                     match config_value.get_source() {
                         ConfigSource::File(path) => Some(
-                            abs_path_from_path(&value, Some(&path))
+                            abs_path_from_path(&value, Some(path))
                                 .to_string_lossy()
                                 .to_string(),
                         ),

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -10,6 +10,7 @@ use shell_escape::escape;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config;
+use crate::internal::config::parser::EnvOperationEnum;
 use crate::internal::config::up::asdf_tool_path;
 use crate::internal::config::up::utils::get_config_mod_times;
 use crate::internal::env::user_home;
@@ -40,12 +41,6 @@ fn check_workdir_config_updated(
     path: Option<String>,
     cache: &UpEnvironmentsCache,
 ) {
-    // TODO: add configuration option to not show that message at all,
-    //       with maybe an option to only show it if the repo has been
-    //       up-ed before (right now it does that by default, but we
-    //       may want an option to show it all the time if a repo can
-    //       be omni up-ed but is not up to date)
-
     let wdpath = path.unwrap_or(".".to_string());
 
     let wdid = if let Some(wdid) = workdir(&wdpath).id() {
@@ -320,12 +315,16 @@ impl DynamicEnv {
             hasher.update(workdir.id().unwrap().as_bytes());
             hasher.update(DATA_SEPARATOR.as_bytes());
 
-            // Add the requested environments to the hash, sorted by key
-            for (key, value) in up_env.env_vars.iter().sorted() {
-                hasher.update(key.as_bytes());
+            // Add the requested environment operations to the hash
+            for env_var in up_env.env_vars.iter() {
+                hasher.update(env_var.operation.as_bytes());
                 hasher.update(DATA_SEPARATOR.as_bytes());
-                hasher.update(value.as_bytes());
+                hasher.update(env_var.name.as_bytes());
                 hasher.update(DATA_SEPARATOR.as_bytes());
+                if let Some(value) = &env_var.value {
+                    hasher.update(value.as_bytes());
+                    hasher.update(DATA_SEPARATOR.as_bytes());
+                }
             }
 
             // Add the requested paths to the hash
@@ -374,12 +373,29 @@ impl DynamicEnv {
         }
 
         if let Some(up_env) = &up_env {
-            // Add the requested environments to the hash, sorted by key
+            // Add the requested environments
             if !up_env.env_vars.is_empty() {
                 self.features.push("env".to_string());
             }
-            for (key, value) in up_env.env_vars.iter() {
-                envsetter.set_value(key, value);
+            for env_var in up_env.env_vars.iter() {
+                match (env_var.operation.clone(), env_var.value.clone()) {
+                    (EnvOperationEnum::Set, Some(value)) => {
+                        envsetter.set_value(&env_var.name, &value);
+                    }
+                    (EnvOperationEnum::Set, None) => {
+                        envsetter.unset_value(&env_var.name);
+                    }
+                    (EnvOperationEnum::Prepend, Some(value)) => {
+                        envsetter.prepend_to_list(&env_var.name, &value);
+                    }
+                    (EnvOperationEnum::Append, Some(value)) => {
+                        envsetter.append_to_list(&env_var.name, &value);
+                    }
+                    (EnvOperationEnum::Remove, Some(value)) => {
+                        envsetter.remove_from_list(&env_var.name, &value);
+                    }
+                    (_, None) => {}
+                }
             }
 
             // Add the requested paths

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -378,7 +378,7 @@ impl DynamicEnv {
                 self.features.push("env".to_string());
             }
             for env_var in up_env.env_vars.iter() {
-                match (env_var.operation.clone(), env_var.value.clone()) {
+                match (env_var.operation, env_var.value.clone()) {
                     (EnvOperationEnum::Set, Some(value)) => {
                         envsetter.set_value(&env_var.name, &value);
                     }

--- a/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
+++ b/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
@@ -18,7 +18,7 @@ Omni configuration files accept the following parameters:
 | `command_match_skip_prompt_if` | [*_skip_prompt_if](parameters/skip-prompt-if) | Configuration of prompt skipping when fuzzy matching a command |
 | `commands` | [commands](parameters/commands) (map) | Commands made available through omni |
 | `config_commands` | [config_commands](parameters/config_commands) | Configuration related to the commands defined in the config file |
-| `env` | map | A key-value map of environment variables to be set when running omni commands |
+| `env` | [env](parameters/env) | Definition of the environment variables to be set when running omni commands |
 | `makefile_commands` | [makefile_commands](parameters/makefile_commands) | Configuration related to the commands generated from Makefile targets |
 | `org` | [org](parameters/org) (list) | Configuration for the default organizations |
 | `path_repo_updates` | [path_repo_updates](parameters/path_repo_updates) | Configuration for the automated updates of the repositories in omni path |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-env.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-env.md
@@ -1,0 +1,51 @@
+---
+description: Configuration of the `env` parameter
+---
+
+# `env`
+
+## Parameters
+
+Contains a list of the environment variables to be set, and their values.
+
+For each environment variables, these are the accepted parameters:
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `value` | string | The value to set for the environment variable; if set to `null`, the environment variable will be unset |
+| `type` | enum | One of `text` for a static value, or `path` for the value to be converted into an absolute path *(default: text)* |
+
+Special blocks are supported for operations on lists. The `append` block will append the proposed value to the list, `prepend` will prepend it, and `remove` will remove it from the list. The `set` block is the one used by default, and simply sets the value of the environment variable.
+
+## Example
+
+```yaml
+# Simple setting of variables
+env:
+  VAR1: VAL1
+  VAR2: VAL2
+
+# Doing list operations; this will prepend the relative path path/to/my/lib
+# directory to the PYTHONPATH environment variable. Using `type: path`, this
+# will be converted into an absolute variable, taking as current directory
+# the configuration file in which that variable is.
+env:
+  PYTHONPATH:
+    prepend:
+      value: path/to/my/lib
+      type: path
+
+# It is possible to specify multiple modifiers at the same time, and multiple
+# values for the same modifier by passing a list
+env:
+  VAR1:
+    prepend:
+      - val1
+      - val2
+    append: val3
+
+# When passed as a list, allows for the same variable to be specified twice
+env:
+  - VAR1: VAL1
+  - VAR2: VAL2
+```


### PR DESCRIPTION
The `env` parameter was doing basic environment variable assignment, and did not take advantage of the whole capabilities of the dynamic environment. This changes that by adding more flexibility and support for also unsetting variables, but also list operations (append, prepend, remove from list).

This also supports handling paths by setting a `type: path` for environment variables. This allows for setting variables such as PYTHONPATH and equivalent.

Closes https://github.com/XaF/omni/issues/358