### PR TITLE
docs: 📝 enable Algolia search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -120,6 +120,15 @@ const config = {
           },
         ],
       },
+      algolia: {
+        appId: '42CGPL0NK3',
+        apiKey: 'dd9a0cfdc1189094accbfbacb6c7046a',
+        indexName: 'omnicli',
+        insights: true,
+        contextualSearch: true,
+        searchParameters: {},
+        searchPagePath: 'search',
+      },
       footer: {
         style: 'dark',
         // links: [


### PR DESCRIPTION
Algolia (https://www.algolia.com/) provides free search for open source documentations; omni being open source, Algolia is now providing a free search engine for the documentation!