### PR TITLE
fix(help): 🐛 colors are now stripped when disabled

### DIFF
--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -9,6 +9,7 @@ use crate::internal::commands::void::VoidCommand;
 use crate::internal::commands::Command;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::user_interface::colors::strip_colors_if_needed;
 use crate::internal::user_interface::term_width;
 use crate::internal::user_interface::wrap_blocks;
 use crate::internal::user_interface::wrap_text;
@@ -204,7 +205,10 @@ impl HelpCommand {
 
         let help = command.help();
         if !help.is_empty() {
-            eprintln!("\n{}", wrap_blocks(&help, max_width).join("\n"));
+            eprintln!(
+                "\n{}",
+                wrap_blocks(&strip_colors_if_needed(help), max_width).join("\n")
+            );
         }
 
         let is_shadow_name = command
@@ -244,7 +248,8 @@ impl HelpCommand {
                     let missing_just = ljust - arg.name.len();
                     let str_name = format!("  {}{}", arg.name.cyan(), " ".repeat(missing_just));
                     let help = if let Some(desc) = &arg.desc {
-                        wrap_text(desc, max_width - ljust).join(join_str.as_str())
+                        wrap_text(&strip_colors_if_needed(desc), max_width - ljust)
+                            .join(join_str.as_str())
                     } else {
                         "".to_string()
                     };
@@ -370,7 +375,8 @@ impl HelpCommand {
             let missing_just = ljust - all_names_len - num_folded_len;
             let str_name = format!("  {}{}{}", all_names, num_folded, " ".repeat(missing_just));
 
-            let help = wrap_text(&command.help_short(), help_just).join(join_str.as_str());
+            let help = wrap_text(&strip_colors_if_needed(&command.help_short()), help_just)
+                .join(join_str.as_str());
 
             eprintln!("{}{}", str_name, help);
         }

--- a/src/internal/user_interface/colors.rs
+++ b/src/internal/user_interface/colors.rs
@@ -56,7 +56,7 @@ pub fn strip_colors_if_needed<T: ToString>(input: T) -> String {
     if colors_enabled() {
         input.to_string()
     } else {
-        strip_colors(&input.to_string())
+        strip_colors(input)
     }
 }
 

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -138,7 +138,7 @@ fn term_columns() -> usize {
         return width;
     }
 
-    return 80;
+    80
 }
 
 pub fn term_width() -> usize {

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -125,12 +125,24 @@ macro_rules! omni_error {
     };
 }
 
+fn term_columns() -> usize {
+    // If the COLUMNS environment variable is set, we respect it
+    if let Ok(columns) = std::env::var("COLUMNS") {
+        if let Ok(columns) = columns.parse::<usize>() {
+            return columns;
+        }
+    }
+
+    // Otherwise, we try to get the terminal size
+    if let Some((width, _)) = term_size::dimensions() {
+        return width;
+    }
+
+    return 80;
+}
+
 pub fn term_width() -> usize {
-    let width = if let Some((width, _)) = term_size::dimensions() {
-        width
-    } else {
-        80
-    };
+    let width = term_columns();
 
     let max = 120;
     if width < max + 4 {
@@ -182,6 +194,11 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
         line_width += 1;
     }
     lines.push(line);
+
+    // Trim trailing whitespaces for each line
+    lines.iter_mut().for_each(|line| {
+        *line = line.trim_end().to_string();
+    });
 
     lines
 }


### PR DESCRIPTION
There was a bug where the colors in help messages from commands, short and long, were still showing when colors were disabled. This fixes that by stripping the colors from those messages when colors are disabled.