### PR TITLE
feat(shims): ✨ add a shims directory with all dynamic binaries

### DIFF
--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::builtin::TidyGitRepo;
 use crate::internal::commands::utils::abs_path;
@@ -148,16 +149,26 @@ impl ConfigBootstrapCommand {
             exit(1);
         })
     }
+}
 
-    pub fn name(&self) -> Vec<String> {
+impl BuiltinCommand for ConfigBootstrapCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
         vec!["config".to_string(), "bootstrap".to_string()]
     }
 
-    pub fn aliases(&self) -> Vec<Vec<String>> {
+    fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
     }
 
-    pub fn help(&self) -> Option<String> {
+    fn help(&self) -> Option<String> {
         Some(
             concat!(
                 "Bootstraps the configuration of omni\n",
@@ -170,7 +181,7 @@ impl ConfigBootstrapCommand {
         )
     }
 
-    pub fn syntax(&self) -> Option<CommandSyntax> {
+    fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
             parameters: vec![
@@ -198,11 +209,11 @@ impl ConfigBootstrapCommand {
         })
     }
 
-    pub fn category(&self) -> Option<Vec<String>> {
+    fn category(&self) -> Option<Vec<String>> {
         Some(vec!["General".to_string()])
     }
 
-    pub fn exec(&self, argv: Vec<String>) {
+    fn exec(&self, argv: Vec<String>) {
         if self
             .cli_args
             .set(ConfigBootstrapCommandArgs::parse(argv))
@@ -225,11 +236,11 @@ impl ConfigBootstrapCommand {
         exit(0);
     }
 
-    pub fn autocompletion(&self) -> bool {
+    fn autocompletion(&self) -> bool {
         true
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         println!("--organizations");
         println!("--repo-path-format");
         println!("--shell");

--- a/src/internal/commands/builtin/config/mod.rs
+++ b/src/internal/commands/builtin/config/mod.rs
@@ -4,3 +4,6 @@ pub(crate) use bootstrap::ConfigBootstrapCommand;
 
 pub(crate) mod path;
 pub(crate) use path::ConfigPathSwitchCommand;
+
+pub(crate) mod reshim;
+pub(crate) use reshim::ConfigReshimCommand;

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -6,6 +6,7 @@ use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 use once_cell::sync::OnceCell;
 
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::builtin::CloneCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::builtin::TidyGitRepo;
@@ -124,15 +125,24 @@ impl ConfigPathSwitchCommand {
         }
     }
 
-    #[allow(dead_code)]
     fn cli_args(&self) -> &ConfigPathSwitchCommandArgs {
         self.cli_args.get_or_init(|| {
             omni_error!("command arguments not initialized");
             exit(1);
         })
     }
+}
 
-    pub fn name(&self) -> Vec<String> {
+impl BuiltinCommand for ConfigPathSwitchCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
         vec![
             "config".to_string(),
             "path".to_string(),
@@ -140,11 +150,11 @@ impl ConfigPathSwitchCommand {
         ]
     }
 
-    pub fn aliases(&self) -> Vec<Vec<String>> {
+    fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
     }
 
-    pub fn help(&self) -> Option<String> {
+    fn help(&self) -> Option<String> {
         Some(
             concat!(
                 "Switch the source of a repository in the omnipath\n",
@@ -159,7 +169,7 @@ impl ConfigPathSwitchCommand {
         )
     }
 
-    pub fn syntax(&self) -> Option<CommandSyntax> {
+    fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
             parameters: vec![
@@ -192,11 +202,11 @@ impl ConfigPathSwitchCommand {
         })
     }
 
-    pub fn category(&self) -> Option<Vec<String>> {
+    fn category(&self) -> Option<Vec<String>> {
         Some(vec!["General".to_string()])
     }
 
-    pub fn exec(&self, argv: Vec<String>) {
+    fn exec(&self, argv: Vec<String>) {
         if self
             .cli_args
             .set(ConfigPathSwitchCommandArgs::parse(argv))
@@ -493,11 +503,11 @@ impl ConfigPathSwitchCommand {
         exit(0);
     }
 
-    pub fn autocompletion(&self) -> bool {
+    fn autocompletion(&self) -> bool {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         Err(())
     }
 }

--- a/src/internal/commands/builtin/config/reshim.rs
+++ b/src/internal/commands/builtin/config/reshim.rs
@@ -1,0 +1,91 @@
+use std::process::exit;
+
+use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::HelpCommand;
+use crate::internal::config::up::utils::reshim;
+use crate::internal::config::up::utils::PrintProgressHandler;
+use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::CommandSyntax;
+use crate::internal::user_interface::StringColor;
+
+#[derive(Debug, Clone)]
+pub struct ConfigReshimCommand {}
+
+impl ConfigReshimCommand {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl BuiltinCommand for ConfigReshimCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
+        vec!["config".to_string(), "reshim".to_string()]
+    }
+
+    fn aliases(&self) -> Vec<Vec<String>> {
+        vec![]
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(
+            concat!(
+                "Regenerate the shims for the environments managed by omni\n",
+                "\n",
+                "This will get all the binaries that exist for at least one of the ",
+                "environments managed by omni and create a shim for them in the ",
+                "shim directory.\n",
+            )
+            .to_string(),
+        )
+    }
+
+    fn syntax(&self) -> Option<CommandSyntax> {
+        Some(CommandSyntax {
+            usage: None,
+            parameters: vec![],
+        })
+    }
+
+    fn category(&self) -> Option<Vec<String>> {
+        Some(vec!["General".to_string()])
+    }
+
+    fn exec(&self, argv: Vec<String>) {
+        if !argv.is_empty() {
+            HelpCommand::new().exec(self.name());
+            exit(1);
+        }
+
+        let progress_handler = PrintProgressHandler::new("reshim:".light_blue(), None);
+        match reshim(&progress_handler) {
+            Ok(Some(result)) => {
+                progress_handler.success_with_message(result);
+            }
+            Ok(None) => {
+                progress_handler.success_with_message("nothing to do".light_black());
+            }
+            Err(e) => {
+                progress_handler.error_with_message(format!("{}", e));
+                exit(1);
+            }
+        }
+
+        exit(0);
+    }
+
+    fn autocompletion(&self) -> bool {
+        false
+    }
+
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        Err(())
+    }
+}

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -1,3 +1,4 @@
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 
@@ -8,20 +9,30 @@ impl HookCommand {
     pub fn new() -> Self {
         Self {}
     }
+}
 
-    pub fn name(&self) -> Vec<String> {
+impl BuiltinCommand for HookCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
         vec!["hook".to_string()]
     }
 
-    pub fn aliases(&self) -> Vec<Vec<String>> {
+    fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
     }
 
-    pub fn help(&self) -> Option<String> {
+    fn help(&self) -> Option<String> {
         Some(concat!("Call one of omni's hooks for the shell\n",).to_string())
     }
 
-    pub fn syntax(&self) -> Option<CommandSyntax> {
+    fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
             parameters: vec![
@@ -39,15 +50,17 @@ impl HookCommand {
         })
     }
 
-    pub fn category(&self) -> Option<Vec<String>> {
+    fn category(&self) -> Option<Vec<String>> {
         Some(vec!["General".to_string()])
     }
 
-    pub fn autocompletion(&self) -> bool {
+    fn exec(&self, _argv: Vec<String>) {}
+
+    fn autocompletion(&self) -> bool {
         false
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(&self, comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         if comp_cword == 0 {
             println!("env");
             println!("init");

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -61,6 +61,7 @@ impl HookEnvCommandArgs {
             }
         };
 
+        #[allow(clippy::redundant_closure)]
         let shell = matches
             .get_one::<String>("shell")
             .map(|shell| Shell::from_str(shell))

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -6,6 +6,7 @@ use shell_escape::escape;
 use tera::Context;
 use tera::Tera;
 
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::HelpCommand;
 use crate::internal::config::global_config;
 use crate::internal::config::CommandSyntax;
@@ -168,16 +169,26 @@ impl HookInitCommand {
     pub fn new() -> Self {
         Self {}
     }
+}
 
-    pub fn name(&self) -> Vec<String> {
+impl BuiltinCommand for HookInitCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
         vec!["hook".to_string(), "init".to_string()]
     }
 
-    pub fn aliases(&self) -> Vec<Vec<String>> {
+    fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
     }
 
-    pub fn help(&self) -> Option<String> {
+    fn help(&self) -> Option<String> {
         Some(
             concat!(
             "Hook used to initialize the shell\n",
@@ -199,7 +210,7 @@ impl HookInitCommand {
         )
     }
 
-    pub fn syntax(&self) -> Option<CommandSyntax> {
+    fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
             parameters: vec![
@@ -235,11 +246,11 @@ impl HookInitCommand {
         })
     }
 
-    pub fn category(&self) -> Option<Vec<String>> {
+    fn category(&self) -> Option<Vec<String>> {
         Some(vec!["General".to_string()])
     }
 
-    pub fn exec(&self, argv: Vec<String>) {
+    fn exec(&self, argv: Vec<String>) {
         let args = HookInitCommandArgs::parse(argv);
 
         match args.shell.as_str() {
@@ -269,11 +280,11 @@ impl HookInitCommand {
         exit(0);
     }
 
-    pub fn autocompletion(&self) -> bool {
+    fn autocompletion(&self) -> bool {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         Err(())
     }
 }

--- a/src/internal/commands/builtin/hook/uuid.rs
+++ b/src/internal/commands/builtin/hook/uuid.rs
@@ -2,6 +2,7 @@ use std::process::exit;
 
 use uuid::Uuid;
 
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::config::CommandSyntax;
 
 #[derive(Debug, Clone)]
@@ -11,16 +12,26 @@ impl HookUuidCommand {
     pub fn new() -> Self {
         Self {}
     }
+}
 
-    pub fn name(&self) -> Vec<String> {
+impl BuiltinCommand for HookUuidCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
         vec!["hook".to_string(), "uuid".to_string()]
     }
 
-    pub fn aliases(&self) -> Vec<Vec<String>> {
+    fn aliases(&self) -> Vec<Vec<String>> {
         vec![]
     }
 
-    pub fn help(&self) -> Option<String> {
+    fn help(&self) -> Option<String> {
         Some(concat!(
             "Hook to generate a UUID\n",
             "\n",
@@ -29,28 +40,28 @@ impl HookUuidCommand {
         ).to_string())
     }
 
-    pub fn syntax(&self) -> Option<CommandSyntax> {
+    fn syntax(&self) -> Option<CommandSyntax> {
         Some(CommandSyntax {
             usage: None,
             parameters: vec![],
         })
     }
 
-    pub fn category(&self) -> Option<Vec<String>> {
+    fn category(&self) -> Option<Vec<String>> {
         Some(vec!["General".to_string()])
     }
 
-    pub fn exec(&self, _argv: Vec<String>) {
+    fn exec(&self, _argv: Vec<String>) {
         let uuid = Uuid::new_v4();
         println!("{}", uuid);
         exit(0);
     }
 
-    pub fn autocompletion(&self) -> bool {
+    fn autocompletion(&self) -> bool {
         false
     }
 
-    pub fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
         Err(())
     }
 }

--- a/src/internal/commands/builtin/mod.rs
+++ b/src/internal/commands/builtin/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod config;
 pub(crate) use config::config_bootstrap;
 pub(crate) use config::ConfigBootstrapCommand;
 pub(crate) use config::ConfigPathSwitchCommand;
+pub(crate) use config::ConfigReshimCommand;
 
 pub(crate) mod scope;
 pub(crate) use scope::ScopeCommand;

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -4,6 +4,7 @@ use once_cell::sync::OnceCell;
 use regex::Regex;
 
 use crate::internal::cache::utils::Empty;
+use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::path::omnipath_entries;
 use crate::internal::config::config;
@@ -135,123 +136,6 @@ impl StatusCommand {
             omni_error!("command arguments not initialized");
             exit(1);
         })
-    }
-
-    pub fn name(&self) -> Vec<String> {
-        vec!["status".to_string()]
-    }
-
-    pub fn aliases(&self) -> Vec<Vec<String>> {
-        vec![]
-    }
-
-    pub fn help(&self) -> Option<String> {
-        Some(
-            concat!(
-                "Show the status of omni\n",
-                "\n",
-                "This will show the configuration that omni is loading when called ",
-                "from the current directory."
-            )
-            .to_string(),
-        )
-    }
-
-    pub fn syntax(&self) -> Option<CommandSyntax> {
-        Some(CommandSyntax {
-            usage: None,
-            parameters: vec![
-                SyntaxOptArg {
-                    name: "--shell-integration".to_string(),
-                    desc: Some("Show if the shell integration is loaded or not.".to_string()),
-                    required: false,
-                },
-                SyntaxOptArg {
-                    name: "--config".to_string(),
-                    desc: Some(
-                        "Show the configuration that omni is using for the current directory. This is not shown by default."
-                            .to_string(),
-                    ),
-                    required: false,
-                },
-                SyntaxOptArg {
-                    name: "--config-files".to_string(),
-                    desc: Some(
-                        "Show the configuration files that omni is loading for the current directory."
-                            .to_string(),
-                    ),
-                    required: false,
-                },
-                SyntaxOptArg {
-                    name: "--worktree".to_string(),
-                    desc: Some(
-                        "Show the default worktree."
-                            .to_string(),
-                    ),
-                    required: false,
-                },
-                SyntaxOptArg {
-                    name: "--orgs".to_string(),
-                    desc: Some(
-                        "Show the organizations."
-                            .to_string(),
-                    ),
-                    required: false,
-                },
-                SyntaxOptArg {
-                    name: "--path".to_string(),
-                    desc: Some(
-                        "Show the current omnipath."
-                            .to_string(),
-                    ),
-                    required: false,
-                },
-            ],
-        })
-    }
-
-    pub fn category(&self) -> Option<Vec<String>> {
-        Some(vec!["General".to_string()])
-    }
-
-    pub fn exec(&self, argv: Vec<String>) {
-        if self.cli_args.set(StatusCommandArgs::parse(argv)).is_err() {
-            unreachable!();
-        }
-
-        if !self.cli_args().single {
-            println!("{}", omni_header!());
-        }
-
-        self.print_shell_integration();
-        self.print_configuration();
-        self.print_configuration_files();
-        self.print_worktree();
-        self.print_orgs();
-        self.print_path();
-
-        exit(0);
-    }
-
-    pub fn autocompletion(&self) -> bool {
-        true
-    }
-
-    pub fn autocomplete(&self, _comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
-        for arg in &[
-            "--shell-integration",
-            "--config",
-            "--config-files",
-            "--worktree",
-            "--orgs",
-            "--path",
-        ] {
-            if !argv.contains(&arg.to_string()) {
-                println!("{}", arg);
-            }
-        }
-
-        Ok(())
     }
 
     fn print_shell_integration(&self) {
@@ -433,5 +317,132 @@ impl StatusCommand {
 
         let yaml_code = yaml_lines.join("\n  │ ");
         format!("  │ {}", yaml_code)
+    }
+}
+
+impl BuiltinCommand for StatusCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
+        vec!["status".to_string()]
+    }
+
+    fn aliases(&self) -> Vec<Vec<String>> {
+        vec![]
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(
+            concat!(
+                "Show the status of omni\n",
+                "\n",
+                "This will show the configuration that omni is loading when called ",
+                "from the current directory."
+            )
+            .to_string(),
+        )
+    }
+
+    fn syntax(&self) -> Option<CommandSyntax> {
+        Some(CommandSyntax {
+            usage: None,
+            parameters: vec![
+                SyntaxOptArg {
+                    name: "--shell-integration".to_string(),
+                    desc: Some("Show if the shell integration is loaded or not.".to_string()),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--config".to_string(),
+                    desc: Some(
+                        "Show the configuration that omni is using for the current directory. This is not shown by default."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--config-files".to_string(),
+                    desc: Some(
+                        "Show the configuration files that omni is loading for the current directory."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--worktree".to_string(),
+                    desc: Some(
+                        "Show the default worktree."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--orgs".to_string(),
+                    desc: Some(
+                        "Show the organizations."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--path".to_string(),
+                    desc: Some(
+                        "Show the current omnipath."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+            ],
+        })
+    }
+
+    fn category(&self) -> Option<Vec<String>> {
+        Some(vec!["General".to_string()])
+    }
+
+    fn exec(&self, argv: Vec<String>) {
+        if self.cli_args.set(StatusCommandArgs::parse(argv)).is_err() {
+            unreachable!();
+        }
+
+        if !self.cli_args().single {
+            println!("{}", omni_header!());
+        }
+
+        self.print_shell_integration();
+        self.print_configuration();
+        self.print_configuration_files();
+        self.print_worktree();
+        self.print_orgs();
+        self.print_path();
+
+        exit(0);
+    }
+
+    fn autocompletion(&self) -> bool {
+        true
+    }
+
+    fn autocomplete(&self, _comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+        for arg in &[
+            "--shell-integration",
+            "--config",
+            "--config-files",
+            "--worktree",
+            "--orgs",
+            "--path",
+        ] {
+            if !argv.contains(&arg.to_string()) {
+                println!("{}", arg);
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -51,7 +51,7 @@ type PostInstallFunc = fn(
     Vec<AsdfToolUpVersion>,
 ) -> Result<(), UpError>;
 
-fn asdf_path() -> String {
+pub fn asdf_path() -> String {
     (*ASDF_PATH).clone()
 }
 

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -6,6 +6,7 @@ use crate::internal::cache::utils::Empty;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::up::utils::cleanup_path;
+use crate::internal::config::up::utils::reshim;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
@@ -218,6 +219,11 @@ impl UpConfig {
         // Then cleanup the data path
         if let Some(cleanup) = self.cleanup_data_path(&progress_handler)? {
             cleanups.push(cleanup);
+        }
+
+        // Then regenerate the shims
+        if let Some(reshim) = reshim(&progress_handler)? {
+            cleanups.push(reshim);
         }
 
         if cleanups.is_empty() {

--- a/src/internal/config/up/utils/directory.rs
+++ b/src/internal/config/up/utils/directory.rs
@@ -29,6 +29,24 @@ pub fn data_path_dir_hash(dir: &str) -> String {
     }
 }
 
+/// Remove the given path, recursively if it is a directory, even
+/// if it contains read-only files. This will first try to remove
+/// the path normally, and if that fails with a PermissionDenied
+/// error, it will make all files and directories in the given path
+/// writeable, and then try again.
+/// The path can be a file, a directory, or a symlink.
+pub fn force_remove_all(path: impl AsRef<Path>) -> std::io::Result<()> {
+    let path = path.as_ref();
+    if path.exists() {
+        if path.is_symlink() || path.is_file() {
+            std::fs::remove_file(path)?;
+        } else {
+            force_remove_dir_all(path)?;
+        }
+    }
+    Ok(())
+}
+
 /// Remove the given directory, even if it contains read-only files.
 /// This will first try to remove the directory normally, and if that
 /// fails with a PermissionDenied error, it will make all files and

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -20,6 +20,10 @@ pub(crate) use progress_handler::ProgressHandler;
 pub(crate) mod run_config;
 pub(crate) use run_config::RunConfig;
 
+pub(crate) mod shims;
+pub(crate) use shims::handle_shims;
+pub(crate) use shims::reshim;
+
 pub(crate) mod spinner_progress_handler;
 pub(crate) use spinner_progress_handler::SpinnerProgressHandler;
 

--- a/src/internal/config/up/utils/shims.rs
+++ b/src/internal/config/up/utils/shims.rs
@@ -1,0 +1,228 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::exit;
+
+use crate::internal::commands::utils::abs_path;
+use crate::internal::config::up::asdf_base::asdf_path;
+use crate::internal::config::up::utils::cleanup_path;
+use crate::internal::config::up::utils::ProgressHandler;
+use crate::internal::config::up::UpError;
+use crate::internal::dynenv::update_dynamic_env_for_command;
+use crate::internal::env::current_exe;
+use crate::internal::env::data_home;
+use crate::internal::env::shims_dir;
+use crate::internal::user_interface::StringColor;
+
+pub fn handle_shims() {
+    let argv0 = match env::args().next() {
+        Some(argv0) => argv0,
+        None => return,
+    };
+
+    // Load the current path environment variable
+    let path_env = env::var("PATH").unwrap_or_else(|_| "".to_string());
+
+    // Check if argv0 is a path, or if it is just a binary name called from the PATH
+    let path = if argv0.contains('/') {
+        abs_path(&argv0)
+    } else {
+        path_env
+            .split(':')
+            .map(|path| PathBuf::from(path).join(&argv0))
+            .find(|path| path.is_file())
+            .unwrap_or_else(|| PathBuf::from(&argv0))
+    };
+
+    // Check if argv0 is a shim, i.e. if its path is in the
+    // shims directory
+    if !path.starts_with(&shims_dir()) {
+        return;
+    }
+
+    // Since argv0 is a shim, let's extract the binary name from it
+    let binary = path
+        .file_name()
+        .map(|file_name| file_name.to_string_lossy().to_string())
+        .unwrap_or_else(|| argv0);
+
+    // Load the dynamic environment for the current directory
+    update_dynamic_env_for_command(".");
+
+    // Make sure that the PATH does not contain the shims directory
+    let path_env = path_env
+        .split(':')
+        .filter(|path| !PathBuf::from(path).starts_with(&shims_dir()))
+        .collect::<Vec<_>>()
+        .join(":");
+    env::set_var("PATH", &path_env);
+
+    // Resolve the binary full path
+    let binary_path = match which::which(&binary) {
+        Ok(binary_path) => binary_path,
+        Err(err) => {
+            // Exit with 127 if the binary was not found
+            eprintln!("{}: {}", binary, err);
+            exit(127);
+        }
+    };
+
+    // Get all the other arguments we received
+    let args = env::args().skip(1).collect::<Vec<_>>();
+
+    // Now replace the current process with the binary
+    let err = std::process::Command::new(&binary_path).args(&args).exec();
+
+    // If we reach this point, it means that the exec failed
+    // so we'll print the error and exit with 126
+    eprintln!("{}: {}", binary, err);
+    exit(126);
+}
+
+pub fn reshim(progress_handler: &dyn ProgressHandler) -> Result<Option<String>, UpError> {
+    // Get all the directories that we need to build shims for
+    let mut shims_sources = vec![];
+
+    // The default asdf shims
+    shims_sources.push(PathBuf::from(asdf_path()).join("shims"));
+
+    // Use a glob to get the shims from the different tools bin
+    // directories in the isolated workdir environments
+    let venv_glob = format!("{}/wd/*/*/*/*/bin", data_home());
+    for entry in glob::glob(&venv_glob).unwrap() {
+        if let Ok(path) = entry {
+            shims_sources.push(path);
+        }
+    }
+
+    // Use a glob to get the shims from the github release tools
+    // bin directories
+    let gh_glob = format!("{}/ghreleases/*/*/*", data_home());
+    for entry in glob::glob(&gh_glob).unwrap() {
+        if let Ok(path) = entry {
+            shims_sources.push(path);
+        }
+    }
+
+    // Figure out the required shims
+    let mut expected_shims = BTreeSet::new();
+
+    // Find all binaries in the source directories and add them
+    // to the list of expected shims
+    for shims_source in &shims_sources {
+        if !shims_source.exists() {
+            continue;
+        }
+
+        let read_dir = match shims_source.read_dir() {
+            Ok(read_dir) => read_dir,
+            Err(_err) => continue,
+        };
+
+        for entry in read_dir {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_err) => continue,
+            };
+
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+
+            let metadata = match path.metadata() {
+                Ok(metadata) => metadata,
+                Err(_err) => continue,
+            };
+
+            let is_executable = metadata.permissions().mode() & 0o111 != 0;
+            if !is_executable {
+                continue;
+            }
+
+            let filename = match path.file_name() {
+                Some(filename) => filename.to_string_lossy().to_string(),
+                None => continue,
+            };
+
+            expected_shims.insert(shims_dir().join(&filename));
+        }
+    }
+
+    let shims_to_create = expected_shims
+        .iter()
+        .filter(|shim| !shim.exists())
+        .collect::<Vec<_>>();
+
+    if !shims_to_create.is_empty() {
+        // Create the shims directory
+        if !shims_dir().exists() {
+            std::fs::create_dir_all(&shims_dir()).map_err(|err| {
+                UpError::Exec(format!(
+                    "failed to create shims directory {}: {}",
+                    shims_dir().display(),
+                    err
+                ))
+            })?;
+        }
+
+        // Create the shims as a symlink to the current executable
+        let target = current_exe();
+        for shim in &shims_to_create {
+            if shim.is_file() || shim.is_symlink() {
+                fs::remove_file(shim).map_err(|err| {
+                    UpError::Exec(format!(
+                        "failed to remove existing file {}: {}",
+                        shim.display(),
+                        err
+                    ))
+                })?;
+            }
+            symlink(&target, shim).map_err(|err| {
+                UpError::Exec(format!(
+                    "failed to create symlink for {}: {}",
+                    shim.display(),
+                    err
+                ))
+            })?;
+        }
+    }
+
+    // Find all shims that are not needed anymore and clean them up
+    let expected_shims: Vec<_> = expected_shims.iter().collect();
+    let (root_removed, num_removed, _) =
+        cleanup_path(&shims_dir(), expected_shims, progress_handler, false)?;
+
+    let num_created = shims_to_create.len();
+    let msg = if root_removed {
+        Some(format!("removed shims directory"))
+    } else if num_created > 0 || num_removed > 0 {
+        let mut msg = String::new();
+        if num_created > 0 {
+            msg.push_str(&format!("+{}", num_created).light_green());
+        }
+        if num_removed > 0 {
+            if num_created > 0 {
+                msg.push_str(", ");
+            }
+            msg.push_str(&format!("-{}", num_removed).light_red());
+        }
+        msg.push_str(&format!(
+            " shim{}",
+            if num_created + num_removed > 1 {
+                "s"
+            } else {
+                ""
+            }
+        ));
+        Some(msg)
+    } else {
+        None
+    };
+
+    Ok(msg)
+}

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -260,7 +260,7 @@ impl DynamicEnvExportOptions {
     }
 
     pub fn apply(&self) {
-        update_dynamic_env(&self);
+        update_dynamic_env(self);
     }
 }
 
@@ -441,7 +441,7 @@ impl DynamicEnv {
 
             // Remove the shims directory from the PATH
             let shims_dir = PathBuf::from(data_home()).join("shims");
-            envsetter.remove_from_list("PATH", &shims_dir.to_str().unwrap());
+            envsetter.remove_from_list("PATH", shims_dir.to_str().unwrap());
 
             // Add the requested paths
             for path in up_env.paths.iter().rev() {

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -95,6 +95,11 @@ lazy_static! {
     };
 
     #[derive(Debug)]
+    static ref SHIMS_DIR: PathBuf = {
+        PathBuf::from(data_home()).join("shims")
+    };
+
+    #[derive(Debug)]
     static ref XDG_CACHE_HOME: String = match std::env::var("XDG_CACHE_HOME") {
         Ok(xdg_cache_home) if !xdg_cache_home.is_empty() && xdg_cache_home.starts_with('/') => {
             xdg_cache_home
@@ -373,6 +378,10 @@ pub fn xdg_data_home() -> String {
 
 pub fn data_home() -> String {
     (*DATA_HOME).to_string()
+}
+
+pub fn shims_dir() -> PathBuf {
+    (*SHIMS_DIR).clone()
 }
 
 pub fn xdg_cache_home() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@ use std::process::exit;
 
 mod internal;
 use internal::command_loader;
+use internal::commands::base::BuiltinCommand;
 use internal::commands::HookEnvCommand;
 use internal::commands::HookInitCommand;
 use internal::commands::HookUuidCommand;
 use internal::config::ensure_bootstrap;
+use internal::config::up::utils::handle_shims;
 use internal::config::up::utils::AskPassRequest;
 use internal::env::tmpdir_cleanup;
 use internal::git::auto_update_async;
@@ -273,6 +275,8 @@ fn set_cleanup_handler() {
 }
 
 fn main() {
+    handle_shims();
+
     let args: Vec<String> = env::args().skip(1).collect();
 
     if !args.is_empty() && args[0] == "--complete" {

--- a/website/contents/reference/02-builtin-commands/02-overview.md
+++ b/website/contents/reference/02-builtin-commands/02-overview.md
@@ -17,6 +17,7 @@ Those commands take precedence over any custom commands, makefile commands or co
 |-------------------------|-----------------------------------------------------------|
 | [`config bootstrap`](builtin-commands/config/bootstrap) | Bootstraps the configuration of omni |
 | [`config path switch`](builtin-commands/config/path/switch) | Switch the source of a repository in the omnipath |
+| [`config reshim`](builtin-commands/config/reshim) | Regenerate the shims for the environments managed by omni |
 | [`help`](builtin-commands/help) | Show help for omni commands |
 | [`hook`](builtin-commands/hook) | Call one of omni's hooks for the shell |
 | [`status`](builtin-commands/status) | Show the status of omni |

--- a/website/contents/reference/02-builtin-commands/0250-config/0250-reshim.md
+++ b/website/contents/reference/02-builtin-commands/0250-config/0250-reshim.md
@@ -1,0 +1,16 @@
+---
+description: Builtin command `config reshim`
+---
+
+# `reshim`
+
+Regenerate the shims for the environments managed by omni
+
+This will get all the binaries that exist for at least one of the environments managed by omni and create a shim for them in the shim directory. This includes binaries imported by using any [`up` operation](/reference/configuration/parameters/up).
+
+## Examples
+
+```bash
+# Regenerate the shims
+omni config reshim
+```

--- a/website/contents/reference/02-builtin-commands/0250-up.md
+++ b/website/contents/reference/02-builtin-commands/0250-up.md
@@ -8,7 +8,7 @@ Sets up a repository depending on its `up` configuration.
 
 The steps to set up the repository are defined in the [`up` configuration parameter](/reference/configuration/parameters/up) of the [repository configuration file](/reference/configuration/files#per-repository-configuration). Those steps are followed in the order in which they are defined when running `omni up`.
 
-Running this command will also refresh the [dynamic environment](/reference/dynamic-environment) of the repository in which it is being run, and cleanup some unused dependencies that omni installed during previous `omni up` calls.
+Running this command will also refresh the [dynamic environment](/reference/dynamic-environment) of the repository in which it is being run, and cleanup some unused dependencies that omni installed during previous `omni up` calls. It will also regenerate the shims.
 
 :::info
 **This needs to be run from a git repository.** If you just created a directory with a basic `up` configuration to start working on a whole new project, run `git init` **and add a remote** before calling `omni up`, as `omni up` depends on the remote identifier to store `up` configuration to be loaded dynamically.


### PR DESCRIPTION
Some tools cannot work directly with the dynamic environment, such as some IDEs. Adding a shims directory that dynamically gets updated on `omni up` allows for a better handling of those IDEs, as they can just fetch the binary from the PATH.

The shims script will simply load omni's environment for the work directory they are being called from, and call the corresponding binary in the PATH. If that PATH does not provide that binary, it will lead to an error. Otherwise, it will return the first matching version of the corresponding binary.

This also adds `omni config reshim` command to update all shims if necessary. This shouldn't be necessary most of the time though, as shims are being regenerated automatically on `omni up`.

Closes https://github.com/XaF/omni/issues/492