### PR TITLE
fix(cleanup): 🐛 data path cleanup won't delete auto versions

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -849,7 +849,7 @@ impl UpConfigAsdfBase {
             let version_data_path = tool_data_path.join(version);
 
             for dir in dirs {
-                let hashed_dir = data_path_dir_hash(&dir);
+                let hashed_dir = data_path_dir_hash(dir);
                 data_paths.insert(version_data_path.join(&hashed_dir));
             }
         }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -830,11 +830,9 @@ impl UpConfigAsdfBase {
 
         if let Some(version) = self.actual_version.get() {
             let dirs = match self.dirs.is_empty() {
-                true => vec!["".to_string()],
-                false => self.dirs.iter().cloned().collect(),
-            }
-            .into_iter()
-            .collect::<BTreeSet<_>>();
+                true => vec!["".to_string()].into_iter().collect(),
+                false => self.dirs.clone(),
+            };
 
             dirs_per_version.insert(version.clone(), dirs);
         }


### PR DESCRIPTION
In 0.0.22, the improved data path cleanup unfortunately didn't follow the auto-discovered versions to know which data paths to keep, leading to cleaning up needed directories.

This fixes that by bubbling down the data paths of all installed versions in all directories.