### PR TITLE
feat(hook init): ✨ handle shims

### DIFF
--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -61,10 +61,10 @@ impl HookEnvCommandArgs {
             }
         };
 
-        #[allow(clippy::redundant_closure)]
         let shell = matches
             .get_one::<String>("shell")
-            .map(|shell| Shell::from_str(shell))
+            .map(|shell| shell.as_str())
+            .map(Shell::from_str)
             .unwrap_or_else(|| Shell::from_env());
         let quiet = *matches.get_one::<bool>("quiet").unwrap_or(&false);
 

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -65,7 +65,7 @@ impl HookEnvCommandArgs {
             .get_one::<String>("shell")
             .map(|shell| shell.as_str())
             .map(Shell::from_str)
-            .unwrap_or_else(|| Shell::from_env());
+            .unwrap_or_else(Shell::from_env);
         let quiet = *matches.get_one::<bool>("quiet").unwrap_or(&false);
 
         Self { shell, quiet }

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -85,7 +85,7 @@ impl HookInitCommandArgs {
             .get_one::<String>("shell")
             .map(|shell| shell.as_str())
             .map(Shell::from_str)
-            .unwrap_or_else(|| Shell::from_env())
+            .unwrap_or_else(Shell::from_env)
             .to_string();
 
         // Load aliases from the configuration first

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::process::exit;
 
 use serde::Serialize;
@@ -12,6 +11,8 @@ use crate::internal::config::global_config;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::current_exe;
+use crate::internal::env::data_home;
+use crate::internal::env::Shell;
 use crate::internal::user_interface::StringColor;
 use crate::omni_error;
 
@@ -20,6 +21,7 @@ struct HookInitCommandArgs {
     shell: String,
     aliases: Vec<String>,
     command_aliases: Vec<InitHookAlias>,
+    shims: bool,
 }
 
 impl HookInitCommandArgs {
@@ -44,42 +46,47 @@ impl HookInitCommandArgs {
                     .number_of_values(2)
                     .action(clap::ArgAction::Append),
             )
+            .arg(
+                clap::Arg::new("shims")
+                    .long("shims")
+                    .action(clap::ArgAction::SetTrue)
+                    .conflicts_with("aliases")
+                    .conflicts_with("command_aliases"),
+            )
             .try_get_matches_from(&parse_argv);
 
-        if let Err(err) = matches {
-            match err.kind() {
-                clap::error::ErrorKind::DisplayHelp
-                | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
-                    HelpCommand::new().exec(vec!["hook".to_string()]);
+        let matches = match matches {
+            Ok(matches) => matches,
+            Err(err) => {
+                match err.kind() {
+                    clap::error::ErrorKind::DisplayHelp
+                    | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+                        HelpCommand::new().exec(vec!["hook".to_string()]);
+                    }
+                    clap::error::ErrorKind::DisplayVersion => {
+                        unreachable!("version flag is disabled");
+                    }
+                    _ => {
+                        let err_str = format!("{}", err);
+                        let err_str = err_str
+                            .split('\n')
+                            .take_while(|line| !line.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let err_str = err_str.trim_start_matches("error: ");
+                        omni_error!(err_str);
+                    }
                 }
-                clap::error::ErrorKind::DisplayVersion => {
-                    unreachable!("version flag is disabled");
-                }
-                _ => {
-                    let err_str = format!("{}", err);
-                    let err_str = err_str
-                        .split('\n')
-                        .take_while(|line| !line.is_empty())
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    let err_str = err_str.trim_start_matches("error: ");
-                    omni_error!(err_str);
-                }
+                exit(1);
             }
-            exit(1);
-        }
-
-        let matches = matches.unwrap();
-
-        let shell = if let Some(shell) = matches.get_one::<String>("shell") {
-            shell.to_string()
-        } else {
-            let mut shell = env::var("SHELL").unwrap_or("bash".to_string());
-            if shell.contains('/') {
-                shell = shell.split('/').last().unwrap().to_string();
-            }
-            shell
         };
+
+        let shell = matches
+            .get_one::<String>("shell")
+            .map(|shell| shell.as_str())
+            .map(Shell::from_str)
+            .unwrap_or_else(|| Shell::from_env())
+            .to_string();
 
         // Load aliases from the configuration first
         let config = global_config();
@@ -120,10 +127,13 @@ impl HookInitCommandArgs {
             },
         );
 
+        let shims = *matches.get_one::<bool>("shims").unwrap_or(&false);
+
         Self {
             shell,
             aliases,
             command_aliases,
+            shims,
         }
     }
 }
@@ -235,6 +245,14 @@ impl BuiltinCommand for HookInitCommand {
                     required: false,
                 },
                 SyntaxOptArg {
+                    name: "--shims".to_string(),
+                    desc: Some(
+                        "Only load the shims without setting up the dynamic environment."
+                            .to_string(),
+                    ),
+                    required: false,
+                },
+                SyntaxOptArg {
                     name: "shell".to_string(),
                     desc: Some(
                         "Which shell to initialize omni for. Can be one of bash, zsh or fish."
@@ -299,8 +317,10 @@ fn dump_integration(args: HookInitCommandArgs, integration: &[u8]) {
             current_exe().to_string_lossy().as_ref(),
         )),
     );
+    context.insert("OMNI_DATA_HOME", &escape(data_home().into()));
     context.insert("OMNI_ALIASES", &args.aliases);
     context.insert("OMNI_COMMAND_ALIASES", &args.command_aliases);
+    context.insert("SHIMS_ONLY", &args.shims);
 
     let result = Tera::one_off(&integration, &context, false)
         .expect("failed to render integration template");

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -819,6 +819,12 @@ pub enum Shell {
     Unknown(String),
 }
 
+impl ToString for Shell {
+    fn to_string(&self) -> String {
+        self.to_str().to_string()
+    }
+}
+
 impl Shell {
     pub fn current() -> Self {
         CURRENT_SHELL.clone()
@@ -888,8 +894,9 @@ fn determine_shell() -> String {
             let shell = shell.to_str().unwrap();
             if !shell.is_empty() {
                 if shell.contains('/') {
-                    let shell = shell.split('/').last().unwrap();
-                    return shell.to_string();
+                    if let Some(shell) = shell.split('/').last() {
+                        return shell.to_string();
+                    }
                 }
                 return shell.to_string();
             }

--- a/templates/shell_integration.bash.tmpl
+++ b/templates/shell_integration.bash.tmpl
@@ -1,3 +1,8 @@
+{% if SHIMS_ONLY -%}
+if [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
+	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+fi
+{%- else -%}
 # This function is used to run the omni command, and then operate on
 # the requested shell changes from the command (changing current
 # working directory, environment, etc.); this is why we require using
@@ -5,14 +10,14 @@
 # command from the path
 function omni() {
 	# Prepare the environment for omni
-	export OMNI_UUID=$(command -v uuidgen >/dev/null && uuidgen || {{OMNI_BIN}} hook uuid)
+	export OMNI_UUID=$(command -v uuidgen >/dev/null && uuidgen || {{ OMNI_BIN }} hook uuid)
 	local tmpdir=${TMPDIR:-/tmp}
 	OMNI_FILE_PREFIX="omni_${OMNI_UUID}"
 	export OMNI_CMD_FILE="${tmpdir}/${OMNI_FILE_PREFIX}.cmd"
 	export OMNI_SHELL=bash
 
 	# Run the command
-	{{OMNI_BIN}} "$@"
+	{{ OMNI_BIN }} "$@"
 	EXIT_CODE=$?
 
 	# Check if OMNI_CMD_FILE exists, and if it does, run the commands
@@ -48,10 +53,10 @@ function omni() {
 {% if OMNI_ALIASES or OMNI_COMMAND_ALIASES -%}
 # Setup aliases for omni
 {% for alias in OMNI_ALIASES -%}
-alias {{alias}}="omni"
+alias {{ alias }}="omni"
 {% endfor -%}
 {% for alias in OMNI_COMMAND_ALIASES -%}
-alias {{alias.alias}}={{alias.full_command}}
+alias {{ alias.alias }}={{ alias.full_command }}
 {% endfor %}
 
 {% endif -%}
@@ -70,9 +75,9 @@ else
 		local alias_skip
 		case "${COMP_WORDS[0]}" in
 			{% for alias in OMNI_COMMAND_ALIASES -%}
-			"{{alias.alias}}")
-				alias_prefix={{alias.command}}
-				alias_skip={{alias.command_size}}
+			"{{ alias.alias }}")
+				alias_prefix={{ alias.command }}
+				alias_skip={{ alias.command_size }}
 				;;
 			{% endfor -%}
 			*)
@@ -96,7 +101,7 @@ else
 		opts=$(\
 			COMP_CWORD=$((COMP_CWORD + alias_skip)) \
 			COMP_TYPE=$COMP_TYPE \
-			{{OMNI_BIN}} --complete ${words[@]})
+			{{ OMNI_BIN }} --complete ${words[@]})
 
 		while read -r opt; do
 			if [[ "${opt}" != "${cur}"* ]]; then
@@ -126,10 +131,10 @@ else
 	complete -F _omni_complete_bash omni
 	{% if OMNI_ALIASES or OMNI_COMMAND_ALIASES -%}
 	{% for alias in OMNI_ALIASES -%}
-	complete -F _omni_complete_bash {{alias}}
+	complete -F _omni_complete_bash {{ alias }}
 	{% endfor -%}
 	{% for alias in OMNI_COMMAND_ALIASES -%}
-	complete -F _omni_complete_bash {{alias.alias}}
+	complete -F _omni_complete_bash {{ alias.alias }}
 	{% endfor -%}
 	{% endif -%}
 fi
@@ -138,7 +143,7 @@ fi
 # Prepare omni's hook
 __omni_hook() {
 	local ppid=$$
-	eval "$(OMNI_SHELL_PPID="${ppid}" "{{OMNI_BIN}}" hook env "${@}")"
+	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env "${@}")"
 }
 
 
@@ -153,3 +158,12 @@ __omni_hook() {
 	} 4>&2 2>/dev/null 3>&4;
 	${PROMPT_COMMAND}"
 }
+
+
+# If we are not in an interactive shell, we will add the
+# shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells
+if [[ $- != *i* ]] && [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
+	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+fi
+{%- endif -%}

--- a/templates/shell_integration.fish.tmpl
+++ b/templates/shell_integration.fish.tmpl
@@ -1,3 +1,15 @@
+{% if SHIMS_ONLY -%}
+set -l omni_shims_path {{ OMNI_DATA_HOME }}/shims
+if not contains $omni_shims_path $PATH
+    set -l PATH $omni_shims_path $PATH
+    set -gx PATH $PATH
+end
+{%- else -%}
+# This function is used to run the omni command, and then operate on
+# the requested shell changes from the command (changing current
+# working directory, environment, etc.); this is why we require using
+# a shell function for this, instead of simply calling the omni
+# command from the path
 function omni
     # Prepare the environment for omni
     set -gx OMNI_UUID (uuidgen)
@@ -97,3 +109,15 @@ function __omni_hook --on-event fish_prompt --on-variable PWD
             eval "$line" 2>/dev/null
         end
 end
+
+# If we are not in an interactive shell, we will add the
+# shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells
+if status is-interactive
+    set -l omni_shims_path {{ OMNI_DATA_HOME }}/shims
+    if not contains $omni_shims_path $PATH
+        set -l PATH $omni_shims_path $PATH
+        set -gx PATH $PATH
+    end
+end
+{%- endif -%}

--- a/templates/shell_integration.zsh.tmpl
+++ b/templates/shell_integration.zsh.tmpl
@@ -1,3 +1,8 @@
+{% if SHIMS_ONLY -%}
+if [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
+	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+fi
+{%- else -%}
 # This function is used to run the omni command, and then operate on
 # the requested shell changes from the command (changing current
 # working directory, environment, etc.); this is why we require using
@@ -5,14 +10,14 @@
 # command from the path
 function omni() {
 	# Prepare the environment for omni
-	export OMNI_UUID=$(command -v uuidgen >/dev/null && uuidgen || {{OMNI_BIN}} hook uuid)
+	export OMNI_UUID=$(command -v uuidgen >/dev/null && uuidgen || {{ OMNI_BIN }} hook uuid)
 	local tmpdir=${TMPDIR:-/tmp}
 	OMNI_FILE_PREFIX="omni_${OMNI_UUID}"
 	export OMNI_CMD_FILE="${tmpdir}/${OMNI_FILE_PREFIX}.cmd"
 	export OMNI_SHELL=zsh
 
 	# Run the command
-	{{OMNI_BIN}} "$@"
+	{{ OMNI_BIN }} "$@"
 	EXIT_CODE=$?
 
 	# Check if OMNI_CMD_FILE exists, and if it does, run the commands
@@ -48,10 +53,10 @@ function omni() {
 {% if OMNI_ALIASES or OMNI_COMMAND_ALIASES -%}
 # Setup aliases for omni
 {% for alias in OMNI_ALIASES -%}
-alias {{alias}}="omni"
+alias {{ alias }}="omni"
 {% endfor -%}
 {% for alias in OMNI_COMMAND_ALIASES -%}
-alias {{alias.alias}}={{alias.full_command}}
+alias {{ alias.alias }}={{ alias.full_command }}
 {% endfor %}
 
 {% endif -%}
@@ -66,9 +71,9 @@ _omni_complete_zsh() {
 	local alias_skip
 	case "${words[1]}" in
 		{% for alias in OMNI_COMMAND_ALIASES -%}
-		"{{alias.alias}}")
-			alias_prefix={{alias.command}}
-			alias_skip={{alias.command_size}}
+		"{{ alias.alias }}")
+			alias_prefix={{ alias.command }}
+			alias_skip={{ alias.command_size }}
 			;;
 		{% endfor -%}
 		*)
@@ -77,7 +82,7 @@ _omni_complete_zsh() {
 	esac
 
 	{% endif -%}
-	autocomplete="{{OMNI_BIN}} --complete"
+	autocomplete="{{ OMNI_BIN }} --complete"
 	{%- if OMNI_COMMAND_ALIASES %}
 	[[ -n "${alias_prefix}" ]] && autocomplete="${autocomplete} ${alias_prefix}"
 	{%- endif %}
@@ -112,21 +117,31 @@ fi
 compdef _omni_complete_zsh omni
 {% if OMNI_ALIASES or OMNI_COMMAND_ALIASES -%}
 {% for alias in OMNI_ALIASES -%}
-compdef _omni_complete_zsh {{alias}}
+compdef _omni_complete_zsh {{ alias }}
 {% endfor -%}
 {% for alias in OMNI_COMMAND_ALIASES -%}
-compdef _omni_complete_zsh {{alias.alias}}
+compdef _omni_complete_zsh {{ alias.alias }}
 {% endfor -%}
 {% endif %}
 
 # Prepare omni's hook
 __omni_hook() {
 	local ppid=$$
-	eval "$(OMNI_SHELL_PPID="${ppid}" "{{OMNI_BIN}}" hook env "${@}")"
+	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env "${@}")"
 }
+
 
 # Inject omni's hooks into the prompt command
 __omni_hook_precmd()  { __omni_hook zsh }
 if [[ ! ${precmd_functions[(r)__omni_hook_precmd]} ]]; then
 	precmd_functions+=("__omni_hook_precmd");
 fi
+
+
+# If we are not in an interactive shell, we will add the
+# shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells
+if [[ $- != *i* ]] && [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
+	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+fi
+{%- endif -%}

--- a/website/contents/reference/02-builtin-commands/0250-hook.md
+++ b/website/contents/reference/02-builtin-commands/0250-hook.md
@@ -17,6 +17,7 @@ The `init` hook will provide you with the command to run to initialize omni in y
 | `shell` | no | enum: `zsh`, `bash` or `fish` | The shell for which to provide the shell integration; defaults to the value of `SHELL` environment variable, or `bash` otherwise. |
 | `--alias <alias>` | no | string | Adds `<alias>` as a shell alias to the `omni` command, with autocompletion support; can be repeated. |
 | `--command-alias <alias> <subcommand>` | no | string, string | Adds `<alias>` as a shell alias to the `omni <subcommand>` command, with autocompletion support; can be repeated. |
+| `--shims` | no | `null` | Only load the shims without setting up the dynamic environment. |
 
 ### Examples
 
@@ -38,11 +39,16 @@ omni hook init --alias o | source
 # With 'ocd' as an alias to 'omni cd'
 eval "$(omni hook init --command-alias ocd cd)"
 omni hook init --command-alias ocd cd | source
+
+# Only load the shims
+eval "$(omni hook init bash --shims)"  # for bash
+eval "$(omni hook init zsh --shims)"   # for zsh
+omni hook init fish --shims | source   # for fish
 ```
 
 ## `env`
 
-The `env` hook is called during your shell prompt to set the [dynamic environment](/reference/dynamic-environment) for `omni up`-ed repositories.
+The `env` hook is called during your shell prompt or before executing a shim to set the [dynamic environment](/reference/dynamic-environment) for `omni up`-ed repositories.
 
 ## `uuid`
 


### PR DESCRIPTION
This allows to call `omni hook init --shims` to only prepend the shims to the `PATH`. This also supports prepending the shims to the environment automatically for non-interactive shells.

Closes https://github.com/XaF/omni/issues/498