### PR TITLE
feat(asdf): ✨ add suppport for arbitrary asdf tools

### DIFF
--- a/src/internal/cache/asdf_operation.rs
+++ b/src/internal/cache/asdf_operation.rs
@@ -76,7 +76,13 @@ impl AsdfOperationCache {
         )
     }
 
-    pub fn add_installed(&mut self, workdir_id: &str, tool: &str, version: &str) -> bool {
+    pub fn add_installed(
+        &mut self,
+        workdir_id: &str,
+        tool: &str,
+        version: &str,
+        tool_real_name: Option<&str>,
+    ) -> bool {
         let inserted = if let Some(install) = self
             .installed
             .iter_mut()
@@ -86,6 +92,7 @@ impl AsdfOperationCache {
         } else {
             let install = AsdfInstalled {
                 tool: tool.to_string(),
+                tool_real_name: tool_real_name.map(|s| s.to_string()),
                 version: version.to_string(),
                 required_by: [workdir_id.to_string()].iter().cloned().collect(),
             };
@@ -139,6 +146,8 @@ impl CacheObject for AsdfOperationCache {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AsdfInstalled {
     pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_real_name: Option<String>,
     pub version: String,
     #[serde(default = "BTreeSet::new", skip_serializing_if = "BTreeSet::is_empty")]
     pub required_by: BTreeSet<String>,

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -125,6 +125,7 @@ impl UpEnvironmentsCache {
         &mut self,
         workdir_id: &str,
         tool: &str,
+        tool_real_name: Option<&str>,
         version: &str,
         dirs: BTreeSet<String>,
     ) -> bool {
@@ -155,7 +156,9 @@ impl UpEnvironmentsCache {
         };
 
         for dir in dirs {
-            wd_up_env.versions.push(UpVersion::new(tool, version, &dir));
+            wd_up_env
+                .versions
+                .push(UpVersion::new(tool, tool_real_name, version, &dir));
         }
 
         self.updated();
@@ -291,6 +294,8 @@ impl UpEnvironment {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpVersion {
     pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_real_name: Option<String>,
     pub version: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub dir: String,
@@ -299,9 +304,10 @@ pub struct UpVersion {
 }
 
 impl UpVersion {
-    pub fn new(tool: &str, version: &str, dir: &str) -> Self {
+    pub fn new(tool: &str, tool_real_name: Option<&str>, version: &str, dir: &str) -> Self {
         Self {
             tool: tool.to_string(),
+            tool_real_name: tool_real_name.map(|s| s.to_string()),
             version: version.to_string(),
             dir: dir.to_string(),
             data_path: None,

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -339,7 +339,7 @@ impl UpConfigAsdfBase {
             }
         }
 
-        let (tool, tool_url, tool_real_name) = match &override_tool_url {
+        let (tool, tool_real_name, tool_url) = match &override_tool_url {
             Some(url) => {
                 let tool_real_name = Some(tool.to_string());
 

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -370,18 +370,9 @@ impl UpConfigAsdfBase {
     }
 
     pub fn name(&self) -> String {
-        match self.override_tool_url {
+        match &self.tool_real_name {
+            Some(tool) => tool.to_string(),
             None => self.tool.clone(),
-            Some(_) => {
-                // The name is everything before the last `-`
-                let name = self.tool.clone();
-                let last_dash = name.rfind('-').unwrap_or(0);
-                if last_dash == 0 {
-                    self.tool.clone()
-                } else {
-                    name[0..last_dash].to_string()
-                }
-            }
         }
     }
 

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -12,6 +12,8 @@ use normalize_path::NormalizePath;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
 use tokio::process::Command as TokioCommand;
 use walkdir::WalkDir;
 
@@ -172,9 +174,20 @@ pub struct UpConfigAsdfBase {
     #[serde(skip)]
     pub tool: String,
 
+    /// The real name of the tool, if different than tool
+    #[serde(skip)]
+    pub tool_real_name: Option<String>,
+
     /// The URL to use to install the tool.
     #[serde(skip)]
     pub tool_url: Option<String>,
+
+    /// The URL passed as parameter to override the location
+    /// of the tool; this is stored as a separate parameter
+    /// to make sure it can be dumped when looking at the
+    /// configuration.
+    #[serde(rename = "url", default, skip_serializing_if = "Option::is_none")]
+    pub override_tool_url: Option<String>,
 
     /// The version of the tool to install, as specified in the config file.
     pub version: String,
@@ -237,16 +250,9 @@ impl UpConfigAsdfBase {
     pub fn new(tool: &str, version: &str, dirs: BTreeSet<String>) -> Self {
         UpConfigAsdfBase {
             tool: tool.to_string(),
-            tool_url: None,
             version: version.to_string(),
             dirs: dirs.clone(),
-            detect_version_funcs: vec![],
-            post_install_funcs: vec![],
-            actual_version: OnceCell::new(),
-            actual_versions: OnceCell::new(),
-            config_value: None,
-            up_succeeded: OnceCell::new(),
-            deps: OnceCell::new(),
+            ..UpConfigAsdfBase::default()
         }
     }
 
@@ -264,19 +270,7 @@ impl UpConfigAsdfBase {
             tool_url: self.tool_url.clone(),
             version: version.to_string(),
             dirs: dirs.clone(),
-
-            up_succeeded: OnceCell::new(),
-            deps: OnceCell::new(),
-
-            // We can ignore all those fields, as they won't be used,
-            // since the version passed to that call is a specific version
-            // that we got from running the detection functions from a
-            // main instance called with "auto" as the version.
-            detect_version_funcs: vec![],
-            post_install_funcs: vec![],
-            actual_version: OnceCell::new(),
-            actual_versions: OnceCell::new(),
-            config_value: None,
+            ..UpConfigAsdfBase::default()
         }
     }
 
@@ -299,6 +293,7 @@ impl UpConfigAsdfBase {
     ) -> Self {
         let mut version = "latest".to_string();
         let mut dirs = BTreeSet::new();
+        let mut override_tool_url = None;
 
         if let Some(config_value) = config_value {
             if let Some(value) = config_value.as_str() {
@@ -331,21 +326,62 @@ impl UpConfigAsdfBase {
                         }
                     }
                 }
+
+                if let Some(url) = config_value.get_as_str_forced("url") {
+                    let set_override = match &tool_url {
+                        None => true,
+                        Some(tool_url) => url != *tool_url,
+                    };
+                    if set_override {
+                        override_tool_url = Some(url.to_string());
+                    }
+                }
             }
         }
 
+        let (tool, tool_url, tool_real_name) = match &override_tool_url {
+            Some(url) => {
+                let tool_real_name = Some(tool.to_string());
+
+                // Hash the URL into sha256
+                let mut hasher = Sha256::new();
+                hasher.update(url.as_bytes());
+                let hash = format!("{:x}", hasher.finalize());
+                let short_hash = &hash[0..8];
+
+                let tool = format!("{}-{}", tool, short_hash);
+                let tool_url = Some(url.to_string());
+
+                (tool, tool_real_name, tool_url)
+            }
+            None => (tool.to_string(), None, tool_url),
+        };
+
         UpConfigAsdfBase {
-            tool: tool.to_string(),
+            tool,
+            tool_real_name,
             tool_url,
+            override_tool_url,
             version,
             dirs,
-            detect_version_funcs: vec![],
-            post_install_funcs: vec![],
-            actual_version: OnceCell::new(),
-            actual_versions: OnceCell::new(),
             config_value: config_value.cloned(),
-            up_succeeded: OnceCell::new(),
-            deps: OnceCell::new(),
+            ..UpConfigAsdfBase::default()
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self.override_tool_url {
+            None => self.tool.clone(),
+            Some(_) => {
+                // The name is everything before the last `-`
+                let name = self.tool.clone();
+                let last_dash = name.rfind('-').unwrap_or(0);
+                if last_dash == 0 {
+                    self.tool.clone()
+                } else {
+                    name[0..last_dash].to_string()
+                }
+            }
         }
     }
 
@@ -367,7 +403,12 @@ impl UpConfigAsdfBase {
         progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = AsdfOperationCache::exclusive(|asdf_cache| {
-            asdf_cache.add_installed(&repo_id, &self.tool, &version)
+            asdf_cache.add_installed(
+                &repo_id,
+                &self.tool,
+                &version,
+                self.tool_real_name.as_deref(),
+            )
         }) {
             progress_handler.progress(format!("failed to update tool cache: {}", err));
             return;
@@ -379,7 +420,13 @@ impl UpConfigAsdfBase {
                 dirs.insert("".to_string());
             }
 
-            up_env.add_version(&repo_id, &self.tool, &version, dirs.clone())
+            up_env.add_version(
+                &repo_id,
+                &self.tool,
+                self.tool_real_name.as_deref(),
+                &version,
+                dirs.clone(),
+            )
         }) {
             progress_handler.progress(format!("failed to update tool cache: {}", err));
             return;
@@ -414,7 +461,7 @@ impl UpConfigAsdfBase {
         options: &UpOptions,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
-        progress_handler.init(format!("{} ({}):", self.tool, self.version).light_blue());
+        progress_handler.init(format!("{} ({}):", self.name(), self.version).light_blue());
 
         // Make sure that dependencies are installed
         let subhandler = progress_handler.subhandler(&"deps: ".light_black());
@@ -422,12 +469,12 @@ impl UpConfigAsdfBase {
         update_dynamic_env_for_command(".");
 
         if let Err(err) = install_asdf(progress_handler) {
-            progress_handler.error_with_message(format!("error: {}", err));
+            progress_handler.error();
             return Err(err);
         }
 
         if let Err(err) = self.install_plugin(progress_handler) {
-            progress_handler.error_with_message(format!("error: {}", err));
+            progress_handler.error();
             return Err(err);
         }
 
@@ -563,7 +610,7 @@ impl UpConfigAsdfBase {
                 msgs.push(
                     format!(
                         "{} {} installed",
-                        self.tool,
+                        self.name(),
                         installed_versions
                             .iter()
                             .map(|version| version.to_string())
@@ -578,7 +625,7 @@ impl UpConfigAsdfBase {
                 msgs.push(
                     format!(
                         "{} {} already installed",
-                        self.tool,
+                        self.name(),
                         already_installed_versions
                             .iter()
                             .map(|version| version.to_string())
@@ -625,9 +672,9 @@ impl UpConfigAsdfBase {
                     }
 
                     let msg = if installed {
-                        format!("{} {} installed", self.tool, version).green()
+                        format!("{} {} installed", self.name(), version).green()
                     } else {
-                        format!("{} {} already installed", self.tool, version).light_black()
+                        format!("{} {} already installed", self.name(), version).light_black()
                     };
                     progress_handler.success_with_message(msg);
 
@@ -686,12 +733,13 @@ impl UpConfigAsdfBase {
                     } else {
                         omni_error!(format!(
                             "failed to list versions for {}; exited with status {}",
-                            self.tool, output.status
+                            self.name(),
+                            output.status
                         ));
                         return "".to_string();
                     }
                 } else {
-                    omni_error!(format!("failed to list versions for {}", self.tool));
+                    omni_error!(format!("failed to list versions for {}", self.name()));
                     return "".to_string();
                 }
             };
@@ -709,7 +757,8 @@ impl UpConfigAsdfBase {
         if version.is_empty() {
             return Err(UpError::Exec(format!(
                 "No {} version found matching {}",
-                self.tool, self.version,
+                self.name(),
+                self.version,
             )));
         }
 
@@ -802,7 +851,7 @@ impl UpConfigAsdfBase {
             return Ok(false);
         }
 
-        progress_handler.progress(format!("installing {} {}", self.tool, version));
+        progress_handler.progress(format!("installing {} {}", self.name(), version));
 
         let mut asdf_install = asdf_async_command();
         asdf_install.arg("install");
@@ -973,7 +1022,7 @@ impl UpConfigAsdfBase {
             // HomebrewInstall::new_formula("unixodbc"),
         ];
 
-        match self.tool.as_str() {
+        match self.name().as_str() {
             "python" => {
                 homebrew_install.extend(vec![
                     HomebrewInstall::new_formula("pkg-config"),

--- a/src/internal/config/up/utils/print_progress_handler.rs
+++ b/src/internal/config/up/utils/print_progress_handler.rs
@@ -1,9 +1,12 @@
+use std::cell::RefCell;
+
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::user_interface::StringColor;
 
 #[derive(Debug, Clone)]
 pub struct PrintProgressHandler {
     template: String,
+    message: RefCell<String>,
 }
 
 impl PrintProgressHandler {
@@ -24,7 +27,18 @@ impl PrintProgressHandler {
 
         let template = format!("{}{{}} {} {{}}", prefix, desc);
 
-        PrintProgressHandler { template }
+        PrintProgressHandler {
+            template,
+            message: RefCell::new("".to_string()),
+        }
+    }
+
+    fn set_message(&self, message: impl ToString) {
+        self.message.replace(message.to_string());
+    }
+
+    fn get_message(&self) -> String {
+        self.message.borrow().clone()
     }
 }
 
@@ -34,6 +48,7 @@ impl ProgressHandler for PrintProgressHandler {
     }
 
     fn progress(&self, message: String) {
+        self.set_message(&message);
         eprintln!(
             "{}",
             self.template
@@ -47,6 +62,7 @@ impl ProgressHandler for PrintProgressHandler {
     }
 
     fn success_with_message(&self, message: String) {
+        self.set_message(&message);
         eprintln!(
             "{}",
             self.template
@@ -56,10 +72,11 @@ impl ProgressHandler for PrintProgressHandler {
     }
 
     fn error(&self) {
-        self.error_with_message("error".to_string());
+        self.error_with_message(self.get_message());
     }
 
     fn error_with_message(&self, message: String) {
+        self.set_message(&message);
         eprintln!(
             "{}",
             self.template

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -452,13 +452,14 @@ impl DynamicEnv {
             let dir = workdir.reldir(&path).unwrap_or("".to_string());
             for toolversion in up_env.versions_for_dir(&dir).iter() {
                 let tool = toolversion.tool.clone();
+                let tool_real_name = toolversion.tool_real_name.clone().unwrap_or(tool.clone());
                 let version = toolversion.version.clone();
                 let version_minor = version.split('.').take(2).join(".");
                 let tool_prefix = asdf_tool_path(&tool, &version);
 
                 self.features.push(format!("{}:{}", tool, version));
 
-                match tool.as_str() {
+                match tool_real_name.as_str() {
                     "ruby" => {
                         envsetter.remove_from_list_by_fn("PATH", || {
                             let mut values_to_remove = Vec::new();


### PR DESCRIPTION
A large number of `asdf` tools are available that omni can take advantage of right away, but this was not available as requiring specific tool definition to work.
This changes that by changing the default behavior when a tool is unknown, and considering it's an asdf plugin by default.

This also adds support for the `url` parameter to any asdf tool, which will override the repository used for that tool. If this does not correspond to the default tool URL, it will keep the tool installation separate from one that wouldn't provide an `url` or would provide a different one.

Closes https://github.com/XaF/omni/issues/494