### PR TITLE
feat(github release): ✨ try refreshing releases cache if none match

### DIFF
--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -194,7 +194,7 @@ impl GithubReleases {
     }
 
     pub fn is_fresh(&self) -> bool {
-        self.fetched_at >= GITHUB_RELEASE_OPERATION_NOW.clone()
+        self.fetched_at >= github_release_operation_now()
     }
 
     pub fn is_stale(&self, ttl: u64) -> bool {

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -193,6 +193,10 @@ impl GithubReleases {
         })
     }
 
+    pub fn is_fresh(&self) -> bool {
+        self.fetched_at >= GITHUB_RELEASE_OPERATION_NOW.clone()
+    }
+
     pub fn is_stale(&self, ttl: u64) -> bool {
         let duration = time::Duration::seconds(ttl as i64);
         self.fetched_at + duration < OffsetDateTime::now_utc()

--- a/src/internal/config/up/error.rs
+++ b/src/internal/config/up/error.rs
@@ -15,16 +15,27 @@ pub enum UpError {
     StepFailed(String, Option<(usize, usize)>),
 }
 
-// impl UpError {
-// fn error_type(&self) -> String {
-// match self {
-// UpError::Config(_) => "configuration error".to_string(),
-// UpError::Exec(_) => "execution error".to_string(),
-// UpError::Timeout(_) => "timeout".to_string(),
-// UpError::HomebrewTapInUse => "tap in use".to_string(),
-// }
-// }
-// }
+impl UpError {
+    pub fn message(&self) -> String {
+        match self {
+            UpError::Config(message) => message.clone(),
+            UpError::Exec(message) => message.clone(),
+            UpError::Timeout(message) => message.clone(),
+            UpError::Cache(message) => message.clone(),
+            UpError::HomebrewTapInUse => "tap in use".to_string(),
+            UpError::StepFailed(message, _) => message.clone(),
+        }
+    }
+
+    // fn error_type(&self) -> String {
+    // match self {
+    // UpError::Config(_) => "configuration error".to_string(),
+    // UpError::Exec(_) => "execution error".to_string(),
+    // UpError::Timeout(_) => "timeout".to_string(),
+    // UpError::HomebrewTapInUse => "tap in use".to_string(),
+    // }
+    // }
+}
 
 impl Display for UpError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {


### PR DESCRIPTION
Previously, the cache was kept for the duration even if no release matched the requirements. With that change, if the cache was used and no release matches the requirements, the cache will be refreshed and the releases evaluated a second time.

This allows to satisfy bound requirements (e.g. specific version number) even if the change to the requirement is recent and the cache has been refreshed recently for the user.

Closes https://github.com/XaF/omni/issues/486