### PR TITLE
feat(github release): ✨ add more compact configuration handling

### DIFF
--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -10,7 +10,7 @@ use crate::internal::config::up::utils::reshim;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
-use crate::internal::config::up::UpConfigGithubRelease;
+use crate::internal::config::up::UpConfigGithubReleases;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
@@ -212,7 +212,7 @@ impl UpConfig {
         if let Some(cleanup) = UpConfigHomebrew::cleanup(&progress_handler)? {
             cleanups.push(cleanup);
         }
-        if let Some(cleanup) = UpConfigGithubRelease::cleanup(&progress_handler)? {
+        if let Some(cleanup) = UpConfigGithubReleases::cleanup(&progress_handler)? {
             cleanups.push(cleanup);
         }
 

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -28,7 +28,7 @@ use crate::internal::env::data_home;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 
-const GITHUB_RELEASES_BIN_PATH: Lazy<PathBuf> =
+static GITHUB_RELEASES_BIN_PATH: Lazy<PathBuf> =
     Lazy::new(|| PathBuf::from(data_home()).join("ghreleases"));
 
 fn github_releases_bin_path() -> PathBuf {
@@ -124,7 +124,7 @@ impl UpConfigGithubReleases {
             return Self { releases };
         }
 
-        return UpConfigGithubReleases::default();
+        UpConfigGithubReleases::default()
     }
 
     pub fn up(
@@ -182,7 +182,7 @@ impl UpConfigGithubReleases {
                     release
                         .actual_version
                         .get()
-                        .and_then(|v| Some(v.to_string()))
+                        .map(|v| v.to_string())
                         .unwrap_or_else(|| "?".to_string())
                 )),
                 _ => None,
@@ -190,7 +190,7 @@ impl UpConfigGithubReleases {
             .sorted()
             .collect();
 
-        if handled.len() == 0 {
+        if handled.is_empty() {
             return "nothing done".to_string();
         }
 

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod custom;
 pub(crate) use custom::UpConfigCustom;
 
 pub(crate) mod github_release;
-pub(crate) use github_release::UpConfigGithubRelease;
+pub(crate) use github_release::UpConfigGithubReleases;
 
 pub(crate) mod golang;
 pub(crate) use golang::UpConfigGolang;

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -12,7 +12,7 @@ use crate::internal::config::up::UpConfig;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpConfigBundler;
 use crate::internal::config::up::UpConfigCustom;
-use crate::internal::config::up::UpConfigGithubRelease;
+use crate::internal::config::up::UpConfigGithubReleases;
 use crate::internal::config::up::UpConfigGolang;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigNix;
@@ -52,7 +52,7 @@ pub enum UpConfigTool {
     // TODO: Dnf(UpConfigDnf),
     /// GithubRelease represents a tool that can be installed from
     /// a github release.
-    GithubRelease(UpConfigGithubRelease),
+    GithubRelease(UpConfigGithubReleases),
 
     /// Go represents the golang tool.
     Go(UpConfigGolang),
@@ -163,9 +163,12 @@ impl UpConfigTool {
             "custom" => Some(UpConfigTool::Custom(UpConfigCustom::from_config_value(
                 config_value,
             ))),
-            "github-release" | "github_release" | "githubrelease" | "ghrelease" => Some(
-                UpConfigTool::GithubRelease(UpConfigGithubRelease::from_config_value(config_value)),
-            ),
+            "github-release" | "github_release" | "githubrelease" | "ghrelease"
+            | "github-releases" | "github_releases" | "githubreleases" | "ghreleases" => {
+                Some(UpConfigTool::GithubRelease(
+                    UpConfigGithubReleases::from_config_value(config_value),
+                ))
+            }
             "go" | "golang" => Some(UpConfigTool::Go(UpConfigGolang::from_config_value(
                 config_value,
             ))),

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
@@ -7,7 +7,7 @@ description: Configuration of the `github-release` kind of `up` parameter
 Install a tool from a GitHub release.
 
 For this to work properly for a GitHub release, it will need to:
-- Be provided as a `.tar.gz` or `.zip` archive
+- Be provided as a `.tar.gz` or `.zip` archive, or as a binary file (no extension)
 - Have a file name that contains hints about the OS it was built for (e.g. `linux`, `darwin`, ...)
 - Have a file name that contains hints about the architecture it was built for (e.g. `amd64`, `arm64`, ...)
 
@@ -22,6 +22,10 @@ This does not support using authentication yet, and thus will only work for publ
 - `ghrelease`
 - `github_release`
 - `githubrelease`
+- `github-releases`
+- `ghreleases`
+- `github_releases`
+- `githubreleases`
 
 ## Parameters
 
@@ -71,6 +75,10 @@ up:
   - ghrelease: XaF/omni
   - github_release: XaF/omni
   - githubrelease: XaF/omni
+  - github-releases: XaF/omni
+  - ghreleases: XaF/omni
+  - github_releases: XaF/omni
+  - githubreleases: XaF/omni
 
   # Will also install the latest version
   - github-release:
@@ -99,6 +107,19 @@ up:
       repository: XaF/omni
       version: 1
       prerelease: true
+
+  # Will install all the specified releases
+  - github-release:
+      XaF/omni: 1.2.3
+      omnicli/omni:
+        version: 4.5.6
+        prerelease: true
+
+  # Will install all the listed releases
+  - github-release:
+      - XaF/omni: 1.2.3
+      - repository: omnicli/omni
+        version: 4.5.6
 ```
 
 ## Dynamic environment


### PR DESCRIPTION
GitHub release operation required to add an entry for each release, which made it verbose both to write the configuration and during `omni up`. This fixes that by allowing to specify multiple versions, either as a list or as a map of repository => repository config.

When used with multiple versions, this will show as a single entry that will summarize the installed releases at the end.