### PR TITLE
fix(help): 🐛 handle lower terminal width properly

### DIFF
--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -357,8 +357,7 @@ impl HelpCommand {
                 _ => (" ▶".light_black(), 2),
             };
 
-            let (print_name_on_same_line, wrap_threshold) = match get_command_length(&cmd, &prefix)
-            {
+            let (print_name_on_same_line, wrap_threshold) = match get_command_length(cmd, &prefix) {
                 n if n <= longest_under_threshold => (true, longest_under_threshold),
                 _ => (false, term_width() - 4),
             };
@@ -607,8 +606,8 @@ impl HelpCommandMetadata {
 }
 
 fn get_longest_command(
-    commands: &Vec<HelpCommandMetadata>,
-    prefix: &Vec<String>,
+    commands: &[HelpCommandMetadata],
+    prefix: &[String],
     wrap_threshold: usize,
 ) -> (usize, usize) {
     let mut longest_command = 0;
@@ -617,7 +616,7 @@ fn get_longest_command(
     for cmd in commands.iter() {
         let command = &cmd.command;
         let all_names = command
-            .all_names_with_prefix(prefix.clone())
+            .all_names_with_prefix(prefix.to_vec())
             .iter()
             .map(|name| name.join(" "))
             .collect::<Vec<String>>();
@@ -653,10 +652,10 @@ fn get_longest_command(
     (longest_command, longest_under_threshold)
 }
 
-fn get_command_length(command: &HelpCommandMetadata, prefix: &Vec<String>) -> usize {
+fn get_command_length(command: &HelpCommandMetadata, prefix: &[String]) -> usize {
     let all_names = command
         .command
-        .all_names_with_prefix(prefix.clone())
+        .all_names_with_prefix(prefix.to_vec())
         .iter()
         .map(|name| name.join(" "))
         .collect::<Vec<String>>();

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -10,6 +10,7 @@ use crate::internal::commands::Command;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::user_interface::colors::strip_colors_if_needed;
+use crate::internal::user_interface::print::strip_ansi_codes;
 use crate::internal::user_interface::term_width;
 use crate::internal::user_interface::wrap_blocks;
 use crate::internal::user_interface::wrap_text;
@@ -292,28 +293,17 @@ impl HelpCommand {
         let mut seen = HashSet::new();
 
         // Get the longest command so we know how to justify the help
-        let longest_command = commands
-            .iter()
-            .map(|cmd| {
-                let command = &cmd.command;
-                let all_names = command
-                    .all_names_with_prefix(prefix.clone())
-                    .iter()
-                    .map(|name| name.join(" "))
-                    .collect::<Vec<String>>();
-                let all_names_len = all_names.join(", ").len();
+        const MIN_LJUST: usize = 15;
+        let abs_max_ljust = term_width() / 2;
+        let max_ljust = std::cmp::min(std::cmp::max(term_width() / 3, 40), abs_max_ljust);
+        if max_ljust < MIN_LJUST {
+            omni_error!("terminal width is too small to print help");
+            exit(1);
+        }
 
-                let num_folded = match cmd.num_folded() {
-                    0 => 0,
-                    _ => 2,
-                };
+        let (_, longest_under_threshold) = get_longest_command(&commands, &prefix, max_ljust - 4);
+        let ljust = std::cmp::max(longest_under_threshold + 2, MIN_LJUST);
 
-                all_names_len + num_folded
-            })
-            .max()
-            .unwrap_or(0);
-        let ljust = std::cmp::max(longest_command + 2, 15);
-        let join_str = format!("\n  {}", " ".repeat(ljust));
         let help_just = term_width() - ljust - 4;
 
         // Keep track of the current category so we only print it once
@@ -356,29 +346,109 @@ impl HelpCommand {
                 .iter()
                 .map(|name| name.join(" "))
                 .collect::<Vec<String>>();
-            let all_names_len = all_names.join(", ").len();
-            let all_names = all_names
+            let all_names_str = all_names
                 .iter()
                 .map(|name| name.cyan())
                 .collect::<Vec<String>>()
                 .join(", ");
 
-            let num_folded_len = match cmd.num_folded() {
-                0 => 0,
-                _ => 2,
-            };
-            let num_folded = match cmd.num_folded() {
-                0 => "".to_string(),
-                _ => " ▶".light_black(),
+            let (num_folded, num_folded_len) = match cmd.num_folded() {
+                0 => ("".to_string(), 0),
+                _ => (" ▶".light_black(), 2),
             };
 
-            let missing_just = ljust - all_names_len - num_folded_len;
-            let str_name = format!("  {}{}{}", all_names, num_folded, " ".repeat(missing_just));
+            let (print_name_on_same_line, wrap_threshold) = match get_command_length(&cmd, &prefix)
+            {
+                n if n <= longest_under_threshold => (true, longest_under_threshold),
+                _ => (false, term_width() - 4),
+            };
 
-            let help = wrap_text(&strip_colors_if_needed(&command.help_short()), help_just)
-                .join(join_str.as_str());
+            let all_names_str = format!("{}{}", all_names_str, "-".repeat(num_folded_len));
+            let all_names_vec = wrap_text(&all_names_str, wrap_threshold);
+            let all_names_and_len = all_names_vec
+                .iter()
+                .enumerate()
+                .map(|(idx, name)| {
+                    let namelen = strip_ansi_codes(name).len();
+                    let name = if idx == all_names_vec.len() - 1 {
+                        match name.strip_suffix("--") {
+                            Some(name) => format!("{}{}", name, num_folded),
+                            None => name.to_string(),
+                        }
+                    } else {
+                        name.to_string()
+                    };
+                    (name, namelen)
+                })
+                .collect::<Vec<(String, usize)>>();
 
-            eprintln!("{}{}", str_name, help);
+            // Prepare the help contents
+            let help_vec = wrap_text(&strip_colors_if_needed(&command.help_short()), help_just);
+
+            // Prepare the help message to print for this command
+            let empty_str = "".to_string();
+            let mut buf = String::new();
+            if print_name_on_same_line {
+                all_names_and_len
+                    .iter()
+                    .take(all_names_and_len.len() - 1)
+                    .for_each(|(name, _)| {
+                        buf.push_str(&format!("  {}\n", name));
+                    });
+
+                let first_desc_line = help_vec.first().unwrap_or(&empty_str);
+                let last_name_line = all_names_and_len.last().expect("Name should not be empty");
+                buf.push_str(&format!(
+                    "  {}{}{}\n",
+                    last_name_line.0,
+                    " ".repeat(ljust - last_name_line.1),
+                    first_desc_line,
+                ));
+
+                help_vec.iter().skip(1).for_each(|line| {
+                    buf.push_str(&format!("{}{}\n", " ".repeat(ljust + 2), line));
+                });
+            } else {
+                all_names_and_len.iter().for_each(|(name, _)| {
+                    buf.push_str(&format!("  {}\n", name));
+                });
+
+                help_vec.iter().for_each(|line| {
+                    buf.push_str(&format!("{}{}\n", " ".repeat(ljust + 2), line));
+                });
+            }
+
+            eprint!("{}", buf);
+
+            // This makes sure that the help message starts only on the last line of
+            // the command shown on the left
+            // let empty_str = "".to_string();
+            // let help_vec = std::iter::repeat(&empty_str)
+            // .take(all_names_and_len.len() - 1)
+            // .chain(help_vec.iter())
+            // .collect::<Vec<&String>>();
+
+            // // Generate the final help message
+            // let help = all_names_and_len
+            // .into_iter()
+            // .chain(std::iter::repeat(("".to_string(), 0)))
+            // .zip(help_vec.iter())
+            // .map(|((name, namelen), help)| {
+            // format!(
+            // "  {}{}{}",
+            // name,
+            // if help.is_empty() {
+            // "".to_string()
+            // } else {
+            // " ".repeat(ljust - namelen)
+            // },
+            // help,
+            // )
+            // })
+            // .collect::<Vec<String>>()
+            // .join("\n");
+
+            // eprintln!("{}", help);
         }
 
         true
@@ -534,4 +604,80 @@ impl HelpCommandMetadata {
             false => 0,
         }
     }
+}
+
+fn get_longest_command(
+    commands: &Vec<HelpCommandMetadata>,
+    prefix: &Vec<String>,
+    wrap_threshold: usize,
+) -> (usize, usize) {
+    let mut longest_command = 0;
+    let mut longest_under_threshold = 0;
+
+    for cmd in commands.iter() {
+        let command = &cmd.command;
+        let all_names = command
+            .all_names_with_prefix(prefix.clone())
+            .iter()
+            .map(|name| name.join(" "))
+            .collect::<Vec<String>>();
+        let all_names_str = all_names.join(", ");
+        let all_names_wrapped = wrap_text(&all_names_str, wrap_threshold);
+        let all_names_len = all_names_wrapped
+            .iter()
+            .enumerate()
+            .map(|(idx, name)| {
+                if idx == all_names_wrapped.len() - 1 {
+                    name.len()
+                        + match cmd.num_folded() {
+                            0 => 0,
+                            _ => 2,
+                        }
+                } else {
+                    name.len()
+                }
+            })
+            .collect::<Vec<usize>>();
+
+        let max_len = all_names_len.clone().into_iter().max().unwrap_or(0);
+        let max_under_threshold = all_names_len
+            .into_iter()
+            .filter(|len| *len <= wrap_threshold)
+            .max()
+            .unwrap_or(0);
+
+        longest_command = std::cmp::max(longest_command, max_len);
+        longest_under_threshold = std::cmp::max(longest_under_threshold, max_under_threshold);
+    }
+
+    (longest_command, longest_under_threshold)
+}
+
+fn get_command_length(command: &HelpCommandMetadata, prefix: &Vec<String>) -> usize {
+    let all_names = command
+        .command
+        .all_names_with_prefix(prefix.clone())
+        .iter()
+        .map(|name| name.join(" "))
+        .collect::<Vec<String>>();
+    let all_names_str = all_names.join(", ");
+    let all_names_wrapped = wrap_text(&all_names_str, 40);
+    let all_names_len = all_names_wrapped
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| {
+            if idx == all_names_wrapped.len() - 1 {
+                name.len()
+                    + match command.num_folded() {
+                        0 => 0,
+                        _ => 2,
+                    }
+            } else {
+                name.len()
+            }
+        })
+        .max()
+        .unwrap_or(0);
+
+    all_names_len
 }

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -144,11 +144,15 @@ fn term_columns() -> usize {
 pub fn term_width() -> usize {
     let width = term_columns();
 
-    let max = 120;
-    if width < max + 4 {
-        width - 4
+    const MAX_WIDTH: usize = 120;
+    if width < MAX_WIDTH + 4 {
+        if width > 4 {
+            width - 4
+        } else {
+            0
+        }
     } else {
-        max
+        MAX_WIDTH
     }
 }
 
@@ -177,12 +181,16 @@ lazy_static! {
     static ref COLOR_PATTERN: Regex = Regex::new(r"\x1B(?:\[(?:\d+)(?:;\d+)*m)").unwrap();
 }
 
+pub fn strip_ansi_codes(text: &str) -> String {
+    COLOR_PATTERN.replace_all(text, "").to_string()
+}
+
 pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
     let mut lines = vec![];
     let mut line = String::new();
     let mut line_width = 0;
     for word in SPLIT_PATTERN.split(text) {
-        let word_width = COLOR_PATTERN.replace_all(word, "").len();
+        let word_width = strip_ansi_codes(word).len();
         if line_width + word_width > width {
             lines.push(line);
             line = String::new();

--- a/tests/helpers/utils.bash
+++ b/tests/helpers/utils.bash
@@ -96,7 +96,6 @@ omni_setup() {
   add_fakebin "${HOME}/bin/brew"
   add_fakebin "${HOME}/bin/nix"
   add_fakebin "${HOME}/.local/share/omni/asdf/bin/asdf"
-  add_fakebin "${HOME}/bin/python"
 
   # Switch current directory to that new temp one
   cd "${HOME}"
@@ -275,20 +274,21 @@ check_commands() {
   local commands="${HOME}/.commands"
   if [ -d "$commands" ]; then
     # Print the called log
-    local log="${commands}/called.log"
-    if [ -f "$log" ]; then
+    local called_log="${commands}/called.log"
+    if [ -f "$called_log" ]; then
       echo "==== CALLED LOG === BEGIN ===" >&2
-      cat "$log" >&2
+      cat "$called_log" >&2
       echo "==== CALLED LOG === END   ===" >&2
     fi
 
     # Check for any unexpected commands
-    unexpected=0
-    if [ -f "${commands}/unexpected.log" ]; then
+    local unexpected=0
+    local unexpected_log="${commands}/unexpected.log"
+    if [ -f "$unexpected_log" ]; then
       echo "==== UNEXPECTED LOG === BEGIN ===" >&2
-      cat "${commands}/unexpected.log" >&2
+      cat "$unexpected_log" >&2
       echo "==== UNEXPECTED LOG === END   ===" >&2
-      unexpected=$(wc -l < "${commands}/unexpected.log")
+      unexpected=$(wc -l < "$unexpected_log")
       echo "Unexpected commands: $unexpected (should be 0)" >&2
     fi
 
@@ -307,15 +307,5 @@ check_commands() {
 
     # Return the status
     [ "$unexpected" -eq 0 ] && [ "$missing_required" -eq 0 ]
-  fi
-}
-
-print_called_log() {
-  local commands="${HOME}/.commands"
-  local log="${commands}/called.log"
-  if [ -f "$log" ]; then
-    echo "==== CALLED LOG === BEGIN ===" >&2
-    cat "$log" >&2
-    echo "==== CALLED LOG === END   ===" >&2
   fi
 }

--- a/tests/test_omni_help.bats
+++ b/tests/test_omni_help.bats
@@ -20,7 +20,7 @@ setup() {
 }
 
 
-# bats test_tags=omni:help
+# bats test_tags=omni:help,omni:help:self
 @test "omni help shows the help message with default omni commands" {
   version=$(omni --version | cut -d' ' -f3)
 
@@ -386,7 +386,7 @@ EOF
   [[ "$output" == "$expected" ]]
 }
 
-# bats test_tags=omni:help
+# bats test_tags=omni:help,omni:help:up
 @test "omni help up shows the help message for the command" {
   version=$(omni --version | cut -d' ' -f3)
 
@@ -432,6 +432,283 @@ EOF
   echo "STATUS: $status"
   echo "OUTPUT: $output"
   [ "$status" -eq 0 ]
+
+  set -o pipefail
+  diff -u <(echo "$expected") <(echo "$output") 3>&- | cat "-$CAT_OPTS" 3>&-
+  [ "$?" -eq 0 ]
+  [[ "$output" == "$expected" ]]
+}
+
+# bats test_tags=omni:help,omni:help:self
+@test "omni help shows the help message with a very long config command (columns=1000)" {
+  local omni_config="${HOME}/.config/omni/config.yaml"
+  mkdir -p "$(dirname "$omni_config")"
+  cat <<EOF >>"$omni_config"
+commands:
+  supercalifragilisticexpialidocious:
+    aliases:
+      - abracadabra
+      - hocuspocus
+      - open-sesame
+    desc: |
+      lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+      enim ad minim veniam, quis nostrud exercitation ullamco laboris
+      nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+      in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+      nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+      sunt in culpa qui officia deserunt mollit anim id est laborum.
+    run: |
+      echo "Hello, world!"
+EOF
+
+  version=$(omni --version | cut -d' ' -f3)
+
+  read -r -d '' expected <<EOF || true
+omni - omnipotent tool (v$version)
+
+Usage: omni <command> [options] ARG...
+
+General
+  config ▶                              Provides config commands
+  help                                  Show help for omni commands
+  hook ▶                                Call one of omni's hooks for the shell
+  status                                Show the status of omni
+
+Git commands
+  cd                                    Change directory to the git directory of the specified repository
+  clone                                 Clone the specified repository
+  up, down                              Sets up or tear down a repository depending on its up configuration
+  scope                                 Runs an omni command in the context of the specified repository
+  tidy                                  Organize your git repositories using the configured format
+
+Configuration < .config/omni/config.yaml
+  supercalifragilisticexpialidocious,
+  abracadabra, hocuspocus, open sesame  lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                                        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                                        nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                                        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+                                        eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+                                        in culpa qui officia deserunt mollit anim id est laborum.
+EOF
+
+  export COLUMNS=1000
+  run omni help 3>&-
+
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  set -o pipefail
+  diff -u <(echo "$expected") <(echo "$output") 3>&- | cat "-$CAT_OPTS" 3>&-
+  [ "$?" -eq 0 ]
+  [[ "$output" == "$expected" ]]
+}
+
+# bats test_tags=omni:help,omni:help:self
+@test "omni help shows the help message with a very long config command (columns=100)" {
+  local omni_config="${HOME}/.config/omni/config.yaml"
+  mkdir -p "$(dirname "$omni_config")"
+  cat <<EOF >>"$omni_config"
+commands:
+  supercalifragilisticexpialidocious:
+    aliases:
+      - abracadabra
+      - hocuspocus
+      - open-sesame
+    desc: |
+      lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+      enim ad minim veniam, quis nostrud exercitation ullamco laboris
+      nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+      in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+      nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+      sunt in culpa qui officia deserunt mollit anim id est laborum.
+    run: |
+      echo "Hello, world!"
+EOF
+
+  version=$(omni --version | cut -d' ' -f3)
+
+  read -r -d '' expected <<EOF || true
+omni - omnipotent tool (v$version)
+
+Usage: omni <command> [options] ARG...
+
+General
+  config ▶                              Provides config commands
+  help                                  Show help for omni commands
+  hook ▶                                Call one of omni's hooks for the shell
+  status                                Show the status of omni
+
+Git commands
+  cd                                    Change directory to the git directory of the specified
+                                        repository
+  clone                                 Clone the specified repository
+  up, down                              Sets up or tear down a repository depending on its up
+                                        configuration
+  scope                                 Runs an omni command in the context of the specified
+                                        repository
+  tidy                                  Organize your git repositories using the configured
+                                        format
+
+Configuration < .config/omni/config.yaml
+  supercalifragilisticexpialidocious,
+  abracadabra, hocuspocus, open sesame  lorem ipsum dolor sit amet, consectetur adipiscing
+                                        elit, sed do eiusmod tempor incididunt ut labore et
+                                        dolore magna aliqua. Ut enim ad minim veniam, quis
+                                        nostrud exercitation ullamco laboris nisi ut aliquip
+                                        ex ea commodo consequat. Duis aute irure dolor in
+                                        reprehenderit in voluptate velit esse cillum dolore eu
+                                        fugiat nulla pariatur. Excepteur sint occaecat
+                                        cupidatat non proident, sunt in culpa qui officia
+                                        deserunt mollit anim id est laborum.
+EOF
+
+  export COLUMNS=100
+  run omni help 3>&-
+
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  set -o pipefail
+  diff -u <(echo "$expected") <(echo "$output") 3>&- | cat "-$CAT_OPTS" 3>&-
+  [ "$?" -eq 0 ]
+  [[ "$output" == "$expected" ]]
+}
+
+# bats test_tags=omni:help,omni:help:self
+@test "omni help shows the help message with a very long config command (columns=50)" {
+  local omni_config="${HOME}/.config/omni/config.yaml"
+  mkdir -p "$(dirname "$omni_config")"
+  cat <<EOF >>"$omni_config"
+commands:
+  supercalifragilisticexpialidocious:
+    aliases:
+      - abracadabra
+      - hocuspocus
+      - open-sesame
+    desc: |
+      lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+      enim ad minim veniam, quis nostrud exercitation ullamco laboris
+      nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+      in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+      nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+      sunt in culpa qui officia deserunt mollit anim id est laborum.
+    run: |
+      echo "Hello, world!"
+EOF
+
+  version=$(omni --version | cut -d' ' -f3)
+
+  read -r -d '' expected <<EOF || true
+omni - omnipotent tool (v$version)
+
+Usage: omni <command> [options] ARG...
+
+General
+  config ▶          Provides config commands
+  help              Show help for omni
+                    commands
+  hook ▶            Call one of omni's hooks
+                    for the shell
+  status            Show the status of omni
+
+Git commands
+  cd                Change directory to the
+                    git directory of the
+                    specified repository
+  clone             Clone the specified
+                    repository
+  up, down          Sets up or tear down a
+                    repository depending on
+                    its up configuration
+  scope             Runs an omni command in
+                    the context of the
+                    specified repository
+  tidy              Organize your git
+                    repositories using the
+                    configured format
+
+Configuration < .config/omni/config.yaml
+  supercalifragilisticexpialidocious,
+  abracadabra, hocuspocus, open sesame
+                    lorem ipsum dolor sit
+                    amet, consectetur
+                    adipiscing elit, sed do
+                    eiusmod tempor
+                    incididunt ut labore et
+                    dolore magna aliqua. Ut
+                    enim ad minim veniam,
+                    quis nostrud
+                    exercitation ullamco
+                    laboris nisi ut aliquip
+                    ex ea commodo consequat.
+                    Duis aute irure dolor in
+                    reprehenderit in
+                    voluptate velit esse
+                    cillum dolore eu fugiat
+                    nulla pariatur.
+                    Excepteur sint occaecat
+                    cupidatat non proident,
+                    sunt in culpa qui
+                    officia deserunt mollit
+                    anim id est laborum.
+EOF
+
+  export COLUMNS=50
+  run omni help 3>&-
+
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  set -o pipefail
+  diff -u <(echo "$expected") <(echo "$output") 3>&- | cat "-$CAT_OPTS" 3>&-
+  [ "$?" -eq 0 ]
+  [[ "$output" == "$expected" ]]
+}
+
+# bats test_tags=omni:help,omni:help:self
+@test "omni help fails to show the help message if terminal width is too low (columns=10)" {
+  local omni_config="${HOME}/.config/omni/config.yaml"
+  mkdir -p "$(dirname "$omni_config")"
+  cat <<EOF >>"$omni_config"
+commands:
+  supercalifragilisticexpialidocious:
+    aliases:
+      - abracadabra
+      - hocuspocus
+      - open-sesame
+    desc: |
+      lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+      eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+      enim ad minim veniam, quis nostrud exercitation ullamco laboris
+      nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+      in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+      nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+      sunt in culpa qui officia deserunt mollit anim id est laborum.
+    run: |
+      echo "Hello, world!"
+EOF
+
+  version=$(omni --version | cut -d' ' -f3)
+
+  read -r -d '' expected <<EOF || true
+omni - omnipotent tool (v$version)
+
+Usage: omni <command> [options] ARG...
+omni: help command failed: terminal width is too small to print help
+EOF
+
+  export COLUMNS=10
+  run omni help 3>&-
+
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
 
   set -o pipefail
   diff -u <(echo "$expected") <(echo "$output") 3>&- | cat "-$CAT_OPTS" 3>&-


### PR DESCRIPTION
This handles lower resolutions of terminal by splitting the command name over multiple lines if needed. It also adds an error message for very low terminal resolutions.

Fixes https://github.com/XaF/omni/issues/462