### PR TITLE
fix: 🐛 Add truncate policy when opening files

### DIFF
--- a/src/internal/cache/handler.rs
+++ b/src/internal/cache/handler.rs
@@ -153,6 +153,7 @@ where
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(cache_path)?;
 
     // Take the exclusive lock on the file, it will be release when `_file_lock` goes out of scope

--- a/src/internal/config/loader.rs
+++ b/src/internal/config/loader.rs
@@ -268,6 +268,7 @@ impl ConfigLoader {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(file_path.clone())?;
 
         // Take the exclusive lock on the file, it will be release when `_file_lock` goes out of scope

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -338,6 +338,7 @@ impl OmniRelease {
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(tarball_path.as_path())?;
         io::copy(&mut response, &mut file)?;
 


### PR DESCRIPTION
This is required by rust 1.77's clippy rules.