### PR TITLE
feat(cd): ✨ special path '...' now represents the root of current work directory

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,7 @@ jobs:
 
     outputs:
       deploy_website: ${{ steps.changed-files.outputs.website_any_modified }}
+      trigger_algolia: ${{ steps.changed-files.outputs.website_contents_any_modified }}
       run_tests: ${{ steps.changed-files.outputs.core_any_modified }}
       pages_environment: ${{ env.PAGES_ENVIRONMENT }}
 
@@ -58,6 +59,8 @@ jobs:
             website:
               - '.github/workflows/tests.yaml'
               - 'website/**'
+            website_contents:
+              - 'website/contents/**'
             core:
               - '.github/workflows/build.yaml'
               - '.github/workflows/tests.yaml'
@@ -236,7 +239,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
       - name: Trigger Algolia crawler
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' &&  needs.check-changed-files.outputs.trigger_algolia == 'true'
         uses: algolia/algoliasearch-crawler-github-actions@v1.1.10
         with:
           crawler-name: omnicli

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -14,6 +14,7 @@ use crate::internal::env::user_home;
 use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
+use crate::internal::workdir;
 use crate::omni_error;
 
 #[derive(Debug, Clone)]
@@ -336,6 +337,12 @@ impl CdCommand {
     }
 
     fn cd_repo_find(&self, repo: &str) -> Option<String> {
+        // Handle the special case of `...` to go to the work directory root
+        if repo == "..." {
+            let wd = workdir(".");
+            return wd.root().map(|wd_root| wd_root.to_string());
+        }
+
         // Delegate to the shell if this is a path
         if repo.starts_with('/')
             || repo.starts_with('.')

--- a/website/contents/reference/02-builtin-commands/0250-cd.md
+++ b/website/contents/reference/02-builtin-commands/0250-cd.md
@@ -4,9 +4,11 @@ description: Builtin command `cd`
 
 # `cd`
 
-Change directory to the git directory of the specified repository
+Change directory to the git directory of the specified work directory.
 
-If no repository or path is specified, change to the git directory of the first organization's worktree, or defaults to the default worktree.
+If no repository or path is specified, change to the first organization's worktree, or defaults to the default worktree.
+
+The `...` special path can also be used to change to the root of the current work directory.
 
 ## Parameters
 
@@ -30,7 +32,7 @@ omni cd https://github.com/XaF/omni  # CWD: /home/xaf/git/github.com/XaF/omni
 omni cd XaF/omni  # CWD: /home/xaf/git/github.com/XaF/omni
 omni cd omni      # CWD: /home/xaf/git/github.com/XaF/omni
 
-# Will switch the the root of the first organization's worktree, or to the
+# Will switch to the root of the first organization's worktree, or to the
 # root of the default worktree if no organization is configured
 omni cd  # CWD: /home/xaf/git
 
@@ -44,5 +46,12 @@ omni cd ..              # CWD: /absolute
 # Will return the matching directory for the repository
 omni cd --locate XaF/omni  # stdout: /home/xaf/git/github.com/XaF/omni ; exit code: 0
 omni cd --locate unknown   # exit code: 1
+
+# Will change to the root of the current work directory
+# if CWD is /home/xaf/git/github.com/XaF/omni/relative/path
+omni cd ...  # CWD: /home/xaf/git/github.com/XaF/omni
+
+# Will error out if not in a work directory
+omni cd ...  # exit code: 1
 ```
 


### PR DESCRIPTION
This adds support for `omni cd ...` to change directory to the root of the current work directory. This simplifies intra-project navigation by adding a handy shortcut.

Closes https://github.com/XaF/omni/issues/424