### PR TITLE
fix(up env cache): 🐛 add default deserialization

### DIFF
--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -239,15 +239,15 @@ impl CacheObject for UpEnvironmentsCache {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpEnvironment {
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub versions: Vec<UpVersion>,
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub paths: Vec<PathBuf>,
-    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env_vars: Vec<UpEnvVar>,
-    #[serde(default = "HashMap::new", skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub config_modtimes: HashMap<String, u64>,
-    #[serde(default = "String::new", skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub config_hash: String,
 }
 
@@ -311,14 +311,15 @@ impl UpVersion {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpEnvVar {
-    #[serde(rename = "n", alias = "name", skip_serializing_if = "String::is_empty")]
+    #[serde(rename = "n", alias = "name", default, skip_serializing_if = "String::is_empty")]
     pub name: String,
-    #[serde(rename = "v", alias = "value", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "v", alias = "value", default, skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     #[serde(
         rename = "o",
         alias = "operation",
-        skip_serializing_if = "EnvOperationEnum::is_default"
+        default,
+        skip_serializing_if = "EnvOperationEnum::is_default",
     )]
     pub operation: EnvOperationEnum,
 }

--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -308,7 +308,7 @@ impl Serialize for EnvOperationConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, Default)]
 pub enum EnvOperationEnum {
     #[default]
     #[serde(rename = "s", alias = "set")]


### PR DESCRIPTION
The up environment cache deserialization for environment variables had a bug since we didn't specify the default value for the operation type if not specified, while at the same time skipping serialization if the value was the default `set` value.

This fixes that by adding the `default` marker so serde knows to deserialize into the default value if none specified.