### PR TITLE
feat(nix): ✨ add nix up operation

### DIFF
--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -87,7 +87,7 @@ impl UpEnvironmentsCache {
         let up_env_var = UpEnvVar {
             name: key.to_string(),
             value: Some(value.to_string()),
-            operation: operation,
+            operation,
         };
 
         if let Some(env) = self.env.get_mut(workdir_id) {

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -74,19 +74,27 @@ impl UpEnvironmentsCache {
     }
 
     pub fn add_env_var(&mut self, workdir_id: &str, key: &str, value: &str) -> bool {
+        self.add_env_var_operation(workdir_id, key, value, EnvOperationEnum::Set)
+    }
+
+    pub fn add_env_var_operation(
+        &mut self,
+        workdir_id: &str,
+        key: &str,
+        value: &str,
+        operation: EnvOperationEnum,
+    ) -> bool {
+        let up_env_var = UpEnvVar {
+            name: key.to_string(),
+            value: Some(value.to_string()),
+            operation: operation,
+        };
+
         if let Some(env) = self.env.get_mut(workdir_id) {
-            env.env_vars.push(UpEnvVars {
-                name: key.to_string(),
-                value: Some(value.to_string()),
-                operation: EnvOperationEnum::Set,
-            });
+            env.env_vars.push(up_env_var);
         } else {
             let mut env = UpEnvironment::new();
-            env.env_vars.push(UpEnvVars {
-                name: key.to_string(),
-                value: Some(value.to_string()),
-                operation: EnvOperationEnum::Set,
-            });
+            env.env_vars.push(up_env_var);
             self.env.insert(workdir_id.to_string(), env);
         }
         self.updated();
@@ -103,6 +111,13 @@ impl UpEnvironmentsCache {
             self.env.insert(workdir_id.to_string(), env);
         }
         self.updated();
+        true
+    }
+
+    pub fn add_paths(&mut self, workdir_id: &str, paths: Vec<PathBuf>) -> bool {
+        for path in paths {
+            self.add_path(workdir_id, path);
+        }
         true
     }
 
@@ -229,7 +244,7 @@ pub struct UpEnvironment {
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub paths: Vec<PathBuf>,
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
-    pub env_vars: Vec<UpEnvVars>,
+    pub env_vars: Vec<UpEnvVar>,
     #[serde(default = "HashMap::new", skip_serializing_if = "HashMap::is_empty")]
     pub config_modtimes: HashMap<String, u64>,
     #[serde(default = "String::new", skip_serializing_if = "String::is_empty")]
@@ -295,13 +310,20 @@ impl UpVersion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct UpEnvVars {
+pub struct UpEnvVar {
+    #[serde(rename = "n", alias = "name", skip_serializing_if = "String::is_empty")]
     pub name: String,
+    #[serde(rename = "v", alias = "value", skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    #[serde(
+        rename = "o",
+        alias = "operation",
+        skip_serializing_if = "EnvOperationEnum::is_default"
+    )]
     pub operation: EnvOperationEnum,
 }
 
-impl From<EnvOperationConfig> for UpEnvVars {
+impl From<EnvOperationConfig> for UpEnvVar {
     fn from(env_op: EnvOperationConfig) -> Self {
         Self {
             name: env_op.name,

--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -244,6 +244,24 @@ impl EnvOperationConfig {
                 ))
             }
 
+            if let Some(config_value) = table.get("prefix") {
+                matched_any = true;
+                operations.extend(Self::from_config_value_multi(
+                    name,
+                    config_value,
+                    EnvOperationEnum::Prefix,
+                ))
+            }
+
+            if let Some(config_value) = table.get("suffix") {
+                matched_any = true;
+                operations.extend(Self::from_config_value_multi(
+                    name,
+                    config_value,
+                    EnvOperationEnum::Suffix,
+                ))
+            }
+
             if matched_any {
                 return operations;
             }
@@ -274,7 +292,11 @@ impl Serialize for EnvOperationConfig {
                 env_var.insert(self.name.clone(), self.value.clone());
                 env_var.serialize(serializer)
             }
-            EnvOperationEnum::Prepend | EnvOperationEnum::Append | EnvOperationEnum::Remove => {
+            EnvOperationEnum::Prepend
+            | EnvOperationEnum::Append
+            | EnvOperationEnum::Remove
+            | EnvOperationEnum::Prefix
+            | EnvOperationEnum::Suffix => {
                 let mut env_var_wrapped = HashMap::new();
                 env_var_wrapped.insert(self.operation.to_string(), self.value.clone());
 
@@ -288,14 +310,24 @@ impl Serialize for EnvOperationConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy)]
 pub enum EnvOperationEnum {
-    #[serde(rename = "set")]
+    #[serde(rename = "s", alias = "set")]
     Set,
-    #[serde(rename = "prepend")]
+    #[serde(rename = "p", alias = "prepend")]
     Prepend,
-    #[serde(rename = "append")]
+    #[serde(rename = "a", alias = "append")]
     Append,
-    #[serde(rename = "remove")]
+    #[serde(rename = "r", alias = "remove")]
     Remove,
+    #[serde(rename = "pf", alias = "prefix")]
+    Prefix,
+    #[serde(rename = "sf", alias = "suffix")]
+    Suffix,
+}
+
+impl Default for EnvOperationEnum {
+    fn default() -> Self {
+        EnvOperationEnum::Set
+    }
 }
 
 impl ToString for EnvOperationEnum {
@@ -305,6 +337,8 @@ impl ToString for EnvOperationEnum {
             EnvOperationEnum::Prepend => "prepend".to_string(),
             EnvOperationEnum::Append => "append".to_string(),
             EnvOperationEnum::Remove => "remove".to_string(),
+            EnvOperationEnum::Prefix => "prefix".to_string(),
+            EnvOperationEnum::Suffix => "suffix".to_string(),
         }
     }
 }
@@ -316,6 +350,12 @@ impl EnvOperationEnum {
             EnvOperationEnum::Prepend => b"prepend",
             EnvOperationEnum::Append => b"append",
             EnvOperationEnum::Remove => b"remove",
+            EnvOperationEnum::Prefix => b"prefix",
+            EnvOperationEnum::Suffix => b"suffix",
         }
+    }
+
+    pub fn is_default(other: &EnvOperationEnum) -> bool {
+        *other == EnvOperationEnum::default()
     }
 }

--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -308,8 +308,9 @@ impl Serialize for EnvOperationConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy, Default)]
 pub enum EnvOperationEnum {
+    #[default]
     #[serde(rename = "s", alias = "set")]
     Set,
     #[serde(rename = "p", alias = "prepend")]
@@ -322,12 +323,6 @@ pub enum EnvOperationEnum {
     Prefix,
     #[serde(rename = "sf", alias = "suffix")]
     Suffix,
-}
-
-impl Default for EnvOperationEnum {
-    fn default() -> Self {
-        EnvOperationEnum::Set
-    }
 }
 
 impl ToString for EnvOperationEnum {

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -821,7 +821,7 @@ impl UpConfigAsdfBase {
             Err(_) => return vec![],
         };
 
-        let tool_data_path = wd_data_path.join(&self.tool).join(&version);
+        let tool_data_path = wd_data_path.join(&self.tool).join(version);
 
         let mut dirs = self.dirs.clone();
         if dirs.is_empty() {

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -5,7 +5,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use itertools::any;
 use lazy_static::lazy_static;
 use node_semver::Range as semverRange;
 use node_semver::Version as semverVersion;
@@ -19,7 +18,7 @@ use walkdir::WalkDir;
 use crate::internal::cache::AsdfOperationCache;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
-use crate::internal::config::up::utils::force_remove_dir_all;
+use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
@@ -33,6 +32,7 @@ use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::omni_error;
+use crate::omni_warning;
 
 lazy_static! {
     static ref ASDF_PATH: String = format!("{}/asdf", data_home());
@@ -200,8 +200,14 @@ pub struct UpConfigAsdfBase {
     #[serde(skip)]
     actual_versions: OnceCell<BTreeSet<String>>,
 
+    /// The configuration value that was used to create this object.
     #[serde(skip)]
     config_value: Option<ConfigValue>,
+
+    /// Whether the up operation succeeded. If unset, the operation has not
+    /// been attempted yet.
+    #[serde(skip)]
+    up_succeeded: OnceCell<bool>,
 }
 
 impl UpConfigAsdfBase {
@@ -216,6 +222,7 @@ impl UpConfigAsdfBase {
             actual_version: OnceCell::new(),
             actual_versions: OnceCell::new(),
             config_value: None,
+            up_succeeded: OnceCell::new(),
         }
     }
 
@@ -233,6 +240,8 @@ impl UpConfigAsdfBase {
             tool_url: self.tool_url.clone(),
             version: version.to_string(),
             dirs: dirs.clone(),
+
+            up_succeeded: OnceCell::new(),
 
             // We can ignore all those fields, as they won't be used,
             // since the version passed to that call is a specific version
@@ -310,6 +319,7 @@ impl UpConfigAsdfBase {
             actual_version: OnceCell::new(),
             actual_versions: OnceCell::new(),
             config_value: config_value.cloned(),
+            up_succeeded: OnceCell::new(),
         }
     }
 
@@ -352,7 +362,24 @@ impl UpConfigAsdfBase {
         progress_handler.progress("updated cache".to_string());
     }
 
-    pub fn up(
+    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        if self.up_succeeded.get().is_some() {
+            return Err(UpError::Exec("up operation already attempted".to_string()));
+        }
+
+        let result = self.run_up(options, progress);
+        if let Err(err) = self.up_succeeded.set(result.is_ok()) {
+            omni_warning!(format!("failed to record status of up operation: {}", err));
+        }
+
+        result
+    }
+
+    pub fn was_upped(&self) -> bool {
+        matches!(self.up_succeeded.get(), Some(true))
+    }
+
+    fn run_up(
         &self,
         _options: &UpOptions,
         progress: Option<(usize, usize)>,
@@ -781,20 +808,40 @@ impl UpConfigAsdfBase {
         Ok(true)
     }
 
-    pub fn cleanup_unused(progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        let desc = "resources cleanup:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
-
+    pub fn data_paths(&self) -> Vec<PathBuf> {
         let workdir = workdir(".");
-        let workdir_id = if let Some(workdir_id) = workdir.id() {
-            workdir_id
-        } else {
-            return Err(UpError::Exec("failed to get workdir id".to_string()));
+
+        let wd_data_path = match workdir.data_path() {
+            Some(wd_data_path) => wd_data_path,
+            None => return vec![],
+        };
+
+        let version = match self.version(None) {
+            Ok(version) => version,
+            Err(_) => return vec![],
+        };
+
+        let tool_data_path = wd_data_path.join(&self.tool).join(&version);
+
+        let mut dirs = self.dirs.clone();
+        if dirs.is_empty() {
+            dirs.insert("".to_string());
+        }
+
+        let mut data_paths = BTreeSet::new();
+        for dir in dirs {
+            let hashed_dir = data_path_dir_hash(&dir);
+            data_paths.insert(tool_data_path.join(&hashed_dir));
+        }
+
+        data_paths.into_iter().collect()
+    }
+
+    pub fn cleanup(progress_handler: &dyn ProgressHandler) -> Result<Option<String>, UpError> {
+        let workdir = workdir(".");
+        let workdir_id = match workdir.id() {
+            Some(workdir_id) => workdir_id,
+            None => return Err(UpError::Exec("failed to get workdir id".to_string())),
         };
 
         // Get the expected installed versions of the tool from
@@ -804,145 +851,13 @@ impl UpConfigAsdfBase {
             env_tools.extend(env.versions.iter().cloned());
         }
 
-        if let Some(wd_data_path) = workdir.data_path() {
-            if wd_data_path.exists() {
-                if let Some(ph) = progress_handler {
-                    ph.progress("removing unused data paths".to_string());
-                }
-
-                // If any data path in the versions
-                if !any(&env_tools, |tool| tool.data_path.is_some()) {
-                    force_remove_dir_all(wd_data_path).map_err(|err| {
-                        UpError::Exec(format!(
-                            "failed to remove workdir data path {}: {}",
-                            wd_data_path.display(),
-                            err
-                        ))
-                    })?;
-                } else {
-                    let expected_tools = env_tools
-                        .iter()
-                        .map(|tool| tool.tool.clone())
-                        .collect::<BTreeSet<_>>();
-
-                    let tool_dirs = std::fs::read_dir(wd_data_path.clone()).map_err(|err| {
-                        UpError::Exec(format!(
-                            "failed to read data path directory for {}: {}",
-                            workdir_id, err,
-                        ))
-                    })?;
-                    for tool_dir in tool_dirs {
-                        let tool_dir = tool_dir.map_err(|err| {
-                            UpError::Exec(format!(
-                                "failed to read data path directory for {}: {}",
-                                workdir_id, err,
-                            ))
-                        })?;
-
-                        let tool_dir_name = tool_dir.file_name().to_string_lossy().to_string();
-
-                        // Remove the tool directory if the tool is not expected
-                        if !expected_tools.contains(&tool_dir_name) {
-                            force_remove_dir_all(tool_dir.path()).map_err(|err| {
-                                UpError::Exec(format!(
-                                    "failed to remove workdir data path for tool {}: {}",
-                                    tool_dir_name, err
-                                ))
-                            })?;
-                            continue;
-                        }
-
-                        // Check the versions for that tool
-                        let expected_versions = env_tools
-                            .iter()
-                            .filter(|tool| tool.tool == tool_dir_name)
-                            .map(|tool| tool.version.clone())
-                            .collect::<BTreeSet<_>>();
-
-                        let version_dirs = std::fs::read_dir(tool_dir.path()).map_err(|err| {
-                            UpError::Exec(format!(
-                                "failed to read data path directory for workdir {} and tool {}: {}",
-                                workdir_id, tool_dir_name, err,
-                            ))
-                        })?;
-
-                        for version_dir in version_dirs {
-                            let version_dir = version_dir.map_err(|err| {
-                                UpError::Exec(format!(
-                                    "failed to read data path directory for workdir {} and tool {}: {}",
-                                    workdir_id, tool_dir_name, err,
-                                ))
-                            })?;
-
-                            let version_dir_name =
-                                version_dir.file_name().to_string_lossy().to_string();
-
-                            // Remove the version directory if the version is not expected
-                            if !expected_versions.contains(&version_dir_name) {
-                                force_remove_dir_all(version_dir.path()).map_err(|err| {
-                                    UpError::Exec(format!(
-                                        "failed to remove workdir data path for workdir {}, tool {} and version {}: {}",
-                                        workdir_id, tool_dir_name, version_dir_name, err
-                                    ))
-                                })?;
-                                continue;
-                            }
-
-                            // Check the paths for that version
-                            let expected_paths = env_tools
-                                .iter()
-                                .filter(|tool| tool.tool == tool_dir_name)
-                                .filter(|tool| tool.version == version_dir_name)
-                                .filter_map(|tool| tool.data_path.clone())
-                                .filter_map(|path| {
-                                    PathBuf::from(&path)
-                                        .strip_prefix(&version_dir.path())
-                                        .map(|path| path.to_string_lossy().to_string())
-                                        .ok()
-                                })
-                                .collect::<BTreeSet<_>>();
-
-                            let path_dirs = std::fs::read_dir(version_dir.path()).map_err(|err| {
-                                UpError::Exec(format!(
-                                    "failed to read data path directory for workdir {}, tool {} and version {}: {}",
-                                    workdir_id, tool_dir_name, version_dir_name, err,
-                                ))
-                            })?;
-
-                            for path_dir in path_dirs {
-                                let path_dir = path_dir.map_err(|err| {
-                                    UpError::Exec(format!(
-                                        "failed to read data path directory for workdir {}, tool {} and version {}: {}",
-                                        workdir_id, tool_dir_name, version_dir_name, err,
-                                    ))
-                                })?;
-
-                                let path_dir_name =
-                                    path_dir.file_name().to_string_lossy().to_string();
-
-                                // Remove the path directory if the path is not expected
-                                if !expected_paths.contains(&path_dir_name) {
-                                    force_remove_dir_all(path_dir.path()).map_err(|err| {
-                                        UpError::Exec(format!(
-                                            "failed to remove workdir data path for workdir {}, tool {}, version {} and path {}: {}",
-                                            workdir_id, tool_dir_name, version_dir_name, path_dir_name, err
-                                        ))
-                                    })?;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         let expected_tools = env_tools
             .iter()
             .map(|tool| (tool.tool.clone(), tool.version.clone()))
             .collect::<HashSet<_>>();
 
         let mut uninstalled = Vec::new();
-        let write_cache = AsdfOperationCache::exclusive(|asdf_cache| {
+        if let Err(err) = AsdfOperationCache::exclusive(|asdf_cache| {
             // Update the asdf versions cache
             let mut updated = false;
             let mut to_remove = Vec::new();
@@ -960,22 +875,17 @@ impl UpConfigAsdfBase {
             }
 
             if to_remove.is_empty() {
-                if let Some(handler) = progress_handler {
-                    handler.success_with_message("nothing to do".to_string().light_black());
-                }
                 return updated;
             }
 
             for (idx, to_remove) in to_remove.iter().rev() {
                 if is_asdf_tool_version_installed(&to_remove.tool, &to_remove.version) {
-                    if let Some(handler) = progress_handler {
-                        handler.progress(format!(
-                            "uninstalling {} {}",
-                            to_remove.tool, to_remove.version,
-                        ));
-                    }
+                    progress_handler.progress(format!(
+                        "uninstalling {} {}",
+                        to_remove.tool, to_remove.version,
+                    ));
 
-                    let mut asdf_uninstall = tokio::process::Command::new(asdf_bin());
+                    let mut asdf_uninstall = TokioCommand::new(asdf_bin());
                     asdf_uninstall.arg("uninstall");
                     asdf_uninstall.arg(to_remove.tool.clone());
                     asdf_uninstall.arg(to_remove.version.clone());
@@ -984,15 +894,15 @@ impl UpConfigAsdfBase {
                     asdf_uninstall.stdout(std::process::Stdio::piped());
                     asdf_uninstall.stderr(std::process::Stdio::piped());
 
-                    if let Err(_err) =
-                        run_progress(&mut asdf_uninstall, progress_handler, RunConfig::default())
-                    {
-                        if let Some(handler) = progress_handler {
-                            handler.error_with_message(format!(
-                                "failed to uninstall {} {}",
-                                to_remove.tool, to_remove.version,
-                            ));
-                        }
+                    if let Err(_err) = run_progress(
+                        &mut asdf_uninstall,
+                        Some(progress_handler),
+                        RunConfig::default(),
+                    ) {
+                        progress_handler.error_with_message(format!(
+                            "failed to uninstall {} {}",
+                            to_remove.tool, to_remove.version,
+                        ));
                         return updated;
                     }
 
@@ -1004,28 +914,20 @@ impl UpConfigAsdfBase {
             }
 
             updated
-        });
-
-        if let Err(err) = write_cache {
-            if let Some(handler) = progress_handler {
-                handler.error_with_message(format!("failed to update cache: {}", err));
-            }
+        }) {
+            progress_handler.progress(format!("failed to update cache: {}", err));
             return Err(UpError::Exec("failed to update cache".to_string()));
         }
 
-        if let Some(handler) = progress_handler {
-            if !uninstalled.is_empty() {
-                let uninstalled = uninstalled
-                    .iter()
-                    .map(|tool| tool.light_blue().to_string())
-                    .collect::<Vec<_>>();
-                handler.success_with_message(format!("uninstalled {}", uninstalled.join(", ")));
-            } else {
-                handler.success_with_message("nothing to do".light_black());
-            }
+        if uninstalled.is_empty() {
+            Ok(None)
+        } else {
+            let uninstalled = uninstalled
+                .iter()
+                .map(|tool| tool.light_blue().to_string())
+                .collect::<Vec<_>>();
+            Ok(Some(format!("uninstalled {}", uninstalled.join(", "))))
         }
-
-        Ok(())
     }
 }
 

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -1,15 +1,22 @@
+use itertools::any;
+use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::cache::utils::Empty;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::config::up::utils::force_remove_dir_all;
+use crate::internal::config::up::utils::PrintProgressHandler;
+use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::dynenv::update_dynamic_env_for_command;
+use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::colors::StringColor;
 use crate::internal::workdir;
 use crate::omni_warning;
@@ -133,8 +140,7 @@ impl UpConfig {
             .steps
             .iter()
             .filter(|step| step.is_available())
-            .cloned()
-            .collect::<Vec<UpConfigTool>>();
+            .collect::<Vec<&UpConfigTool>>();
 
         // Go through the steps
         let num_steps = steps.len() + 1;
@@ -156,10 +162,8 @@ impl UpConfig {
             step.up(options, Some((idx + 1, num_steps)))?
         }
 
-        // This is a special case, as we could have multiple versions of
-        // a single tool loaded in the same repo we need to clean up
-        // the unused ones _at the end_ of the process
-        UpConfigAsdfBase::cleanup_unused(Some((num_steps, num_steps)))?;
+        // Cleanup anything that's not needed
+        self.cleanup(Some((num_steps, num_steps)))?;
 
         Ok(())
     }
@@ -170,8 +174,7 @@ impl UpConfig {
             .steps
             .iter()
             .filter(|step| step.is_available())
-            .cloned()
-            .collect::<Vec<UpConfigTool>>();
+            .collect::<Vec<&UpConfigTool>>();
 
         // Go through the steps, in reverse
         let num_steps = steps.len();
@@ -183,8 +186,176 @@ impl UpConfig {
             step.down(Some((idx + 1, num_steps)))?
         }
 
-        UpConfigAsdfBase::cleanup_unused(Some((num_steps, num_steps)))?;
+        // Cleanup anything that's not needed
+        self.cleanup(Some((num_steps, num_steps)))?;
 
         Ok(())
+    }
+
+    /// Cleanup anything that's not needed anymore; this will call the cleanup
+    /// method of every existing tool, so that it can cleanup dependencies from
+    /// steps that do not exist anymore on top of previous versions of recently
+    /// upgraded tools.
+    pub fn cleanup(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        let desc = "resources cleanup:".light_blue();
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
+            Box::new(SpinnerProgressHandler::new(desc, progress))
+        } else {
+            Box::new(PrintProgressHandler::new(desc, progress))
+        };
+        let progress_handler: &dyn ProgressHandler = progress_handler.as_ref();
+
+        let mut cleanups = vec![];
+
+        // Call cleanup on the different operation types
+        if let Some(cleanup) = UpConfigAsdfBase::cleanup(progress_handler)? {
+            cleanups.push(cleanup);
+        }
+        // TODO: call cleanup on homebrew
+
+        // Then cleanup the data path
+        if let Some(cleanup) = self.cleanup_data_path(progress_handler)? {
+            cleanups.push(cleanup);
+        }
+
+        if cleanups.is_empty() {
+            progress_handler.success_with_message("nothing to do".light_black());
+        } else {
+            progress_handler.success_with_message(cleanups.join(", "));
+        }
+
+        Ok(())
+    }
+
+    pub fn cleanup_data_path(
+        &self,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<Option<String>, UpError> {
+        let wd = workdir(".");
+        let wd_data_path = match wd.data_path() {
+            Some(data_path) => data_path,
+            None => return Ok(None),
+        };
+
+        // If the workdir data path does not exist, we're done
+        if !wd_data_path.exists() {
+            return Ok(None);
+        }
+
+        let expected_data_paths = self
+            .steps
+            .iter()
+            .filter(|step| step.is_available() && step.was_upped())
+            .map(|step| step.data_paths())
+            .flatten()
+            .filter(|data_path| data_path.starts_with(&wd_data_path))
+            .sorted()
+            .dedup()
+            .collect::<Vec<_>>();
+
+        // If there are no expected data paths, we can remove the workdir
+        // data path entirely
+        if expected_data_paths.is_empty() {
+            force_remove_dir_all(wd_data_path).map_err(|err| {
+                UpError::Exec(format!(
+                    "failed to remove workdir data path {}: {}",
+                    wd_data_path.display(),
+                    err
+                ))
+            })?;
+
+            return Ok(Some("removed workdir data path".to_string()));
+        }
+
+        // If there are expected paths, we want to do a breadth-first search
+        // so that we can remove paths fast when they are not expected; we
+        // can stop in depth when we find a path that is expected (since it
+        // means that any deeper path is also expected)
+        let mut known_unknown_paths = vec![];
+        let mut num_removed = 0;
+        for entry in walkdir::WalkDir::new(&wd_data_path)
+            .into_iter()
+            .filter_entry(|e| {
+                // If the path is the root, we want to keep it
+                if e.path() == wd_data_path {
+                    return true;
+                }
+
+                // Check if the path is known, in which case we can skip it
+                // and its children
+                if any(expected_data_paths.iter(), |expected_data_path| {
+                    e.path() == *expected_data_path
+                }) {
+                    return false;
+                }
+
+                // If we're here, the path is not known, but we want to keep
+                // digging if it is the beginning of a known path; we will need
+                // to filter those paths out after
+                if any(expected_data_paths.iter(), |expected_data_path| {
+                    expected_data_path.starts_with(e.path())
+                }) {
+                    return true;
+                }
+
+                // If we're here, the path is not known and is not the beginning
+                // of a known path, so we want to keep it as it will need to get
+                // removed; however, we don't want to dig indefinitely, so we will
+                // keep track of paths that we already marked as unknown, so we
+                // can skip their children
+                if any(known_unknown_paths.iter(), |unknown_path| {
+                    e.path().starts_with(unknown_path)
+                }) {
+                    return false;
+                }
+
+                // If we're here, the path is not known and is not the beginning
+                // of a known path, so we want to keep it as it will need to get
+                known_unknown_paths.push(e.path().to_path_buf());
+                return true;
+            })
+            .filter_map(|e| e.ok())
+            // Filter the parents of known paths since we don't want to remove them
+            .filter(|e| {
+                !any(expected_data_paths.iter(), |expected_data_path| {
+                    expected_data_path.starts_with(e.path())
+                })
+            })
+        {
+            let path = entry.path();
+
+            progress_handler.progress(format!("removing {}", path.display()));
+
+            if path.is_file() {
+                if let Err(error) = std::fs::remove_file(&path) {
+                    return Err(UpError::Exec(format!(
+                        "failed to remove {}: {}",
+                        path.display(),
+                        error
+                    )));
+                }
+                num_removed += 1;
+            } else if path.is_dir() {
+                force_remove_dir_all(path).map_err(|err| {
+                    UpError::Exec(format!("failed to remove{}: {}", path.display(), err))
+                })?;
+                num_removed += 1;
+            } else {
+                return Err(UpError::Exec(format!(
+                    "unexpected path type: {}",
+                    path.display()
+                )));
+            }
+        }
+
+        if num_removed == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(format!(
+            "removed {} entr{} from the data path",
+            num_removed.to_string().light_yellow(),
+            if num_removed > 1 { "ies" } else { "y" }
+        )))
     }
 }

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -246,9 +246,8 @@ impl UpConfig {
             .steps
             .iter()
             .filter(|step| step.is_available() && step.was_upped())
-            .map(|step| step.data_paths())
-            .flatten()
-            .filter(|data_path| data_path.starts_with(&wd_data_path))
+            .flat_map(|step| step.data_paths())
+            .filter(|data_path| data_path.starts_with(wd_data_path))
             .sorted()
             .dedup()
             .collect::<Vec<_>>();
@@ -273,7 +272,7 @@ impl UpConfig {
         // means that any deeper path is also expected)
         let mut known_unknown_paths = vec![];
         let mut num_removed = 0;
-        for entry in walkdir::WalkDir::new(&wd_data_path)
+        for entry in walkdir::WalkDir::new(wd_data_path)
             .into_iter()
             .filter_entry(|e| {
                 // If the path is the root, we want to keep it
@@ -312,7 +311,7 @@ impl UpConfig {
                 // If we're here, the path is not known and is not the beginning
                 // of a known path, so we want to keep it as it will need to get
                 known_unknown_paths.push(e.path().to_path_buf());
-                return true;
+                true
             })
             .filter_map(|e| e.ok())
             // Filter the parents of known paths since we don't want to remove them
@@ -327,7 +326,7 @@ impl UpConfig {
             progress_handler.progress(format!("removing {}", path.display()));
 
             if path.is_file() {
-                if let Err(error) = std::fs::remove_file(&path) {
+                if let Err(error) = std::fs::remove_file(path) {
                     return Err(UpError::Exec(format!(
                         "failed to remove {}: {}",
                         path.display(),

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -119,6 +119,16 @@ impl UpConfigGolang {
         self.asdf_base()?.down(progress)
     }
 
+    pub fn was_upped(&self) -> bool {
+        self.asdf_base()
+            .map_or(false, |asdf_base| asdf_base.was_upped())
+    }
+
+    pub fn data_paths(&self) -> Vec<PathBuf> {
+        self.asdf_base()
+            .map_or(vec![], |asdf_base| asdf_base.data_paths())
+    }
+
     pub fn asdf_base(&self) -> Result<&UpConfigAsdfBase, UpError> {
         self.asdf_base.get_or_try_init(|| {
             let version = if let Some(version) = &self.version {

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -16,6 +16,9 @@ pub(crate) use custom::UpConfigCustom;
 pub(crate) mod golang;
 pub(crate) use golang::UpConfigGolang;
 
+pub(crate) mod nix;
+pub(crate) use nix::UpConfigNix;
+
 pub(crate) mod nodejs;
 pub(crate) use nodejs::UpConfigNodejs;
 

--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -1,0 +1,607 @@
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use duct::cmd;
+use itertools::Itertools;
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::process::Command as TokioCommand;
+
+use crate::internal::cache::CacheObject;
+use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::commands::utils::abs_path;
+use crate::internal::config::parser::EnvOperationEnum;
+use crate::internal::config::up::utils::run_progress;
+use crate::internal::config::up::utils::PrintProgressHandler;
+use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
+use crate::internal::config::ConfigValue;
+use crate::internal::env::current_dir;
+use crate::internal::env::shell_is_interactive;
+use crate::internal::user_interface::StringColor;
+use crate::internal::workdir;
+use crate::omni_warning;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct UpConfigNix {
+    /// List of nix packages to install.
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<String>,
+
+    /// Path to a nix file to use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nixfile: Option<String>,
+
+    /// Path to the nix profile that was configured.
+    #[serde(skip)]
+    pub profile_path: OnceCell<PathBuf>,
+}
+
+impl UpConfigNix {
+    /// Parse the configuration value into a `UpConfigNix` struct.
+    ///
+    /// The following are all valid ways to specify nix dependencies:
+    /// ```yaml
+    /// # Installing nix packages
+    /// up:
+    /// - nix:
+    ///   - gcc
+    ///   - gnused
+    ///   - ...
+    ///
+    /// # Also valid, using the 'packages' key
+    /// up:
+    /// - nix:
+    ///    packages:
+    ///    - gcc
+    ///    - gnused
+    ///    - ...
+    ///
+    /// # Or specifying a nix file
+    /// up:
+    /// - nix: "shell.nix"
+    ///
+    /// # Also valid, using the file key; note that the 'packages' key
+    /// # will be ignored if a nix file is specified
+    /// up:
+    /// - nix:
+    ///     file: "shell.nix"
+    ///
+    /// # Finally, using the default configuration, which will look for
+    /// # a `shell.nix` or `default.nix` file in the current directory.
+    /// # Note that if no nix file is found, the operation will fail.
+    /// up:
+    /// - nix
+    /// ```
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        if let Some(config_value) = config_value {
+            if let Some(table) = config_value.as_table() {
+                if let Some(nixfile) = table.get("file") {
+                    if let Some(nixfile) = nixfile.as_str_forced() {
+                        return UpConfigNix {
+                            packages: Vec::new(),
+                            nixfile: Some(nixfile.to_string()),
+                            profile_path: OnceCell::new(),
+                        };
+                    }
+                }
+
+                if let Some(packages) = table.get("packages") {
+                    if let Some(pkg_array) = packages.as_array() {
+                        return UpConfigNix {
+                            packages: pkg_array
+                                .iter()
+                                .filter_map(|v| v.as_str_forced())
+                                .collect::<Vec<_>>(),
+                            nixfile: None,
+                            profile_path: OnceCell::new(),
+                        };
+                    }
+                }
+            } else if let Some(pkg_array) = config_value.as_array() {
+                return UpConfigNix {
+                    packages: pkg_array
+                        .iter()
+                        .filter_map(|v| v.as_str_forced())
+                        .collect::<Vec<_>>(),
+                    nixfile: None,
+                    profile_path: OnceCell::new(),
+                };
+            } else if let Some(nixfile) = config_value.as_str_forced() {
+                return UpConfigNix {
+                    packages: Vec::new(),
+                    nixfile: Some(nixfile.to_string()),
+                    profile_path: OnceCell::new(),
+                };
+            }
+        }
+
+        UpConfigNix::default()
+    }
+
+    pub fn up(
+        &self,
+        _options: &UpOptions,
+        progress: Option<(usize, usize)>,
+    ) -> Result<(), UpError> {
+        let wd = workdir(".");
+        let wd_root = match wd.root() {
+            Some(wd_root) => PathBuf::from(wd_root),
+            None => {
+                let msg = format!(
+                    "failed to get work directory root for {}",
+                    current_dir().display()
+                );
+                return Err(UpError::Exec(msg));
+            }
+        };
+
+        let nixfile = if let Some(nixfile) = &self.nixfile {
+            Some(abs_path(nixfile))
+        } else if !self.packages.is_empty() {
+            None
+        } else {
+            let mut nixfile = None;
+
+            for file in &["shell.nix", "default.nix"] {
+                let absfile = wd_root.join(file);
+                if absfile.exists() && absfile.is_file() {
+                    nixfile = Some(absfile);
+                    break;
+                }
+            }
+
+            // If no nix file was found, we fail, since if there is a `nix` step
+            // we expect to have to install some dependencies.
+            match nixfile {
+                Some(nixfile) => Some(abs_path(&nixfile)),
+                None => {
+                    return Err(UpError::Exec(format!(
+                        "no nix file found in {}",
+                        wd_root.display()
+                    )))
+                }
+            }
+        };
+
+        if let Some(nixfile) = &nixfile {
+            // Check if path is in current dir
+            if !nixfile.starts_with(&wd_root) {
+                return Err(UpError::Exec(format!(
+                    "file {} is not in work directory",
+                    nixfile.display()
+                )));
+            }
+        }
+
+        // Prepare the progress handler
+        let desc = format!(
+            "nix ({}):",
+            match &nixfile {
+                Some(nixfile) => match nixfile.file_name() {
+                    Some(file_name) => file_name.to_string_lossy().to_string(),
+                    None => "nixfile".to_string(),
+                },
+                None => "packages".to_string(),
+            }
+        )
+        .light_blue();
+        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
+            Box::new(SpinnerProgressHandler::new(desc, progress))
+        } else {
+            Box::new(PrintProgressHandler::new(desc, progress))
+        };
+        let progress_handler: &dyn ProgressHandler = progress_handler.as_ref();
+
+        // Generate a profile id either by hashing the list of packages
+        // or the contents of the nix file.
+        let mut config_hasher = blake3::Hasher::new();
+        let profile_suffix = if let Some(nixfile) = &nixfile {
+            // Load the file contents into the hasher
+            match std::fs::read(nixfile) {
+                Ok(contents) => config_hasher.update(&contents),
+                Err(e) => {
+                    let msg = format!("failed to read nix file: {}", e);
+                    return Err(UpError::Exec(msg));
+                }
+            };
+
+            match nixfile.file_name() {
+                Some(file_name) => file_name.to_string_lossy().to_string(),
+                None => "nixfile".to_string(),
+            }
+        } else {
+            // Get a hash of the sorted, unique list of packages
+            let mut packages = BTreeSet::new();
+            packages.extend(self.packages.iter());
+            let packages = packages.iter().join("\n");
+            config_hasher.update(packages.as_bytes());
+
+            "pkgs".to_string()
+        };
+        let profile_hash = config_hasher.finalize().to_hex()[..16].to_string();
+        let profile_id = format!("profile-{}-{}", profile_suffix, profile_hash);
+
+        // Generate the full path to the permanent nix profile
+        let data_path = match wd.data_path() {
+            Some(data_path) => data_path,
+            None => {
+                let msg = format!("failed to get data path for {}", current_dir().display());
+                progress_handler.error_with_message(msg.clone());
+                return Err(UpError::Exec(msg));
+            }
+        };
+        let nix_path = data_path.join("nix");
+        let profile_path = nix_path.join(&profile_id);
+
+        // If the profile already exists, we don't need to do anything
+        // NOTE: should this be skipped when using --no-cache?
+        if profile_path.exists() {
+            if let Err(e) = self.profile_path.set(profile_path) {
+                omni_warning!(format!("failed to save nix profile path: {:?}", e));
+            }
+
+            self.update_cache(progress_handler)?;
+
+            progress_handler.success_with_message("already configured".light_black());
+            return Ok(());
+        }
+
+        // We want to generate a nix profile from either the package or the nix file;
+        // we do that first in a temporary directory so that if any issue happens, we
+        // don't overwrite the permanent file for now, protecting against an unexpected
+        // garbage collection.
+        //
+        // We want to call:
+        //    nix --extra-experimental-features "nix-command flakes" \
+        //          print-dev-env --profile "$tmp_profile" --impure $expression
+        //
+        // Where $expression is either:
+        //  - For a nixfile:
+        //      --file "$nixfile"
+        //  - For a nixfile with attribute:
+        //      --expr "(import ${nixfile} {}).${attribute}"
+        //      Where attribute is a string that can be either: "devShell", "shell", "buildInputs", etc.
+        //  - For a list of packages:
+        //      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }"
+        //  - For multiple files: (to verify)
+        //      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ (import ./file1.nix {}) (import ./file2.nix {}) ]; }"
+
+        // Generate a temporary file to store the nix profile, we want a directory as
+        // a second file will be generated in the same directory as our temp profile,
+        // and we want to remove both of them once we're done. Using a temporary
+        // directory will make sure that the directory is removed automatically
+        // with all its content.
+        let tmp_dir = match tempfile::Builder::new().prefix("omni_up_nix.").tempdir() {
+            Ok(tmp_dir) => tmp_dir,
+            Err(e) => {
+                let msg = format!("failed to create temporary directory: {}", e);
+                progress_handler.error_with_message(msg.clone());
+                return Err(UpError::Exec(msg));
+            }
+        };
+        let tmp_profile = tmp_dir.path().join("profile");
+
+        progress_handler.progress("preparing nix environment".to_string());
+
+        let mut nix_print_dev_env = TokioCommand::new("nix");
+        nix_print_dev_env.stdout(std::process::Stdio::piped());
+        nix_print_dev_env.stderr(std::process::Stdio::piped());
+        nix_print_dev_env.arg("--extra-experimental-features");
+        nix_print_dev_env.arg("nix-command flakes");
+        nix_print_dev_env.arg("print-dev-env");
+        nix_print_dev_env.arg("--verbose");
+        nix_print_dev_env.arg("--print-build-logs");
+        nix_print_dev_env.arg("--profile");
+        nix_print_dev_env.arg(&tmp_profile);
+        nix_print_dev_env.arg("--impure");
+
+        let mut packages_message = String::new();
+        if let Some(nixfile) = &self.nixfile {
+            nix_print_dev_env.arg("--file");
+            nix_print_dev_env.arg(&nixfile);
+            packages_message = format!("packages from {}", nixfile.light_yellow());
+        } else if !self.packages.is_empty() {
+            let mut context = tera::Context::new();
+            context.insert("packages", &self.packages.join(" "));
+            let tmpl = r#"with import <nixpkgs> {}; mkShell { buildInputs = [ {{ packages }} ]; }"#;
+            let expr = match tera::Tera::one_off(tmpl, &context, false) {
+                Ok(expr) => expr,
+                Err(e) => {
+                    let msg = format!("failed to render nix expression: {}", e);
+                    progress_handler.error_with_message(msg.clone());
+                    return Err(UpError::Exec(msg));
+                }
+            };
+
+            nix_print_dev_env.arg("--expr");
+            nix_print_dev_env.arg(&expr);
+            packages_message = format!(
+                "{} package{}",
+                self.packages.len().to_string().light_yellow(),
+                if self.packages.len() > 1 { "s" } else { "" },
+            );
+        } else {
+            // Look for default nix files 'shell.nix' and 'default.nix'
+            // We want to behave similarly as nix-shell, which looks for 'shell.nix'
+            // first but if not found will default to 'default.nix'
+            let mut found = false;
+            for file in &["shell.nix", "default.nix"] {
+                let nixfile = wd_root.join(file);
+                // Check if exists and is file
+                if nixfile.exists() && nixfile.is_file() {
+                    nix_print_dev_env.arg("--file");
+                    nix_print_dev_env.arg(&nixfile);
+                    packages_message = format!("packages from {}", file.light_yellow());
+                    found = true;
+                    break;
+                }
+            }
+
+            // If no nix file was found, we fail, since if there is a `nix` step
+            // we expect to have to install some dependencies.
+            if !found {
+                let msg = format!("no nix file found in {}", wd_root.display());
+                progress_handler.error_with_message(msg.clone());
+                return Err(UpError::Exec(msg));
+            }
+        }
+        progress_handler.progress(format!("installing {}", packages_message));
+
+        let result = run_progress(
+            &mut nix_print_dev_env,
+            Some(progress_handler),
+            RunConfig::default(),
+        );
+        if let Err(e) = result {
+            let msg = format!("failed to install nix packages: {}", e);
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        // Now we want to build the nix profile and add it to the gcroots
+        // so that the packages don't get garbage collected.
+        //
+        // We want to call:
+        //      nix --extra-experimental-features "nix-command flakes" \
+        //          build --out-link "$perm_profile" "$tmp_profile"
+        //
+        // And we will put the permanent profile in the data directory
+        // of the work directory, so that its life is tied to the work
+        // directory cache.
+
+        progress_handler.progress("protecting dependencies with gcroots".to_string());
+
+        let mut nix_build = TokioCommand::new("nix");
+        nix_build.arg("--extra-experimental-features");
+        nix_build.arg("nix-command flakes");
+        nix_build.arg("build");
+        nix_build.arg("--print-out-paths");
+        nix_build.arg("--out-link");
+        nix_build.arg(&profile_path);
+        nix_build.arg(&tmp_profile);
+        nix_build.stdout(std::process::Stdio::piped());
+        nix_build.stderr(std::process::Stdio::piped());
+
+        let result = run_progress(&mut nix_build, Some(progress_handler), RunConfig::default());
+        if let Err(e) = result {
+            let msg = format!("failed to build nix profile: {}", e);
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        if let Err(e) = self.profile_path.set(profile_path) {
+            omni_warning!(format!("failed to save nix profile path: {:?}", e));
+        }
+
+        self.update_cache(progress_handler)?;
+
+        // We are all done, the temporary directory will be removed automatically,
+        // so we don't need to worry about it, hence removing our temporary profile
+        // for us.
+        progress_handler.success_with_message(format!("installed {}", packages_message));
+
+        Ok(())
+    }
+
+    pub fn down(&self, _progress: Option<(usize, usize)>) -> Result<(), UpError> {
+        // At the end of the 'down' operation, the work directory cache will be
+        // wiped. Cleaning dependencies for nix just means removing the gcroots
+        // file, so we don't need to do anything here since it will be removed
+        // with the cache directory.
+
+        Ok(())
+    }
+
+    fn update_cache(&self, progress_handler: &dyn ProgressHandler) -> Result<(), UpError> {
+        // Get the nix profile path
+        let profile_path = match self.profile_path.get() {
+            Some(profile_path) => profile_path,
+            None => {
+                return Err(UpError::Exec("nix profile path not set".to_string()));
+            }
+        };
+
+        // Load it into a nix profile struct
+        let profile = match NixProfile::from_file(profile_path) {
+            Ok(profile) => profile,
+            Err(e) => {
+                return Err(UpError::Exec(format!("failed to load nix profile: {}", e)));
+            }
+        };
+
+        let paths = profile.get_paths();
+        let cflags = profile.get_cflags();
+        let ldflags = profile.get_ldflags();
+        let pkg_config_paths = profile.get_pkg_config_paths();
+
+        if paths.is_empty() && cflags.is_none() && ldflags.is_none() && pkg_config_paths.is_empty()
+        {
+            return Ok(());
+        }
+
+        let wd = workdir(".");
+        let wd_id = match wd.id() {
+            Some(wd_id) => wd_id,
+            None => {
+                return Err(UpError::Exec(format!(
+                    "failed to get work directory id for {}",
+                    current_dir().display()
+                )));
+            }
+        };
+
+        progress_handler.progress("updating cache".to_string());
+
+        if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
+            if !paths.is_empty() {
+                up_env.add_paths(&wd_id, profile.get_paths());
+            }
+
+            if let Some(cflags) = cflags {
+                up_env.add_env_var_operation(&wd_id, "CFLAGS", &cflags, EnvOperationEnum::Suffix);
+                up_env.add_env_var_operation(&wd_id, "CPPFLAGS", &cflags, EnvOperationEnum::Suffix);
+            }
+
+            if let Some(ldflags) = ldflags {
+                up_env.add_env_var_operation(&wd_id, "LDFLAGS", &ldflags, EnvOperationEnum::Suffix);
+            }
+
+            for pkg_config_path in pkg_config_paths.iter().rev() {
+                up_env.add_env_var_operation(
+                    &wd_id,
+                    "PKG_CONFIG_PATH",
+                    &pkg_config_path,
+                    EnvOperationEnum::Prepend,
+                );
+            }
+
+            true
+        }) {
+            progress_handler.progress(format!("failed to update cache: {}", err));
+        }
+
+        progress_handler.progress("cache updated".to_string());
+
+        Ok(())
+    }
+
+    pub fn is_available(&self) -> bool {
+        if cmd!("command", "-v", "nix")
+            .stdout_null()
+            .stderr_null()
+            .run()
+            .is_ok()
+        {
+            return true;
+        }
+        false
+    }
+
+    pub fn was_upped(&self) -> bool {
+        matches!(self.profile_path.get(), Some(_))
+    }
+
+    pub fn data_paths(&self) -> Vec<PathBuf> {
+        match self.profile_path.get() {
+            Some(profile_path) => vec![profile_path.clone()],
+            None => vec![],
+        }
+    }
+}
+
+/// NixProfile is a structure that allows to deserialize a nix profile
+/// so that we can extract the environment variables and paths from it.
+#[derive(Debug, Deserialize)]
+struct NixProfile {
+    pub variables: HashMap<String, NixProfileVariable>,
+}
+
+impl NixProfile {
+    fn from_file(profile_path: &PathBuf) -> Result<Self, UpError> {
+        let file = match std::fs::File::open(profile_path) {
+            Ok(file) => file,
+            Err(e) => {
+                return Err(UpError::Exec(format!("failed to open nix profile: {}", e)));
+            }
+        };
+
+        let profile: NixProfile = match serde_json::from_reader(file) {
+            Ok(profile) => profile,
+            Err(e) => {
+                return Err(UpError::Exec(format!("failed to parse nix profile: {}", e)));
+            }
+        };
+
+        Ok(profile)
+    }
+
+    fn get_paths(&self) -> Vec<PathBuf> {
+        ["pkgsHostTarget", "pkgsHostHost"]
+            .iter()
+            .filter_map(|key| self.variables.get(key.to_string().as_str()))
+            .filter_map(|pkg| match pkg {
+                NixProfileVariable::Array { value, .. } => Some(value),
+                _ => None,
+            })
+            .flatten()
+            .dedup()
+            .map(|path| PathBuf::from(path).join("bin"))
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>()
+    }
+
+    fn get_cflags(&self) -> Option<String> {
+        self.get_var("NIX_CFLAGS_COMPILE_FOR_TARGET")
+    }
+
+    fn get_ldflags(&self) -> Option<String> {
+        self.get_var("NIX_LDFLAGS_FOR_TARGET")
+    }
+
+    fn get_pkg_config_paths(&self) -> Vec<String> {
+        match self.get_var("PKG_CONFIG_PATH_FOR_TARGET") {
+            Some(pkg_config_path) => pkg_config_path
+                .split(':')
+                .map(|path| path.to_string())
+                .collect::<Vec<_>>(),
+            None => Vec::new(),
+        }
+    }
+
+    fn get_var(&self, key: &str) -> Option<String> {
+        match self.variables.get(key) {
+            Some(var) => match var {
+                NixProfileVariable::Var { value, .. } => Some(value.to_string()),
+                _ => None,
+            },
+            None => None,
+        }
+    }
+}
+
+/// NixProfileVariable is a structure representing one of the variables
+/// in a nix profile, that can either be a string or an array of strings.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum NixProfileVariable {
+    Var {
+        #[allow(dead_code)]
+        r#type: String,
+        value: String,
+    },
+    Array {
+        #[allow(dead_code)]
+        r#type: String,
+        value: Vec<String>,
+    },
+    Unknown {
+        #[allow(dead_code)]
+        r#type: String,
+    },
+}

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-homebrew.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-homebrew.md
@@ -90,3 +90,11 @@ up:
       install:
         - omni
 ```
+
+## Dynamic environment
+
+The following variables will be set as part of the [dynamic environment](/reference/dynamic-environment).
+
+| Environment variable | Operation | Description |
+|----------------------|-----------|-------------|
+| `PATH` | prepend | For formulas, uses `$(brew --prefix --installed <formula>)/bin`; for casks, adds any `bin` directory containing at least one executable in the `$(brew --prefix)/Caskroom/<cask>` directory; in both cases, also injects the `$(brew --prefix)/bin` directory |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-nix.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-nix.md
@@ -1,0 +1,53 @@
+---
+description: Configuration of the `nix` kind of `up` parameter
+---
+
+# `nix` operation
+
+Installs nix packages and loads them into the environment.
+
+Similarly to [`nix-direnv`](https://github.com/nix-community/nix-direnv), this prevents garbage collection of dependencies by symlinking the resulting shell derivation in the user's gcroots.
+
+:::info
+If `nix` is not available on the system, this step will be ignored.
+:::
+
+## Parameters
+
+Contains a list of objects with the following parameters:
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `package` | string | The name of the package to install |
+| `version` | string | The version to install for the package |
+
+## Examples
+
+```yaml
+up:
+  # Will look for `shell.nix` or `default.nix` at the
+  # root of the work directory and use it to build
+  # dependencies
+  - nix
+
+  # Will install the listed packages
+  - nix:
+    - gawk
+    - gcc
+    - gnused
+
+  # Will install the packages defined in `file.nix`
+  - nix: file.nix
+```
+
+## Dynamic environment
+
+The following variables will be set as part of the [dynamic environment](/reference/dynamic-environment).
+
+| Environment variable | Operation | Description |
+|----------------------|-----------|-------------|
+| `CFLAGS` | suffix | The flags read from the `NIX_CFLAGS_COMPILE_FOR_TARGET` variable in the `nix` derivation |
+| `CPPFLAGS` | suffix | The flags read from the `NIX_CFLAGS_COMPILE_FOR_TARGET` variable in the `nix` derivation |
+| `LDFLAGS` | suffix | The flags read from the `NIX_LDFLAGS` variable in the `nix` derivation |
+| `PATH` | prepend | The `bin` directories for all the packages, read from the `pkgsHostTarget` and `pkgsHostHost` variables in the `nix` derivation |
+| `PKG_CONFIG_PATH` | append | The `pkgconfig` read from the `PKG_CONFIG_PATH_FOR_TARGET` variable in the `nix` derivation |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
@@ -20,6 +20,7 @@ Each entry in the list can either be a single string (loads the operation with d
 | `dnf` | [dnf](up/dnf) | Install packages with `dnf` for fedora-based systems |
 | `go` | [go](up/go) | Install go |
 | `homebrew`  | [Homebrew](up/homebrew) | Install formulae and casks with homebrew |
+| `nix` | [nix](up/nix) | Install packages with `nix` |
 | `node` | [node](up/node) | Install node |
 | `pacman` | [pacman](up/pacman) | Install packages with `pacman` for arch-based systems |
 | `python` | [python](up/python) | Install python |


### PR DESCRIPTION
This adds support for the nix operation to install dependencies.

This creates a profile with the required packages (or from a specified nix file) and symlink its derivation into the gcroots to prevent nix garbage collection to kick-in for required packages.

Closes https://github.com/XaF/omni/issues/414