### PR TITLE
fix(bootstrap): 🐛 flush config

### DIFF
--- a/src/internal/config/bootstrap.rs
+++ b/src/internal/config/bootstrap.rs
@@ -1,6 +1,7 @@
 use std::process::exit;
 
 use crate::internal::commands::config_bootstrap;
+use crate::internal::config::flush_config;
 use crate::internal::config::global_config_loader;
 use crate::internal::user_interface::colors::StringColor;
 use crate::omni_error;
@@ -20,6 +21,7 @@ pub fn ensure_bootstrap() {
     match config_bootstrap(None) {
         Ok(true) => {
             omni_print!("All done! Your configuration file has been written \u{1F389}");
+            flush_config("/");
         }
         Ok(false) => {
             omni_print!("Alright, I won't write your configuration for now \u{1F44D}");


### PR DESCRIPTION
This makes sure that after a user fills their configuration, it is immediately used by whatever omni command is being ran.

Fixes https://github.com/XaF/omni/issues/363