### PR TITLE
feat(up): ✨ add the `any` operation and `preferred_tools` config

### DIFF
--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -418,36 +418,6 @@ impl HelpCommand {
             }
 
             eprint!("{}", buf);
-
-            // This makes sure that the help message starts only on the last line of
-            // the command shown on the left
-            // let empty_str = "".to_string();
-            // let help_vec = std::iter::repeat(&empty_str)
-            // .take(all_names_and_len.len() - 1)
-            // .chain(help_vec.iter())
-            // .collect::<Vec<&String>>();
-
-            // // Generate the final help message
-            // let help = all_names_and_len
-            // .into_iter()
-            // .chain(std::iter::repeat(("".to_string(), 0)))
-            // .zip(help_vec.iter())
-            // .map(|((name, namelen), help)| {
-            // format!(
-            // "  {}{}{}",
-            // name,
-            // if help.is_empty() {
-            // "".to_string()
-            // } else {
-            // " ".repeat(ljust - namelen)
-            // },
-            // help,
-            // )
-            // })
-            // .collect::<Vec<String>>()
-            // .join("\n");
-
-            // eprintln!("{}", help);
         }
 
         true

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -9,6 +9,18 @@ pub struct UpCommandConfig {
     pub auto_bootstrap: bool,
     pub notify_workdir_config_updated: bool,
     pub notify_workdir_config_available: bool,
+    pub preferred_tools: Vec<String>,
+}
+
+impl Default for UpCommandConfig {
+    fn default() -> Self {
+        Self {
+            auto_bootstrap: Self::DEFAULT_AUTO_BOOTSTRAP,
+            notify_workdir_config_updated: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED,
+            notify_workdir_config_available: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE,
+            preferred_tools: Vec::new(),
+        }
+    }
 }
 
 impl UpCommandConfig {
@@ -17,26 +29,39 @@ impl UpCommandConfig {
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE: bool = true;
 
     pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
-        if let Some(config_value) = config_value {
-            if let Some(config_value) = config_value.reject_scope(&ConfigScope::Workdir) {
-                return Self {
-                    auto_bootstrap: config_value
-                        .get_as_bool("auto_bootstrap")
-                        .unwrap_or(Self::DEFAULT_AUTO_BOOTSTRAP),
-                    notify_workdir_config_updated: config_value
-                        .get_as_bool("notify_workdir_config_updated")
-                        .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED),
-                    notify_workdir_config_available: config_value
-                        .get_as_bool("notify_workdir_config_available")
-                        .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE),
-                };
-            }
-        }
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let config_value = match config_value.reject_scope(&ConfigScope::Workdir) {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let preferred_tools =
+            if let Some(preferred_tools) = config_value.get_as_array("preferred_tools") {
+                preferred_tools
+                    .iter()
+                    .filter_map(|value| value.as_str().map(|value| value.to_string()))
+                    .collect()
+            } else if let Some(preferred_tool) = config_value.get_as_str_forced("preferred_tools") {
+                vec![preferred_tool]
+            } else {
+                Vec::new()
+            };
 
         Self {
-            auto_bootstrap: Self::DEFAULT_AUTO_BOOTSTRAP,
-            notify_workdir_config_updated: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED,
-            notify_workdir_config_available: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE,
+            auto_bootstrap: config_value
+                .get_as_bool("auto_bootstrap")
+                .unwrap_or(Self::DEFAULT_AUTO_BOOTSTRAP),
+            notify_workdir_config_updated: config_value
+                .get_as_bool("notify_workdir_config_updated")
+                .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED),
+            notify_workdir_config_available: config_value
+                .get_as_bool("notify_workdir_config_available")
+                .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE),
+            preferred_tools,
         }
     }
 }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -942,14 +942,10 @@ impl UpConfigAsdfBase {
     fn deps(&self) -> &UpConfigTool {
         self.deps
             .get_or_init(|| {
-                let deps: Vec<UpConfigTool> = vec![
-                    // TODO: Add a way to specify the preferred package manager, so
-                    // we can order the dependencies handling based on that
+                Box::new(UpConfigTool::Any(vec![
                     self.deps_using_homebrew(),
                     self.deps_using_nix(),
-                ];
-
-                Box::new(UpConfigTool::Or(deps))
+                ]))
             })
             .as_ref()
     }

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -386,7 +386,7 @@ impl UpConfigTool {
     }
 }
 
-fn ordered_configs(configs: &Vec<UpConfigTool>) -> Vec<&UpConfigTool> {
+fn ordered_configs(configs: &[UpConfigTool]) -> Vec<&UpConfigTool> {
     configs
         .iter()
         .sorted_by(|a, b| a.sort_value().cmp(&b.sort_value()))

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use itertools::any;
+use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::internal::config::global_config;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfig;
 use crate::internal::config::up::UpConfigAsdfBase;
@@ -20,25 +22,64 @@ use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::dynenv::update_dynamic_env_for_command;
 
+/// UpConfigTool represents a tool that can be upped or downed.
+/// It can be a single tool or a combination of tools.
 #[derive(Debug, Deserialize, Clone)]
 pub enum UpConfigTool {
+    /// And represents a combination of tools that must all be upped.
     And(Vec<UpConfigTool>),
+
+    /// Any represents a combination of tools where at least one must
+    /// be upped. It will try to follow user preferences for ordering
+    /// of which tool to handle. If none are available, it will try
+    /// the others in the order they are defined. If the selected tool
+    /// fails to up, it will try the next one until one is successful
+    /// or all have been tried.
+    Any(Vec<UpConfigTool>),
+
     // TODO: Apt(UpConfigApt),
+    /// Bash represents the bash tool.
     Bash(UpConfigAsdfBase),
+
+    /// Bundler represents the bundler tool.
     Bundler(UpConfigBundler),
+
+    /// Custom represents a custom tool, where the user can define
+    /// a custom command to run to up/down the tool.
     Custom(UpConfigCustom),
+
     // TODO: Dnf(UpConfigDnf),
+    /// Go represents the golang tool.
     Go(UpConfigGolang),
+
+    /// Homebrew represents the homebrew tool.
     Homebrew(UpConfigHomebrew),
+
     // TODO: Java(UpConfigAsdfBase), // JAVA_HOME
     // TODO: Kotlin(UpConfigAsdfBase), // KOTLIN_HOME
+    /// Nix represents the nix tool, which can be used to install
+    /// packages from the nix package manager.
     Nix(UpConfigNix),
+
+    /// Nodejs represents the nodejs tool.
     Nodejs(UpConfigNodejs),
+
+    /// Or represents a combination of tools where at least one must
+    /// be upped. It will up the first tool that is available, and
+    /// only try the others if the first one fails.
     Or(Vec<UpConfigTool>),
+
     // TODO: Pacman(UpConfigPacman),
+    /// Python represents the python tool.
     Python(UpConfigPython),
+
+    /// Ruby represents the ruby tool.
     Ruby(UpConfigAsdfBase),
+
+    /// Rust represents the rust tool.
     Rust(UpConfigAsdfBase),
+
+    /// Terraform represents the terraform tool.
     Terraform(UpConfigAsdfBase),
 }
 
@@ -58,6 +99,7 @@ impl Serialize for UpConfigTool {
         // type and the value being the UpConfigTool struct.
         match self {
             UpConfigTool::And(configs) => create_hashmap("and", configs).serialize(serializer),
+            UpConfigTool::Any(configs) => create_hashmap("any", configs).serialize(serializer),
             UpConfigTool::Bash(config) => create_hashmap("bash", config).serialize(serializer),
             UpConfigTool::Bundler(config) => {
                 create_hashmap("bundler", config).serialize(serializer)
@@ -83,7 +125,7 @@ impl Serialize for UpConfigTool {
 impl UpConfigTool {
     pub fn from_config_value(up_name: &str, config_value: Option<&ConfigValue>) -> Option<Self> {
         match up_name {
-            "and" | "or" => {
+            "and" | "any" | "or" => {
                 let upconfig = match UpConfig::from_config_value(config_value.cloned()) {
                     Some(upconfig) => upconfig,
                     None => return None,
@@ -91,10 +133,13 @@ impl UpConfigTool {
 
                 if upconfig.steps.is_empty() {
                     None
-                } else if up_name == "and" {
-                    Some(UpConfigTool::And(upconfig.steps))
                 } else {
-                    Some(UpConfigTool::Or(upconfig.steps))
+                    match up_name {
+                        "and" => Some(UpConfigTool::And(upconfig.steps)),
+                        "any" => Some(UpConfigTool::Any(upconfig.steps)),
+                        "or" => Some(UpConfigTool::Or(upconfig.steps)),
+                        _ => None,
+                    }
                 }
             }
             "bash" => Some(UpConfigTool::Bash(
@@ -146,7 +191,7 @@ impl UpConfigTool {
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         match self {
-            UpConfigTool::And(_) | UpConfigTool::Or(_) => {}
+            UpConfigTool::And(_) | UpConfigTool::Any(_) | UpConfigTool::Or(_) => {}
             _ => {
                 // Update the dynamic environment so that if anything has changed
                 // the command can consider it right away
@@ -160,6 +205,18 @@ impl UpConfigTool {
                     config.up(options, progress_handler)?;
                 }
                 Ok(())
+            }
+            UpConfigTool::Any(configs) => {
+                let mut result = Ok(());
+                for config in ordered_configs(configs) {
+                    if config.is_available() {
+                        result = config.up(options, progress_handler);
+                        if result.is_ok() {
+                            break;
+                        }
+                    }
+                }
+                result
             }
             UpConfigTool::Bash(config) => config.up(options, progress_handler),
             UpConfigTool::Bundler(config) => config.up(progress_handler),
@@ -191,7 +248,7 @@ impl UpConfigTool {
 
     pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
         match self {
-            UpConfigTool::And(configs) | UpConfigTool::Or(configs) => {
+            UpConfigTool::And(configs) | UpConfigTool::Any(configs) | UpConfigTool::Or(configs) => {
                 for config in configs {
                     config.down(progress_handler)?;
                 }
@@ -213,7 +270,7 @@ impl UpConfigTool {
 
     pub fn is_available(&self) -> bool {
         match self {
-            UpConfigTool::And(configs) | UpConfigTool::Or(configs) => {
+            UpConfigTool::And(configs) | UpConfigTool::Any(configs) | UpConfigTool::Or(configs) => {
                 any(configs, |config| config.is_available())
             }
             UpConfigTool::Homebrew(config) => config.is_available(),
@@ -231,7 +288,7 @@ impl UpConfigTool {
 
     pub fn was_upped(&self) -> bool {
         match self {
-            UpConfigTool::And(configs) | UpConfigTool::Or(configs) => {
+            UpConfigTool::And(configs) | UpConfigTool::Any(configs) | UpConfigTool::Or(configs) => {
                 any(configs, |config| config.was_upped())
             }
             UpConfigTool::Bash(config) => config.was_upped(),
@@ -277,4 +334,61 @@ impl UpConfigTool {
             _ => vec![],
         }
     }
+
+    pub fn to_name(&self) -> &str {
+        match self {
+            UpConfigTool::And(_) => "and",
+            UpConfigTool::Any(_) => "any",
+            UpConfigTool::Or(_) => "or",
+            UpConfigTool::Bash(_) => "bash",
+            UpConfigTool::Bundler(_) => "bundler",
+            UpConfigTool::Custom(_) => "custom",
+            UpConfigTool::Go(_) => "go",
+            UpConfigTool::Homebrew(_) => "homebrew",
+            UpConfigTool::Nix(_) => "nix",
+            UpConfigTool::Nodejs(_) => "nodejs",
+            UpConfigTool::Python(_) => "python",
+            UpConfigTool::Ruby(_) => "ruby",
+            UpConfigTool::Rust(_) => "rust",
+            UpConfigTool::Terraform(_) => "terraform",
+        }
+    }
+
+    pub fn sort_value(&self) -> i32 {
+        match self {
+            UpConfigTool::And(configs) | UpConfigTool::Any(configs) | UpConfigTool::Or(configs) => {
+                // return the minimum sort value of all the configs
+                // in the list
+                configs
+                    .iter()
+                    .map(|config| config.sort_value())
+                    .min()
+                    .unwrap_or(i32::MAX)
+            }
+            _ => {
+                let config = global_config();
+                let preferred_tools = &config.up_command.preferred_tools;
+
+                // check what is the position for self.to_name() in
+                // preferred_tools and if it is not there, return the
+                // max value possible; the lowest value means the
+                // highest priority
+                let position = preferred_tools
+                    .iter()
+                    .position(|x| x.to_lowercase() == self.to_name());
+
+                match position {
+                    Some(position) => position as i32,
+                    None => i32::MAX,
+                }
+            }
+        }
+    }
+}
+
+fn ordered_configs(configs: &Vec<UpConfigTool>) -> Vec<&UpConfigTool> {
+    configs
+        .iter()
+        .sorted_by(|a, b| a.sort_value().cmp(&b.sort_value()))
+        .collect()
 }

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-any.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-any.md
@@ -1,0 +1,59 @@
+---
+description: Configuration of the `any` kind of `up` parameter
+---
+
+# `any` operation
+
+Composite operation that takes a list of operations as parameter.
+
+When called during `omni up`, it will reorder the list to consider the [configured preferred tools](../up_command) first, then the rest in the order they were defined. It will then execute operations in the list until one of them is available and succeeds. If none of the operations are available, the `any` operation will be considered unavailable. If none of the available operations succeed, the `any` operation will fail.
+
+When called during `omni down`, it will execute all operations in the list.
+
+:::note
+The `any` operation is useful when you want to install a package using different package managers, and you want to use the first available one. It is also useful when you want to use a preferred tool over others.
+:::
+
+:::info
+Other operations requiring to install dependencies (e.g. [python](../up/python), [ruby](../up/ruby), [node](../up/node), [go](../up/go), etc.) are using an `any` operation internally to install the required dependencies prior to installing the requested tool.
+:::
+
+## Examples
+
+### Without preferred tools
+
+```yaml title="~/git/github.com/xaf/repo/.omni.yaml"
+up:
+  # Installs gawk using either homebrew or nix, whichever is available,
+  # and if both are available will use homebrew in priority if no preferred
+  # tools are configured.
+  - any:
+    - homebrew:
+        install:
+        - gawk
+    - nix:
+      - gawk
+```
+
+### With preferred tools (nix, then brew)
+
+```yaml title="~/.config/omni/config.yaml"
+up_command:
+  preferred_tools:
+    - nix
+    - homebrew
+```
+
+```yaml title="~/git/github.com/xaf/repo/.omni.yaml"
+up:
+  # Installs gawk using either homebrew or nix, whichever is available,
+  # and if both are available will use nix in priority since it is a
+  # preferred tool that has a higher priority than homebrew.
+  - any:
+    - homebrew:
+        install:
+        - gawk
+    - nix:
+      - gawk
+```
+

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-any.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-any.md
@@ -22,7 +22,7 @@ Other operations requiring to install dependencies (e.g. [python](../up/python),
 
 ### Without preferred tools
 
-```yaml title="~/git/github.com/xaf/repo/.omni.yaml"
+```yaml title="~/git/<repo path>/.omni.yaml"
 up:
   # Installs gawk using either homebrew or nix, whichever is available,
   # and if both are available will use homebrew in priority if no preferred
@@ -44,7 +44,7 @@ up_command:
     - homebrew
 ```
 
-```yaml title="~/git/github.com/xaf/repo/.omni.yaml"
+```yaml title="~/git/<repo path>/.omni.yaml"
 up:
   # Installs gawk using either homebrew or nix, whichever is available,
   # and if both are available will use nix in priority since it is a

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
@@ -14,6 +14,7 @@ Each entry in the list can either be a single string (loads the operation with d
 | Operation | Type | Description                                                    |
 |-----------|------|---------------------------------------------------------|
 | `and` | [and](up/and) | Run multiple operations in sequence |
+| `any` | [any](up/any) | Run the first operation that succeeds and skip the rest, while considering [configured preferred tools](up_command) |
 | `apt` | [apt](up/apt) | Install packages with `apt` for ubuntu and debian-based systems |
 | `bash` | [bash](up/bash) | Install bash |
 | `bundler` | [bundler](up/bundler) | Install dependencies with bundler |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -13,6 +13,7 @@ Configuration related to the `omni up` command.
 | `auto_bootstrap` | boolean | whether or not to automatically infer the `--bootstrap` parameter when running `omni up`, if changes to the configuration suggestions from the work directory are detected *(default: true)* |
 | `notify_workdir_config_updated` | boolean | whether or not to print a message on the prompt if the `up` configuration of the work directory has been updated since the last `omni up` *(default: true)* |
 | `notify_workdir_config_available` | boolean | whether or not to print a message on the prompt if the current work directory has an available `up` configuration but `omni up` has not been run yet *(default: true)* |
+| `preferred_tools` | list | list of preferred tools for [`any` operations](up/any) when running `omni up`; those tools will be preferred over others, in the order they are defined |
 
 ## Example
 
@@ -21,4 +22,8 @@ up_command:
   auto_bootstrap: true
   notify_workdir_config_updated: true
   notify_workdir_config_available: true
+  preferred_tools:
+  - nix
+  - brew
+  - apt
 ```


### PR DESCRIPTION
This operation works like `or` but handles user preference where `or` only considers operation order. If any tools are defined in `preferred_tools`, these would be considered in priority before defaulting to the rest of the available operations.

This allows for a better handling of dependencies by using the tools that the user favor, even if other tooling is available in the system.

Closes https://github.com/XaF/omni/issues/464