### PR TITLE
feat(up): ✨ add dependencies handling and 'or' and 'and' operations

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -848,7 +848,7 @@ impl UpConfigAsdfBase {
         }
 
         // Add also all data paths from dependencies
-        data_paths.extend(self.deps().data_paths().into_iter());
+        data_paths.extend(self.deps().data_paths());
 
         data_paths.into_iter().collect()
     }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -18,17 +18,20 @@ use walkdir::WalkDir;
 use crate::internal::cache::AsdfOperationCache;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::config::up::homebrew::HomebrewInstall;
 use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::run_progress;
-use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
-use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::config::up::utils::UpProgressHandler;
+use crate::internal::config::up::UpConfigHomebrew;
+use crate::internal::config::up::UpConfigNix;
+use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
+use crate::internal::dynenv::update_dynamic_env_for_command;
 use crate::internal::env::data_home;
-use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::omni_error;
@@ -208,6 +211,10 @@ pub struct UpConfigAsdfBase {
     /// been attempted yet.
     #[serde(skip)]
     up_succeeded: OnceCell<bool>,
+
+    /// The tool object representing the dependencies for this asdf tool.
+    #[serde(skip)]
+    deps: OnceCell<Box<UpConfigTool>>,
 }
 
 impl UpConfigAsdfBase {
@@ -223,6 +230,7 @@ impl UpConfigAsdfBase {
             actual_versions: OnceCell::new(),
             config_value: None,
             up_succeeded: OnceCell::new(),
+            deps: OnceCell::new(),
         }
     }
 
@@ -242,6 +250,7 @@ impl UpConfigAsdfBase {
             dirs: dirs.clone(),
 
             up_succeeded: OnceCell::new(),
+            deps: OnceCell::new(),
 
             // We can ignore all those fields, as they won't be used,
             // since the version passed to that call is a specific version
@@ -320,6 +329,7 @@ impl UpConfigAsdfBase {
             actual_versions: OnceCell::new(),
             config_value: config_value.cloned(),
             up_succeeded: OnceCell::new(),
+            deps: OnceCell::new(),
         }
     }
 
@@ -362,12 +372,16 @@ impl UpConfigAsdfBase {
         progress_handler.progress("updated cache".to_string());
     }
 
-    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
         if self.up_succeeded.get().is_some() {
             return Err(UpError::Exec("up operation already attempted".to_string()));
         }
 
-        let result = self.run_up(options, progress);
+        let result = self.run_up(options, progress_handler);
         if let Err(err) = self.up_succeeded.set(result.is_ok()) {
             omni_warning!(format!("failed to record status of up operation: {}", err));
         }
@@ -381,16 +395,15 @@ impl UpConfigAsdfBase {
 
     fn run_up(
         &self,
-        _options: &UpOptions,
-        progress: Option<(usize, usize)>,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
-        let desc = format!("{} ({}):", self.tool, self.version).light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, progress))
-        };
-        let progress_handler: &dyn ProgressHandler = progress_handler.as_ref();
+        progress_handler.init(format!("{} ({}):", self.tool, self.version).light_blue());
+
+        // Make sure that dependencies are installed
+        let subhandler = progress_handler.subhandler(&"deps: ".light_black());
+        self.deps().up(options, &subhandler)?;
+        update_dynamic_env_for_command(".");
 
         if let Err(err) = install_asdf(progress_handler) {
             progress_handler.error_with_message(format!("error: {}", err));
@@ -612,8 +625,8 @@ impl UpConfigAsdfBase {
         }
     }
 
-    pub fn down(&self, _progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        Ok(())
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        self.deps().down(progress_handler)
     }
 
     fn version(&self, progress_handler: Option<&dyn ProgressHandler>) -> Result<&String, UpError> {
@@ -834,6 +847,9 @@ impl UpConfigAsdfBase {
             data_paths.insert(tool_data_path.join(&hashed_dir));
         }
 
+        // Add also all data paths from dependencies
+        data_paths.extend(self.deps().data_paths().into_iter());
+
         data_paths.into_iter().collect()
     }
 
@@ -928,6 +944,87 @@ impl UpConfigAsdfBase {
                 .collect::<Vec<_>>();
             Ok(Some(format!("uninstalled {}", uninstalled.join(", "))))
         }
+    }
+
+    fn deps(&self) -> &UpConfigTool {
+        self.deps
+            .get_or_init(|| {
+                let deps: Vec<UpConfigTool> = vec![
+                    // TODO: Add a way to specify the preferred package manager, so
+                    // we can order the dependencies handling based on that
+                    self.deps_using_homebrew(),
+                    self.deps_using_nix(),
+                ];
+
+                Box::new(UpConfigTool::Or(deps))
+            })
+            .as_ref()
+    }
+
+    fn deps_using_homebrew(&self) -> UpConfigTool {
+        let mut homebrew_install = vec![
+            HomebrewInstall::new_formula("autoconf"),
+            // HomebrewInstall::new_formula("automake"),
+            HomebrewInstall::new_formula("coreutils"),
+            HomebrewInstall::new_formula("curl"),
+            // HomebrewInstall::new_formula("libtool"),
+            HomebrewInstall::new_formula("libyaml"),
+            HomebrewInstall::new_formula("openssl@3"),
+            HomebrewInstall::new_formula("readline"),
+            // HomebrewInstall::new_formula("unixodbc"),
+        ];
+
+        match self.tool.as_str() {
+            "python" => {
+                homebrew_install.extend(vec![
+                    HomebrewInstall::new_formula("pkg-config"),
+                    // HomebrewInstall::new_formula("sqlite"),
+                    // HomebrewInstall::new_formula("xz"),
+                ]);
+            }
+            "rust" => {
+                homebrew_install.extend(vec![
+                    HomebrewInstall::new_formula("libgit2"),
+                    HomebrewInstall::new_formula("libssh2"),
+                    HomebrewInstall::new_formula("llvm"),
+                    HomebrewInstall::new_formula("pkg-config"),
+                ]);
+            }
+            _ => {}
+        }
+
+        UpConfigTool::Homebrew(UpConfigHomebrew {
+            install: homebrew_install,
+            tap: vec![],
+        })
+    }
+
+    fn deps_using_nix(&self) -> UpConfigTool {
+        let mut nix_packages = vec!["gawk", "gnused", "openssl", "readline"];
+
+        match self.tool.as_str() {
+            "python" => {
+                nix_packages.extend(vec![
+                    "bzip2",
+                    "gcc",
+                    "gnumake",
+                    "libffi",
+                    "lzma",
+                    "ncurses",
+                    "pkg-config",
+                    "sqlite",
+                    "zlib",
+                ]);
+            }
+            "ruby" => {
+                nix_packages.extend(vec!["libyaml"]);
+            }
+            _ => {}
+        }
+
+        UpConfigTool::Nix(UpConfigNix::new_from_packages(
+            nix_packages.into_iter().map(|p| p.to_string()).collect(),
+        ))
     }
 }
 

--- a/src/internal/config/up/bundler.rs
+++ b/src/internal/config/up/bundler.rs
@@ -8,13 +8,11 @@ use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::config::up::utils::run_progress;
-use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
-use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::ConfigValue;
-use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 
@@ -46,7 +44,7 @@ impl UpConfigBundler {
         UpConfigBundler { gemfile, path }
     }
 
-    fn update_cache(&self, progress_handler: Option<&dyn ProgressHandler>) {
+    fn update_cache(&self, progress_handler: &dyn ProgressHandler) {
         let workdir = workdir(".");
         let workdir_id = workdir.id();
         if workdir_id.is_none() {
@@ -54,35 +52,24 @@ impl UpConfigBundler {
         }
         let workdir_id = workdir_id.unwrap();
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updating cache".to_string())
-        }
+        progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
             up_env.add_env_var(&workdir_id, "BUNDLE_GEMFILE", &self.gemfile_abs_path());
             true
         }) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.progress(format!("failed to update cache: {}", err))
-            }
-        } else if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updated cache".to_string())
+            progress_handler.progress(format!("failed to update cache: {}", err));
+        } else {
+            progress_handler.progress("updated cache".to_string());
         }
     }
 
-    pub fn up(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        let desc = "install Gemfile dependencies:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+    pub fn up(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        progress_handler.init("bundler".light_blue());
+        progress_handler.progress("install Gemfile dependencies".to_string());
 
         if let Some(path) = &self.path {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.progress("setting bundle path".to_string())
-            }
+            progress_handler.progress("setting bundle path".to_string());
 
             let mut bundle_config = TokioCommand::new("bundle");
             bundle_config.arg("config");
@@ -92,12 +79,14 @@ impl UpConfigBundler {
             bundle_config.stdout(std::process::Stdio::piped());
             bundle_config.stderr(std::process::Stdio::piped());
 
-            run_progress(&mut bundle_config, progress_handler, RunConfig::default())?;
+            run_progress(
+                &mut bundle_config,
+                Some(progress_handler),
+                RunConfig::default(),
+            )?;
         }
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("installing bundle".to_string())
-        }
+        progress_handler.progress("installing bundle".to_string());
 
         let mut bundle_install = TokioCommand::new("bundle");
         bundle_install.arg("install");
@@ -108,47 +97,37 @@ impl UpConfigBundler {
         bundle_install.stdout(std::process::Stdio::piped());
         bundle_install.stderr(std::process::Stdio::piped());
 
-        let result = run_progress(&mut bundle_install, progress_handler, RunConfig::default());
+        let result = run_progress(
+            &mut bundle_install,
+            Some(progress_handler),
+            RunConfig::default(),
+        );
 
         if let Err(err) = &result {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error_with_message(format!("bundle install failed: {}", err))
-            }
+            progress_handler.error_with_message(format!("bundle install failed: {}", err));
             return result;
         }
 
         self.update_cache(progress_handler);
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.success()
-        }
+        progress_handler.success();
 
         Ok(())
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        let desc = "remove Gemfile dependencies:".light_blue();
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        progress_handler.init("bundler".light_blue());
+        progress_handler.progress("removing Gemfile dependencies".to_string());
 
         // Check if path exists, and if so delete it
         if self.path.is_some() && Path::new(&self.path.clone().unwrap()).exists() {
             let path = self.path.clone().unwrap();
             let path = abs_path(path).to_str().unwrap().to_string();
 
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.progress(format!("removing {}", path));
-            }
+            progress_handler.progress(format!("removing {}", path));
 
             if let Err(err) = std::fs::remove_dir_all(&path) {
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler
-                        .error_with_message(format!("failed to remove {}: {}", path, err));
-                }
+                progress_handler.error_with_message(format!("failed to remove {}: {}", path, err));
                 return Err(UpError::Exec(format!("failed to remove {}: {}", path, err)));
             }
 
@@ -161,10 +140,8 @@ impl UpConfigBundler {
                 parent = path;
             }
 
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.success()
-            }
-        } else if let Some(progress_handler) = progress_handler {
+            progress_handler.success()
+        } else {
             progress_handler.success_with_message("skipping (nothing to do)".light_black())
         }
 

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -14,6 +14,7 @@ use crate::internal::cache::utils::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::config::up::utils::data_path_dir_hash;
+use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::AsdfToolUpVersion;
 use crate::internal::config::up::ProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
@@ -111,12 +112,16 @@ impl UpConfigGolang {
         }
     }
 
-    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base()?.up(options, progress)
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        self.asdf_base()?.up(options, progress_handler)
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base()?.down(progress)
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        self.asdf_base()?.down(progress_handler)
     }
 
     pub fn was_upped(&self) -> bool {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -577,10 +577,7 @@ impl HomebrewTap {
     }
 
     fn was_handled(&self) -> bool {
-        match self.was_handled.get() {
-            Some(HomebrewHandled::Handled) => true,
-            _ => false,
-        }
+        matches!(self.was_handled.get(), Some(HomebrewHandled::Handled))
     }
 
     fn handling(&self) -> HomebrewHandled {
@@ -1442,10 +1439,7 @@ impl HomebrewInstall {
     }
 
     fn was_handled(&self) -> bool {
-        match self.was_handled.get() {
-            Some(HomebrewHandled::Handled) => true,
-            _ => false,
-        }
+        matches!(self.was_handled.get(), Some(HomebrewHandled::Handled))
     }
 
     fn handling(&self) -> HomebrewHandled {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -64,9 +64,7 @@ impl UpConfigHomebrew {
                 )
                 .light_yellow(),
             );
-            if let Err(err) = tap.up(&subhandler) {
-                return Err(err);
-            }
+            tap.up(&subhandler)?;
         }
 
         let num_installs = self.install.len();
@@ -80,9 +78,7 @@ impl UpConfigHomebrew {
                 )
                 .light_yellow(),
             );
-            if let Err(err) = install.up(options, &subhandler) {
-                return Err(err);
-            }
+            install.up(options, &subhandler)?;
         }
 
         progress_handler.success_with_message(self.get_up_message());

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use duct::cmd;
+use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use serde::Serialize;
@@ -13,16 +14,14 @@ use crate::internal::cache::HomebrewInstalled;
 use crate::internal::cache::HomebrewOperationCache;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::utils::run_progress;
-use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
-use crate::internal::config::up::utils::SpinnerProgressHandler;
+use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
 use crate::internal::config::utils::is_executable;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::homebrew_prefix;
-use crate::internal::env::shell_is_interactive;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::omni_warning;
@@ -46,46 +45,138 @@ impl UpConfigHomebrew {
         UpConfigHomebrew { install, tap }
     }
 
-    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        let desc = "install homebrew dependencies:".light_blue();
-        let main_progress_handler = PrintProgressHandler::new(desc, progress);
-        main_progress_handler.progress("".to_string());
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        progress_handler.init("homebrew:".light_blue());
+        progress_handler.progress("installing homebrew dependencies".to_string());
 
         let num_taps = self.tap.len();
         for (idx, tap) in self.tap.iter().enumerate() {
-            if let Err(err) = tap.up(progress, Some((idx + 1, num_taps))) {
-                main_progress_handler.error();
+            let subhandler = progress_handler.subhandler(
+                &format!(
+                    "[{current:padding$}/{total:padding$}] ",
+                    current = idx + 1,
+                    total = num_taps,
+                    padding = format!("{}", num_taps).len(),
+                )
+                .light_yellow(),
+            );
+            if let Err(err) = tap.up(&subhandler) {
                 return Err(err);
             }
         }
 
         let num_installs = self.install.len();
         for (idx, install) in self.install.iter().enumerate() {
-            if let Err(err) = install.up(options, progress, Some((idx + 1, num_installs))) {
-                main_progress_handler.error();
+            let subhandler = progress_handler.subhandler(
+                &format!(
+                    "[{current:padding$}/{total:padding$}] ",
+                    current = idx + 1,
+                    total = num_installs,
+                    padding = format!("{}", num_installs).len(),
+                )
+                .light_yellow(),
+            );
+            if let Err(err) = install.up(options, &subhandler) {
                 return Err(err);
             }
         }
 
-        let num_handled_taps = self.tap.iter().filter(|tap| tap.was_handled()).count();
-        let num_handled_installs = self
-            .install
-            .iter()
-            .filter(|install| install.was_handled())
-            .count();
-
-        main_progress_handler.success_with_message(format!(
-            "installed {} tap{} and {} formula{}",
-            num_handled_taps,
-            if num_handled_taps > 1 { "s" } else { "" },
-            num_handled_installs,
-            if num_handled_installs > 1 { "s" } else { "" },
-        ));
+        progress_handler.success_with_message(self.get_up_message());
 
         Ok(())
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
+    fn get_up_message(&self) -> String {
+        let count_taps: HashMap<HomebrewHandled, usize> = self
+            .tap
+            .iter()
+            .map(|tap| tap.handling())
+            .fold(HashMap::new(), |mut map, item| {
+                *map.entry(item).or_insert(0) += 1;
+                map
+            });
+        let handled_taps: Vec<String> = self
+            .tap
+            .iter()
+            .filter_map(|tap| match tap.handling() {
+                HomebrewHandled::Handled | HomebrewHandled::Updated | HomebrewHandled::Noop => {
+                    Some(tap.name.clone())
+                }
+                _ => None,
+            })
+            .sorted()
+            .collect();
+
+        let count_installs: HashMap<HomebrewHandled, usize> = self
+            .install
+            .iter()
+            .map(|install| install.handling())
+            .fold(HashMap::new(), |mut map, item| {
+                *map.entry(item).or_insert(0) += 1;
+                map
+            });
+        let handled_installs: Vec<String> = self
+            .install
+            .iter()
+            .filter_map(|install| match install.handling() {
+                HomebrewHandled::Handled | HomebrewHandled::Updated | HomebrewHandled::Noop => {
+                    Some(install.package_id())
+                }
+                _ => None,
+            })
+            .sorted()
+            .collect();
+
+        let mut messages = vec![];
+
+        for (name, count, handled) in [
+            ("tap", count_taps, handled_taps),
+            ("formula", count_installs, handled_installs),
+        ] {
+            let count_handled = handled.len();
+            if count_handled == 0 {
+                continue;
+            }
+
+            let mut numbers = vec![];
+
+            if let Some(count) = count.get(&HomebrewHandled::Handled) {
+                numbers.push(format!("+{}", count).green());
+            }
+
+            if let Some(count) = count.get(&HomebrewHandled::Updated) {
+                numbers.push(format!("^{}", count).yellow());
+            }
+
+            if let Some(count) = count.get(&HomebrewHandled::Noop) {
+                numbers.push(format!("{}", count));
+            }
+
+            if numbers.is_empty() {
+                continue;
+            }
+
+            messages.push(format!(
+                "{} {}{} {}",
+                numbers.join(", "),
+                name,
+                if count_handled > 1 { "s" } else { "" },
+                format!("({})", handled.join(", ")).light_black().italic(),
+            ));
+        }
+
+        if messages.is_empty() {
+            "nothing done".to_string()
+        } else {
+            messages.join(" and ")
+        }
+    }
+
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
         let workdir = workdir(".");
         let repo_id = match workdir.id() {
             Some(repo_id) => repo_id,
@@ -95,9 +186,8 @@ impl UpConfigHomebrew {
         let mut return_value = Ok(());
 
         if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
-            let desc = "uninstall (unused) homebrew dependencies:".light_blue();
-            let main_progress_handler = PrintProgressHandler::new(desc, progress);
-            main_progress_handler.progress("".to_string());
+            progress_handler.init("homebrew:".light_blue());
+            progress_handler.progress("uninstalling (unused) homebrew dependencies".to_string());
 
             let mut updated = false;
 
@@ -114,8 +204,18 @@ impl UpConfigHomebrew {
 
             let num_uninstalls = to_uninstall.len();
             for (idx, (rmidx, install)) in to_uninstall.iter().enumerate() {
-                if let Err(err) = install.down(progress, Some((idx + 1, num_uninstalls))) {
-                    main_progress_handler.error();
+                let subhandler = progress_handler.subhandler(
+                    &format!(
+                        "[{current:padding$}/{total:padding$}] ",
+                        current = idx + 1,
+                        total = num_uninstalls,
+                        padding = format!("{}", num_uninstalls).len(),
+                    )
+                    .light_yellow(),
+                );
+
+                if let Err(err) = install.down(&subhandler) {
+                    progress_handler.error();
                     return_value = Err(err);
                     return updated;
                 }
@@ -149,9 +249,18 @@ impl UpConfigHomebrew {
 
             let num_untaps = to_untap.len();
             for (idx, (rmidx, tap)) in to_untap.iter().enumerate() {
-                if let Err(err) = tap.down(progress, Some((idx + 1, num_untaps))) {
+                let subhandler = progress_handler.subhandler(
+                    &format!(
+                        "[{current:padding$}/{total:padding$}] ",
+                        current = idx + 1,
+                        total = num_untaps,
+                        padding = format!("{}", num_untaps).len(),
+                    )
+                    .light_yellow(),
+                );
+                if let Err(err) = tap.down(&subhandler) {
                     if err != UpError::HomebrewTapInUse {
-                        main_progress_handler.error();
+                        progress_handler.error();
                         return_value = Err(err);
                         return updated;
                     }
@@ -170,26 +279,59 @@ impl UpConfigHomebrew {
             }
 
             if updated {
-                let num_handled_taps = to_untap
+                let mut messages = Vec::new();
+
+                let handled_taps = to_untap
                     .iter()
                     .filter(|(_idx, tap)| tap.was_handled())
-                    .count();
-                let num_handled_installs = to_uninstall
+                    .collect::<Vec<_>>();
+                let handled_taps_count = handled_taps.len();
+                if handled_taps_count > 0 {
+                    messages.push(format!(
+                        "{} tap{} {}",
+                        format!("-{}", handled_taps_count).red(),
+                        if handled_taps_count > 1 { "s" } else { "" },
+                        format!(
+                            "({})",
+                            handled_taps
+                                .iter()
+                                .map(|(_idx, tap)| tap.name.clone())
+                                .sorted()
+                                .join(", ")
+                        )
+                        .light_black()
+                        .italic(),
+                    ));
+                }
+
+                let handled_installs = to_uninstall
                     .iter()
                     .filter(|(_idx, install)| install.was_handled())
-                    .count();
+                    .collect::<Vec<_>>();
+                let handled_installs_count = handled_installs.len();
+                if handled_installs_count > 0 {
+                    messages.push(format!(
+                        "{} formula{} {}",
+                        format!("-{}", handled_installs_count).red(),
+                        if handled_installs_count > 1 { "s" } else { "" },
+                        format!(
+                            "({})",
+                            handled_installs
+                                .iter()
+                                .map(|(_idx, install)| install.name())
+                                .sorted()
+                                .join(", ")
+                        )
+                        .light_black()
+                        .italic(),
+                    ));
+                }
 
-                main_progress_handler.success_with_message(format!(
-                    "uninstalled {} tap{} and {} formula{}",
-                    num_handled_taps,
-                    if num_handled_taps > 1 { "s" } else { "" },
-                    num_handled_installs,
-                    if num_handled_installs > 1 { "s" } else { "" },
-                ));
+                progress_handler.success_with_message(messages.join(" and "));
 
                 true
             } else {
-                main_progress_handler
+                progress_handler
                     .success_with_message("no homebrew dependencies to uninstall".to_string());
 
                 false
@@ -214,6 +356,14 @@ impl UpConfigHomebrew {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum HomebrewHandled {
+    Handled,
+    Noop,
+    Updated,
+    Unhandled,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HomebrewTap {
     name: String,
@@ -221,7 +371,7 @@ pub struct HomebrewTap {
     url: Option<String>,
 
     #[serde(skip)]
-    was_handled: OnceCell<bool>,
+    was_handled: OnceCell<HomebrewHandled>,
 }
 
 impl HomebrewTap {
@@ -315,7 +465,7 @@ impl HomebrewTap {
         }
     }
 
-    fn update_cache(&self, progress_handler: Option<&dyn ProgressHandler>) {
+    fn update_cache(&self, progress_handler: &dyn ProgressHandler) {
         let workdir = workdir(".");
         let workdir_id = workdir.id();
         if workdir_id.is_none() {
@@ -323,101 +473,47 @@ impl HomebrewTap {
         }
         let workdir_id = workdir_id.unwrap();
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updating cache".to_string())
-        }
+        progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
             brew_cache.add_tap(&workdir_id, &self.name, self.was_handled())
         }) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.progress(format!("failed to update cache: {}", err))
-            }
-        } else if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updated cache".to_string())
+            progress_handler.progress(format!("failed to update cache: {}", err));
+        } else {
+            progress_handler.progress("updated cache".to_string());
         }
     }
 
-    fn up(
-        &self,
-        main_progress: Option<(usize, usize)>,
-        sub_progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
-        let progress_str = if let Some((current, total)) = sub_progress {
-            let padding = format!("{}", total).len();
-            format!(
-                "[{:padding$}/{:padding$}] ",
-                current,
-                total,
-                padding = padding,
-            )
-        } else {
-            "".to_string()
-        };
-
-        let desc = format!("  {}{} {}:", progress_str, "tap".underline(), self.name).light_yellow();
-
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, main_progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, main_progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+    fn up(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        let progress_handler = progress_handler
+            .subhandler(&format!("{} {}", "tap".underline(), self.name).light_yellow());
 
         if self.is_tapped() {
-            self.update_cache(progress_handler);
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.success_with_message("already tapped".light_black())
+            self.update_cache(&progress_handler);
+            if self.was_handled.set(HomebrewHandled::Noop).is_err() {
+                unreachable!();
             }
+            progress_handler.success_with_message("already tapped".light_black());
             return Ok(());
         }
 
-        if let Err(err) = self.tap(progress_handler, true) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error();
-            }
+        if let Err(err) = self.tap(&progress_handler, true) {
+            progress_handler.error();
             return Err(err);
         }
 
-        self.update_cache(progress_handler);
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.success()
-        }
+        self.update_cache(&progress_handler);
+        progress_handler.success();
 
         Ok(())
     }
 
-    fn down(
-        &self,
-        main_progress: Option<(usize, usize)>,
-        sub_progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
-        let progress_str = if let Some((current, total)) = sub_progress {
-            let padding = format!("{}", total).len();
-            format!(
-                "[{:padding$}/{:padding$}] ",
-                current,
-                total,
-                padding = padding,
-            )
-        } else {
-            "".to_string()
-        };
-
-        let desc =
-            format!("  {}{} {}:", progress_str, "untap".underline(), self.name).light_yellow();
-
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, main_progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, main_progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+    fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        let progress_handler = progress_handler
+            .subhandler(&format!("{} {}: ", "untap".underline(), self.name).light_yellow());
 
         if !self.is_tapped() {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.success_with_message("not currently tapped".light_black())
-            }
+            progress_handler.success_with_message("not currently tapped".light_black());
             return Ok(());
         }
 
@@ -426,22 +522,16 @@ impl HomebrewTap {
             .run()
             .is_ok()
         {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error_with_message("tap is still in use, skipping".light_black())
-            }
+            progress_handler.error_with_message("tap is still in use, skipping".light_black());
             return Err(UpError::HomebrewTapInUse);
         }
 
-        if let Err(err) = self.tap(progress_handler, false) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error();
-            }
+        if let Err(err) = self.tap(&progress_handler, false) {
+            progress_handler.error();
             return Err(err);
         }
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.success()
-        }
+        progress_handler.success();
 
         Ok(())
     }
@@ -463,11 +553,7 @@ impl HomebrewTap {
         false
     }
 
-    fn tap(
-        &self,
-        progress_handler: Option<&dyn ProgressHandler>,
-        tap: bool,
-    ) -> Result<(), UpError> {
+    fn tap(&self, progress_handler: &UpProgressHandler, tap: bool) -> Result<(), UpError> {
         let mut brew_tap = TokioCommand::new("brew");
         if tap {
             brew_tap.arg("tap");
@@ -483,15 +569,25 @@ impl HomebrewTap {
         brew_tap.stdout(std::process::Stdio::piped());
         brew_tap.stderr(std::process::Stdio::piped());
 
-        let result = run_progress(&mut brew_tap, progress_handler, RunConfig::default());
-        if result.is_ok() && self.was_handled.set(true).is_err() {
+        let result = run_progress(&mut brew_tap, Some(progress_handler), RunConfig::default());
+        if result.is_ok() && self.was_handled.set(HomebrewHandled::Handled).is_err() {
             unreachable!();
         }
         result
     }
 
     fn was_handled(&self) -> bool {
-        *self.was_handled.get_or_init(|| false)
+        match self.was_handled.get() {
+            Some(HomebrewHandled::Handled) => true,
+            _ => false,
+        }
+    }
+
+    fn handling(&self) -> HomebrewHandled {
+        match self.was_handled.get() {
+            Some(handled) => handled.clone(),
+            None => HomebrewHandled::Unhandled,
+        }
     }
 }
 
@@ -508,7 +604,7 @@ pub struct HomebrewInstall {
     version: Option<String>,
 
     #[serde(skip)]
-    was_handled: OnceCell<bool>,
+    was_handled: OnceCell<HomebrewHandled>,
 }
 
 impl Serialize for HomebrewInstall {
@@ -533,6 +629,15 @@ impl Serialize for HomebrewInstall {
 }
 
 impl HomebrewInstall {
+    pub fn new_formula(name: &str) -> Self {
+        Self {
+            install_type: HomebrewInstallType::Formula,
+            name: name.to_string(),
+            version: None,
+            was_handled: OnceCell::new(),
+        }
+    }
+
     fn from_config_value(config_value: Option<&ConfigValue>) -> Vec<Self> {
         // TODO: maybe support "alternate" packages with `or`
 
@@ -629,7 +734,7 @@ impl HomebrewInstall {
         }
     }
 
-    fn update_cache(&self, options: &UpOptions, progress_handler: Option<&dyn ProgressHandler>) {
+    fn update_cache(&self, options: &UpOptions, progress_handler: &dyn ProgressHandler) {
         let workdir = workdir(".");
         let workdir_id = workdir.id();
         if workdir_id.is_none() {
@@ -637,9 +742,7 @@ impl HomebrewInstall {
         }
         let workdir_id = workdir_id.unwrap();
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updating cache".to_string())
-        }
+        progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
             brew_cache.add_install(
@@ -650,9 +753,7 @@ impl HomebrewInstall {
                 self.was_handled(),
             )
         }) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.progress(format!("failed to update cache: {}", err))
-            }
+            progress_handler.progress(format!("failed to update cache: {}", err));
             return;
         }
 
@@ -668,137 +769,126 @@ impl HomebrewInstall {
                 }
                 true
             }) {
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler.progress(format!("failed to update cache: {}", err))
-                }
+                progress_handler.progress(format!("failed to update cache: {}", err));
                 return;
             }
         }
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("updated cache".to_string())
-        }
+        progress_handler.progress("updated cache".to_string());
     }
 
     fn up(
         &self,
         options: &UpOptions,
-        main_progress: Option<(usize, usize)>,
-        sub_progress: Option<(usize, usize)>,
+        // main_progress: Option<(usize, usize)>,
+        progress_handler: &UpProgressHandler,
+        // sub_progress: Option<(usize, usize)>,
     ) -> Result<(), UpError> {
-        let progress_str = if let Some((current, total)) = sub_progress {
-            let padding = format!("{}", total).len();
-            format!(
-                "[{:padding$}/{:padding$}] ",
-                current,
-                total,
-                padding = padding,
+        // let progress_str = if let Some((current, total)) = sub_progress {
+        // let padding = format!("{}", total).len();
+        // format!(
+        // "[{:padding$}/{:padding$}] ",
+        // current,
+        // total,
+        // padding = padding,
+        // )
+        // } else {
+        // "".to_string()
+        // };
+
+        // let version_hint = if let Some(version) = &self.version {
+        // format!(" ({})", version)
+        // } else {
+        // "".to_string()
+        // };
+        // let desc =
+        // format!("  {}install {}{}:", progress_str, self.name, version_hint).light_yellow();
+
+        let progress_handler = progress_handler.subhandler(
+            &format!(
+                "install {}{}: ",
+                self.name,
+                match &self.version {
+                    Some(version) => format!(" ({})", version),
+                    None => "".to_string(),
+                }
             )
-        } else {
-            "".to_string()
-        };
+            .light_yellow(),
+        );
 
-        let version_hint = if let Some(version) = &self.version {
-            format!(" ({})", version)
-        } else {
-            "".to_string()
-        };
-        let desc =
-            format!("  {}install {}{}:", progress_str, self.name, version_hint).light_yellow();
-
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, main_progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, main_progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+        // let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
+        // // Box::new(SpinnerProgressHandler::new(desc, main_progress))
+        // Box::new(SpinnerProgressHandler::new(desc, sub_progress))
+        // } else {
+        // // Box::new(PrintProgressHandler::new(desc, main_progress))
+        // Box::new(PrintProgressHandler::new(desc, sub_progress))
+        // };
+        // let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
 
         let installed = self.is_installed(options);
         if installed && self.version.is_some() {
-            self.update_cache(options, progress_handler);
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.success_with_message("already installed".light_black())
+            self.update_cache(options, &progress_handler);
+            if self.was_handled.set(HomebrewHandled::Noop).is_err() {
+                unreachable!();
             }
+            // if let Some(progress_handler) = progress_handler {
+            progress_handler.success_with_message("already installed".light_black());
+            // }
             return Ok(());
         }
 
-        match self.install(options, progress_handler, installed) {
+        match self.install(options, Some(&progress_handler), installed) {
             Ok(did_something) => {
-                self.update_cache(options, progress_handler);
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler.success_with_message(match (installed, did_something) {
-                        (true, true) => "updated".light_green(),
-                        (true, false) => "up to date (cached)".light_black(),
-                        (false, _) => "installed".light_green(),
-                    })
+                self.update_cache(options, &progress_handler);
+                let (was_handled, message) = match (installed, did_something) {
+                    (true, true) => (HomebrewHandled::Updated, "updated".light_green()),
+                    (true, false) => (HomebrewHandled::Noop, "up to date (cached)".light_black()),
+                    (false, _) => (HomebrewHandled::Handled, "installed".light_green()),
+                };
+                if self.was_handled.set(was_handled).is_err() {
+                    unreachable!();
                 }
+                progress_handler.success_with_message(message);
                 Ok(())
             }
             Err(err) => {
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler.error_with_message(err.to_string());
-                }
+                progress_handler.error_with_message(err.to_string());
                 Err(err)
             }
         }
     }
 
-    fn down(
-        &self,
-        main_progress: Option<(usize, usize)>,
-        sub_progress: Option<(usize, usize)>,
-    ) -> Result<(), UpError> {
-        let progress_str = if let Some((current, total)) = sub_progress {
-            let padding = format!("{}", total).len();
-            format!(
-                "[{:padding$}/{:padding$}] ",
-                current,
-                total,
-                padding = padding,
+    fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        let progress_handler = progress_handler.subhandler(
+            &format!(
+                "uninstall {}{}: ",
+                self.name,
+                match &self.version {
+                    Some(version) => format!(" ({})", version),
+                    None => "".to_string(),
+                }
             )
-        } else {
-            "".to_string()
-        };
-
-        let version_hint = if let Some(version) = &self.version {
-            format!(" ({})", version)
-        } else {
-            "".to_string()
-        };
-        let desc =
-            format!("  {}uninstall {}{}:", progress_str, self.name, version_hint).light_yellow();
-
-        let progress_handler: Box<dyn ProgressHandler> = if shell_is_interactive() {
-            Box::new(SpinnerProgressHandler::new(desc, main_progress))
-        } else {
-            Box::new(PrintProgressHandler::new(desc, main_progress))
-        };
-        let progress_handler: Option<&dyn ProgressHandler> = Some(progress_handler.as_ref());
+            .light_yellow(),
+        );
 
         let installed = self.is_installed(&UpOptions::new().cache_disabled());
         if !installed {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.success_with_message("not installed".light_black())
-            }
+            progress_handler.success_with_message("not installed".light_black());
             return Ok(());
         }
 
-        if let Err(err) = self.uninstall(progress_handler) {
-            if let Some(progress_handler) = progress_handler {
-                progress_handler.error_with_message(err.to_string());
-            }
+        if let Err(err) = self.uninstall(&progress_handler) {
+            progress_handler.error_with_message(err.to_string());
             return Err(err);
         }
 
         if self.is_in_local_tap() {
             let tapped_file = self.tapped_file().unwrap();
             if let Err(err) = std::fs::remove_file(tapped_file) {
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler.error_with_message(format!(
-                        "failed to remove formula from local tap: {}",
-                        err
-                    ));
-                }
+                progress_handler.error_with_message(format!(
+                    "failed to remove formula from local tap: {}",
+                    err
+                ));
                 return Err(UpError::Exec(
                     "failed to remove formula from local tap".to_string(),
                 ));
@@ -815,17 +905,17 @@ impl HomebrewInstall {
                 brew_untap.stdout(std::process::Stdio::piped());
                 brew_untap.stderr(std::process::Stdio::piped());
 
-                if let Some(progress_handler) = progress_handler {
-                    progress_handler.progress("removing local tap".to_string());
-                }
+                progress_handler.progress("removing local tap".to_string());
 
-                run_progress(&mut brew_untap, progress_handler, RunConfig::default())?;
+                run_progress(
+                    &mut brew_untap,
+                    Some(&progress_handler),
+                    RunConfig::default(),
+                )?;
             }
         }
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.success_with_message("uninstalled".light_green());
-        }
+        progress_handler.success_with_message("uninstalled".light_green());
 
         Ok(())
     }
@@ -1181,7 +1271,7 @@ impl HomebrewInstall {
 
         match run_progress(&mut brew_install, progress_handler, RunConfig::default()) {
             Ok(_) => {
-                if !installed && self.was_handled.set(true).is_err() {
+                if !installed && self.was_handled.set(HomebrewHandled::Handled).is_err() {
                     unreachable!();
                 }
 
@@ -1201,7 +1291,7 @@ impl HomebrewInstall {
         }
     }
 
-    fn uninstall(&self, progress_handler: Option<&dyn ProgressHandler>) -> Result<(), UpError> {
+    fn uninstall(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
         let mut brew_uninstall = TokioCommand::new("brew");
         brew_uninstall.arg("uninstall");
         if self.install_type == HomebrewInstallType::Cask {
@@ -1214,12 +1304,14 @@ impl HomebrewInstall {
         brew_uninstall.stdout(std::process::Stdio::piped());
         brew_uninstall.stderr(std::process::Stdio::piped());
 
-        if let Some(progress_handler) = progress_handler {
-            progress_handler.progress("uninstalling".to_string())
-        }
+        progress_handler.progress("uninstalling".to_string());
 
-        let result = run_progress(&mut brew_uninstall, progress_handler, RunConfig::default());
-        if result.is_ok() && self.was_handled.set(true).is_err() {
+        let result = run_progress(
+            &mut brew_uninstall,
+            Some(progress_handler),
+            RunConfig::default(),
+        );
+        if result.is_ok() && self.was_handled.set(HomebrewHandled::Handled).is_err() {
             unreachable!();
         }
         result
@@ -1350,6 +1442,16 @@ impl HomebrewInstall {
     }
 
     fn was_handled(&self) -> bool {
-        *self.was_handled.get_or_init(|| false)
+        match self.was_handled.get() {
+            Some(HomebrewHandled::Handled) => true,
+            _ => false,
+        }
+    }
+
+    fn handling(&self) -> HomebrewHandled {
+        match self.was_handled.get() {
+            Some(handled) => handled.clone(),
+            None => HomebrewHandled::Unhandled,
+        }
     }
 }

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -6,6 +6,7 @@ use package_json::PackageJsonManager;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
@@ -33,12 +34,16 @@ impl UpConfigNodejs {
         Self { asdf_base }
     }
 
-    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.up(options, progress)
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        self.asdf_base.up(options, progress_handler)
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.down(progress)
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        self.asdf_base.down(progress_handler)
     }
 }
 

--- a/src/internal/config/up/python.rs
+++ b/src/internal/config/up/python.rs
@@ -14,6 +14,7 @@ use crate::internal::config::up::asdf_tool_path;
 use crate::internal::config::up::run_progress;
 use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::AsdfToolUpVersion;
 use crate::internal::config::up::ProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
@@ -79,12 +80,16 @@ impl UpConfigPython {
         Self { asdf_base, pip }
     }
 
-    pub fn up(&self, options: &UpOptions, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.up(options, progress)
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        self.asdf_base.up(options, progress_handler)
     }
 
-    pub fn down(&self, progress: Option<(usize, usize)>) -> Result<(), UpError> {
-        self.asdf_base.down(progress)
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        self.asdf_base.down(progress_handler)
     }
 }
 

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-and.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-and.md
@@ -8,7 +8,7 @@ Composite operation that takes a list of operations as parameter.
 
 The `and` operation will execute all available operations in the list. If none of the operations are available, the `and` operation will be considered unavailable. If any of the operations fail, the `and` operation will fail.
 
-By default the `up` configuration is considered an `and` operation, it is thus not necessary to specify it explicitly at the root level. However, it becomes useful when combined with the [`or`](../or) operation, as it allows to specify grouped operations to be conditioned by `or`.
+By default the `up` configuration is considered an `and` operation, it is thus not necessary to specify it explicitly at the root level. However, it becomes useful when combined with the [`or`](or) operation, as it allows to specify grouped operations to be conditioned by `or`.
 
 ## Examples
 

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-and.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-and.md
@@ -1,0 +1,36 @@
+---
+description: Configuration of the `and` kind of `up` parameter
+---
+
+# `and` operation
+
+Composite operation that takes a list of operations as parameter.
+
+The `and` operation will execute all available operations in the list. If none of the operations are available, the `and` operation will be considered unavailable. If any of the operations fail, the `and` operation will fail.
+
+By default the `up` configuration is considered an `and` operation, it is thus not necessary to specify it explicitly at the root level. However, it becomes useful when combined with the [`or`](../or) operation, as it allows to specify grouped operations to be conditioned by `or`.
+
+## Examples
+
+```yaml
+up:
+  # Installs gawk using either homebrew or nix, whichever is available,
+  # and if both are available will use homebrew in priority, and will
+  # run a different custom operation depending on which one was used;
+  #
+  # NOTE: if the custom operation fails, the whole `and` operation will
+  #       be considered as failed, and the other branching of `or` will
+  #       be executed.
+  - or:
+    - and:
+      - homebrew:
+          install:
+          - gawk
+      - custom:
+          run: echo "gawk is installed using homebrew"
+    - and:
+      - nix:
+        - gawk
+      - custom:
+          run: echo "gawk is installed using nix"
+```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-or.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-or.md
@@ -1,0 +1,25 @@
+---
+description: Configuration of the `or` kind of `up` parameter
+---
+
+# `or` operation
+
+Composite operation that takes a list of operations as parameter.
+
+When called during `omni up`, it will execute operations in the list until one of them is available and succeeds. If none of the operations are available, the `or` operation will be considered unavailable. If none of the available operations succeed, the `or` operation will fail.
+
+When called during `omni down`, it will execute all operations in the list.
+
+## Examples
+
+```yaml
+up:
+  # Installs gawk using either homebrew or nix, whichever is available,
+  # and if both are available will use homebrew in priority
+  - or:
+    - homebrew:
+        install:
+        - gawk
+    - nix:
+      - gawk
+```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
@@ -13,6 +13,7 @@ Each entry in the list can either be a single string (loads the operation with d
 
 | Operation | Type | Description                                                    |
 |-----------|------|---------------------------------------------------------|
+| `and` | [and](up/and) | Run multiple operations in sequence |
 | `apt` | [apt](up/apt) | Install packages with `apt` for ubuntu and debian-based systems |
 | `bash` | [bash](up/bash) | Install bash |
 | `bundler` | [bundler](up/bundler) | Install dependencies with bundler |
@@ -22,6 +23,7 @@ Each entry in the list can either be a single string (loads the operation with d
 | `homebrew`  | [Homebrew](up/homebrew) | Install formulae and casks with homebrew |
 | `nix` | [nix](up/nix) | Install packages with `nix` |
 | `node` | [node](up/node) | Install node |
+| `or` | [or](up/or) | Run the first available operation that succeeds and skip the rest |
 | `pacman` | [pacman](up/pacman) | Install packages with `pacman` for arch-based systems |
 | `python` | [python](up/python) | Install python |
 | `ruby` | [ruby](up/ruby) | Install ruby |


### PR DESCRIPTION
Some of the tooling installed through `asdf` requires dependencies to already be installed on the system. Those dependencies are stable and known in advance, as long as one of the known package managers that omni supports is available on the system.

This adds support so that when installing tools backed by `asdf`, the right dependencies will be setup on the system using either `brew` or `nix`. This should be extended in the future as support for `apt` and `dnf` is added back.

This also introduces new `or` and `and` operations for the `up` configuration, where `or` allows to indicate that one of the listed operations must succeed (`or` is marked unavailable and gracefully skipped if all underneath operations are unavailable), and will handle operations in the order they are defined, stopping at the first successful one. The `and` operation requires all of the listed operations to succeed, and is particularly useful when combined to an `or` operation.

Closes https://github.com/XaF/omni/issues/336