### PR TITLE
feat(config): ✨ Add system-level configuration files

### DIFF
--- a/src/internal/config/parser/omniconfig.rs
+++ b/src/internal/config/parser/omniconfig.rs
@@ -21,6 +21,7 @@ use crate::internal::config::parser::SuggestCloneConfig;
 use crate::internal::config::parser::SuggestConfig;
 use crate::internal::config::parser::UpCommandConfig;
 use crate::internal::config::up::UpConfig;
+use crate::internal::config::ConfigScope;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::OrgConfig;
 use crate::internal::env::omni_git_env;
@@ -96,8 +97,15 @@ impl OmniConfig {
 
         let mut org_config = Vec::new();
         if let Some(value) = config_value.get("org") {
-            for value in value.as_array().unwrap() {
-                org_config.push(OrgConfig::from_config_value(&value));
+            // TODO: instead of rejecting scope, we should support protected parameters
+            // in the config_value object so that those parameters would never be overwritten
+            // by any work directory specific configuration.
+            if let Some(value) = value.reject_scope(&ConfigScope::Workdir) {
+                if let Some(array) = value.as_array() {
+                    for value in array {
+                        org_config.push(OrgConfig::from_config_value(&value));
+                    }
+                }
             }
         }
 

--- a/website/contents/reference/01-configuration/0101-files.md
+++ b/website/contents/reference/01-configuration/0101-files.md
@@ -6,9 +6,16 @@ description: Configuration files that omni is looking for
 
 The omni configuration files are expected to be in `YAML` format. They are searched for in the order they are listed below. Configuration options from later-applied files override configuration options from earlier-applied files.
 
-Some configuration parameters will be ignored if present in the global configuration, others will be ignored if present in the per-repository configuration. The parameters for which it is the case are clearly identified in the documentation.
+Some configuration parameters will be ignored if present in the global configuration, others will be ignored if present in the per-work directory configuration. The parameters for which it is the case are clearly identified in the documentation.
 
 ## Global configuration
+
+### System configuration (pre)
+
+- `/etc/omni/pre.yaml`
+- Any `.yaml` file in the `/etc/omni/pre.d/` directory, in lexical order
+
+### User configuration
 
 - `~/.omni.yaml`
 - `~/.config/omni.yaml` (will conform to the `XDG_CONFIG_HOME` environment variable, if set)
@@ -16,12 +23,17 @@ Some configuration parameters will be ignored if present in the global configura
 - Any file which path is stored in the `OMNI_CONFIG` environment variable, if present and non-empty
 
 :::note
-If no configuration file is present when omni will need to edit one, the latest in the list will be used.
+If no configuration file is present when omni will need to edit one, the latest non-empty in the list will be used.
 :::
 
-## Per-repository configuration
+### System configuration (post)
 
-From the root of the git repository:
+- `/etc/omni/post.yaml`
+- Any `.yaml` file in the `/etc/omni/post.d/` directory, in lexical order
+
+## Per-work directory configuration
+
+From the root of the work directory:
 
 - `.omni.yaml`
 - `.omni/config.yaml`


### PR DESCRIPTION
This adds support for configuration files to be loaded before (pre) and after (post) the user configuration. These are considered global level but can allow to pre-fill default values to the configuration that the user can override (e.g. using `pre`) or to override values after the user-level configuration (e.g. using `post`).

This can also be used to set a default trusted organization for instance, which would always exist no matter what `org` the user configures:

```yaml
org__toappend:
- handle: git@github.com:XaF
  trusted: true
```

Closes https://github.com/XaF/omni/issues/212