### PR TITLE
feat(template): ✨ add `env` map in the context

### DIFF
--- a/src/internal/config/template.rs
+++ b/src/internal/config/template.rs
@@ -52,10 +52,13 @@ pub fn config_template_context<T: AsRef<str>>(path: T) -> tera::Context {
         context.insert("repo", &repo);
     }
 
+    // Load context for the environment
+    let env = std::env::vars().collect::<HashMap<String, String>>();
+    context.insert("env", &env);
+
     // Load context for the user prompts
     let prompts = PromptsCache::get().answers(path);
     context.insert("prompts", &prompts);
-    // TODO implement this
 
     context
 }

--- a/website/contents/reference/01-configuration/0104-templates.md
+++ b/website/contents/reference/01-configuration/0104-templates.md
@@ -28,6 +28,10 @@ The `repo` object contains information about the current repository, if in a rep
 | `org` | string | The organization of the repository |
 | `name` | string | The name of the repository |
 
+### `env` object
+
+The `env` map contains the environment variables of the current process.
+
 ### `prompts` object
 
 When using prompts in your working directory, they are made available through the `prompts` object in a template, as soon as that prompt has been answered. This means that you can use that prompt's answer when asking any following prompt.


### PR DESCRIPTION
This allows to access environment variables when using templates, in the shape of a key-value map.

Closes https://github.com/XaF/omni/issues/493