### PR TITLE
feat(config trust): ✨ command to manage workdir trust

### DIFF
--- a/src/internal/cache/repositories.rs
+++ b/src/internal/cache/repositories.rs
@@ -32,8 +32,16 @@ impl RepositoriesCache {
     }
 
     pub fn add_trusted(&mut self, repository: &str) -> bool {
-        if !self.has_trusted(repository) {
-            self.trusted.insert(repository.to_string());
+        if self.trusted.insert(repository.to_string()) {
+            self.updated_at = OffsetDateTime::now_utc();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove_trusted(&mut self, repository: &str) -> bool {
+        if self.trusted.remove(repository) {
             self.updated_at = OffsetDateTime::now_utc();
             true
         } else {

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -357,7 +357,7 @@ impl Command {
         match self {
             Command::FromPath(_) | Command::FromConfig(_) | Command::FromMakefile(_) => {
                 // Check if the workdir where the command is located is trusted
-                if !is_trusted(&self.source_dir()) {
+                if !is_trusted(self.source_dir()) {
                     return Err(());
                 }
             }

--- a/src/internal/commands/builtin/config/mod.rs
+++ b/src/internal/commands/builtin/config/mod.rs
@@ -7,3 +7,6 @@ pub(crate) use path::ConfigPathSwitchCommand;
 
 pub(crate) mod reshim;
 pub(crate) use reshim::ConfigReshimCommand;
+
+pub(crate) mod trust;
+pub(crate) use trust::ConfigTrustCommand;

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -1,0 +1,273 @@
+use std::path::PathBuf;
+use std::process::exit;
+
+use once_cell::sync::OnceCell;
+
+use crate::internal::cache::utils::CacheObject;
+use crate::internal::cache::RepositoriesCache;
+use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::HelpCommand;
+use crate::internal::config::CommandSyntax;
+use crate::internal::config::SyntaxOptArg;
+use crate::internal::user_interface::StringColor;
+use crate::internal::workdir;
+use crate::internal::workdir::add_trust;
+use crate::internal::workdir::is_trusted;
+use crate::internal::workdir::remove_trust;
+use crate::internal::ORG_LOADER;
+use crate::omni_error;
+use crate::omni_info;
+
+#[derive(Debug, Clone)]
+struct ConfigTrustCommandArgs {
+    check_status: bool,
+    repository: Option<String>,
+}
+
+impl ConfigTrustCommandArgs {
+    fn parse(argv: Vec<String>) -> Self {
+        let mut parse_argv = vec!["".to_string()];
+        parse_argv.extend(argv);
+
+        let matches = clap::Command::new("")
+            .disable_help_subcommand(true)
+            .disable_version_flag(true)
+            .arg(
+                clap::Arg::new("check")
+                    .long("check")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(clap::Arg::new("repo").action(clap::ArgAction::Set))
+            .try_get_matches_from(&parse_argv);
+
+        let matches = match matches {
+            Ok(matches) => matches,
+            Err(err) => {
+                match err.kind() {
+                    clap::error::ErrorKind::DisplayHelp
+                    | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+                        HelpCommand::new().exec(vec!["cd".to_string()]);
+                    }
+                    clap::error::ErrorKind::DisplayVersion => {
+                        unreachable!("version flag is disabled");
+                    }
+                    _ => {
+                        let err_str = format!("{}", err);
+                        let err_str = err_str
+                            .split('\n')
+                            .take_while(|line| !line.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let err_str = err_str.trim_start_matches("error: ");
+                        omni_error!(err_str);
+                    }
+                }
+                exit(1);
+            }
+        };
+
+        Self {
+            check_status: *matches.get_one::<bool>("check").unwrap_or(&false),
+            repository: matches.get_one::<String>("repo").map(|arg| arg.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigTrustCommand {
+    cli_args: OnceCell<ConfigTrustCommandArgs>,
+}
+
+impl ConfigTrustCommand {
+    pub fn new() -> Self {
+        Self {
+            cli_args: OnceCell::new(),
+        }
+    }
+
+    fn cli_args(&self) -> &ConfigTrustCommandArgs {
+        self.cli_args.get_or_init(|| {
+            omni_error!("command arguments not initialized");
+            exit(1);
+        })
+    }
+
+    fn subcommand(&self) -> String {
+        std::env::var("OMNI_SUBCOMMAND").unwrap_or("config trust".to_string())
+    }
+
+    fn is_trust(&self) -> bool {
+        self.subcommand() == "config trust"
+    }
+}
+
+impl BuiltinCommand for ConfigTrustCommand {
+    fn new_boxed() -> Box<dyn BuiltinCommand> {
+        Box::new(Self::new())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn BuiltinCommand> {
+        Box::new(self.clone())
+    }
+
+    fn name(&self) -> Vec<String> {
+        vec!["config".to_string(), "trust".to_string()]
+    }
+
+    fn aliases(&self) -> Vec<Vec<String>> {
+        vec![vec!["config".to_string(), "untrust".to_string()]]
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(
+            concat!(
+                "Trust or untrust a work directory.\n",
+                "\n",
+                "If the work directory is trusted, \x1B[1mup\x1B[0m and work directory-provided ",
+                "commands will be available to run without asking confirmation.\n",
+            )
+            .to_string(),
+        )
+    }
+
+    fn syntax(&self) -> Option<CommandSyntax> {
+        Some(CommandSyntax {
+            usage: None,
+            parameters: vec![
+                SyntaxOptArg {
+                    name: "--check".to_string(),
+                    desc: Some(
+                        concat!(
+                            "Check the trust status of the repository instead of changing it ",
+                            "\x1B[90m(default: false)\x1B[0m",
+                        )
+                        .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "repo".to_string(),
+                    desc: Some(
+                        concat!(
+                            "The repository to trust or untrust ",
+                            "\x1B[90m(default: current)\x1B[0m",
+                        )
+                        .to_string(),
+                    ),
+                    required: false,
+                },
+            ],
+        })
+    }
+
+    fn category(&self) -> Option<Vec<String>> {
+        Some(vec!["General".to_string()])
+    }
+
+    fn exec(&self, argv: Vec<String>) {
+        if self
+            .cli_args
+            .set(ConfigTrustCommandArgs::parse(argv))
+            .is_err()
+        {
+            unreachable!();
+        }
+
+        let path = if let Some(repo) = &self.cli_args().repository {
+            if let Some(repo_path) = ORG_LOADER.find_repo(&repo, true, false) {
+                repo_path
+            } else {
+                omni_error!(format!("repository not found: {}", repo));
+                exit(1);
+            }
+        } else {
+            PathBuf::from(".")
+        };
+
+        let path_str = path.display().to_string();
+
+        let wd = workdir(path_str.as_str());
+        let wd_id = match wd.id() {
+            Some(id) => id,
+            None => {
+                omni_error!(format!(
+                    "path {} is not a work directory",
+                    path_str.light_yellow()
+                ));
+                exit(2);
+            }
+        };
+
+        let is_trusted = is_trusted(path_str.as_str());
+
+        if self.cli_args().check_status {
+            if is_trusted {
+                omni_info!(
+                    format!("work directory is {}", "trusted".light_green()),
+                    wd_id
+                );
+                exit(0);
+            } else {
+                omni_info!(
+                    format!("work directory is {}", "not trusted".light_red(),),
+                    wd_id
+                );
+                exit(2);
+            }
+        } else if self.is_trust() {
+            if is_trusted {
+                omni_info!(
+                    format!("work directory is already {}", "trusted".light_green()),
+                    wd_id
+                );
+                exit(0);
+            }
+
+            if add_trust(path_str.as_str()) {
+                omni_info!(
+                    format!("work directory is now {}", "trusted".light_green()),
+                    wd_id
+                );
+                exit(0);
+            } else {
+                exit(1);
+            }
+        } else {
+            if !is_trusted {
+                omni_info!(
+                    format!("work directory is already {}", "untrusted".light_red()),
+                    wd_id
+                );
+                exit(0);
+            }
+
+            let wd_trust_id = wd.trust_id().expect("trust id not found");
+            if !RepositoriesCache::get().has_trusted(wd_trust_id.as_str()) {
+                omni_error!(format!(
+                    "work directory {} is in a trusted organization",
+                    wd_id.light_blue()
+                ));
+                exit(1);
+            }
+
+            if remove_trust(path_str.as_str()) {
+                omni_info!(
+                    format!("work directory is now {}", "untrusted".light_red()),
+                    wd_id
+                );
+                exit(0);
+            } else {
+                exit(1);
+            }
+        }
+    }
+
+    fn autocompletion(&self) -> bool {
+        false
+    }
+
+    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
+        // TODO: autocomplete repositories if first argument
+        Err(())
+    }
+}

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -174,7 +174,7 @@ impl BuiltinCommand for ConfigTrustCommand {
         }
 
         let path = if let Some(repo) = &self.cli_args().repository {
-            if let Some(repo_path) = ORG_LOADER.find_repo(&repo, true, false) {
+            if let Some(repo_path) = ORG_LOADER.find_repo(repo, true, false) {
                 repo_path
             } else {
                 omni_error!(format!("repository not found: {}", repo));

--- a/src/internal/commands/builtin/mod.rs
+++ b/src/internal/commands/builtin/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use config::config_bootstrap;
 pub(crate) use config::ConfigBootstrapCommand;
 pub(crate) use config::ConfigPathSwitchCommand;
 pub(crate) use config::ConfigReshimCommand;
+pub(crate) use config::ConfigTrustCommand;
 
 pub(crate) mod scope;
 pub(crate) use scope::ScopeCommand;

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -13,6 +13,7 @@ use crate::internal::commands::builtin::CloneCommand;
 use crate::internal::commands::builtin::ConfigBootstrapCommand;
 use crate::internal::commands::builtin::ConfigPathSwitchCommand;
 use crate::internal::commands::builtin::ConfigReshimCommand;
+use crate::internal::commands::builtin::ConfigTrustCommand;
 use crate::internal::commands::builtin::HelpCommand;
 use crate::internal::commands::builtin::HookCommand;
 use crate::internal::commands::builtin::HookEnvCommand;
@@ -82,6 +83,7 @@ impl CommandLoader {
         commands.push(ConfigBootstrapCommand::new_command());
         commands.push(ConfigPathSwitchCommand::new_command());
         commands.push(ConfigReshimCommand::new_command());
+        commands.push(ConfigTrustCommand::new_command());
         commands.push(HelpCommand::new_command());
         commands.push(HookCommand::new_command());
         commands.push(HookEnvCommand::new_command());

--- a/website/contents/reference/02-builtin-commands/02-overview.md
+++ b/website/contents/reference/02-builtin-commands/02-overview.md
@@ -18,6 +18,8 @@ Those commands take precedence over any custom commands, makefile commands or co
 | [`config bootstrap`](builtin-commands/config/bootstrap) | Bootstraps the configuration of omni |
 | [`config path switch`](builtin-commands/config/path/switch) | Switch the source of a repository in the omnipath |
 | [`config reshim`](builtin-commands/config/reshim) | Regenerate the shims for the environments managed by omni |
+| [`config trust`](builtin-commands/config/trust) | Trust a work directory |
+| [`config untrust`](builtin-commands/config/untrust) | Untrust a work directory |
 | [`help`](builtin-commands/help) | Show help for omni commands |
 | [`hook`](builtin-commands/hook) | Call one of omni's hooks for the shell |
 | [`status`](builtin-commands/status) | Show the status of omni |

--- a/website/contents/reference/02-builtin-commands/0250-config/0250-trust.md
+++ b/website/contents/reference/02-builtin-commands/0250-config/0250-trust.md
@@ -1,0 +1,32 @@
+---
+description: Builtin command `config trust`
+---
+
+# `trust`
+
+Trust a work directory.
+
+When a work directory is trusted, `omni up` and any work directory-provided commands will be available to run without confirmation.
+
+## Parameters
+
+| Parameter       | Required | Value type | Description                                         |
+|-----------------|----------|------------|-----------------------------------------------------|
+| `--check` | no | `null` | If provided, will only check the current status of trust for the repository; if the repository is trusted, exit code will be `0`, if the repository is not trusted, it will be `2` and in case of error it will be `1` |
+| `repo` | no | string | The name of the repo to change directory to; this can be in the format of a full git URL, or `<org>/<repo>`, or just `<repo>`, in which case the repo will be searched for in all the organizations in the order in which they are defined, and then trying all the other repositories in the configured worktrees. |
+
+## Examples
+
+```bash
+# Trust the current repository
+omni config trust
+
+# Trust the xaf/omni repository
+omni config trust xaf/omni
+
+# Check the trust status of the current repository
+omni config trust --check
+
+# Check the trust status of the xaf/omni repository
+omni config trust --check xaf/omni
+```

--- a/website/contents/reference/02-builtin-commands/0250-config/0250-untrust.md
+++ b/website/contents/reference/02-builtin-commands/0250-config/0250-untrust.md
@@ -1,0 +1,32 @@
+---
+description: Builtin command `config untrust`
+---
+
+# `untrust`
+
+Untrust a work directory.
+
+When a work directory is not trusted, `omni up` and any work directory-provided commands will require confirmation before each run.
+
+## Parameters
+
+| Parameter       | Required | Value type | Description                                         |
+|-----------------|----------|------------|-----------------------------------------------------|
+| `--check` | no | `null` | If provided, will only check the current status of trust for the repository; if the repository is trusted, exit code will be `0`, if the repository is not trusted, it will be `2` and in case of error it will be `1` |
+| `repo` | no | string | The name of the repo to change directory to; this can be in the format of a full git URL, or `<org>/<repo>`, or just `<repo>`, in which case the repo will be searched for in all the organizations in the order in which they are defined, and then trying all the other repositories in the configured worktrees. |
+
+## Examples
+
+```bash
+# Trust the current repository
+omni config untrust
+
+# Trust the xaf/omni repository
+omni config untrust xaf/omni
+
+# Check the trust status of the current repository
+omni config untrust --check
+
+# Check the trust status of the xaf/omni repository
+omni config untrust --check xaf/omni
+```


### PR DESCRIPTION
This introduces the new `omni config trust` and `omni config untrust` commands to manage a repository trust in the cache.

This is useful to be proactive about trusting specific repositores or removing the trust of a repository trusted by mistake.

Closes https://github.com/XaF/omni/issues/496 and https://github.com/XaF/omni/issues/487