### PR TITLE
fix(spinners): 🐛 new lines are now ensured properly after a spinner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -297,5 +297,6 @@ jobs:
       - name: Enable auto-merge if Dependabot
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge --squash --auto ${{ github.event.pull_request.number }}
+          gh pr merge --squash --auto --body "" "$PR_NUMBER"

--- a/src/internal/user_interface/mod.rs
+++ b/src/internal/user_interface/mod.rs
@@ -3,6 +3,7 @@ pub use colors::StringColor;
 
 pub mod print;
 pub use print::ensure_newline;
+pub use print::ensure_newline_from_len;
 pub use print::term_width;
 pub use print::wrap_blocks;
 pub use print::wrap_text;

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -220,3 +220,13 @@ pub fn ensure_newline() {
         }
     }
 }
+
+pub fn ensure_newline_from_len(len: usize) {
+    if shell_is_interactive() {
+        if let Ok((x, _y)) = term_cursor::get_pos() {
+            if x > 0 && len > term_columns() {
+                eprintln!();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previous approach was not keeping track of the length of lines, which in turn led to newlines being printed even though it was not required. Now we keep track of the length of the last line printed in a spinner, and only add a line return if it went over the expected line length.