### PR TITLE
fix(asdf): 🐛 post install and detect func use the real tool name

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -44,13 +44,14 @@ lazy_static! {
     static ref ASDF_BIN: String = format!("{}/bin/asdf", *ASDF_PATH);
 }
 
-type DetectVersionFunc = fn(String, PathBuf) -> Option<String>;
+type DetectVersionFunc = fn(tool_real_name: String, path: PathBuf) -> Option<String>;
 type PostInstallFunc = fn(
-    &dyn ProgressHandler,
-    Option<ConfigValue>,
-    String,
-    String,
-    Vec<AsdfToolUpVersion>,
+    progress_handler: &dyn ProgressHandler,
+    config_value: Option<ConfigValue>,
+    tool: String,
+    tool_real_name: String,
+    requested_version: String,
+    versions: Vec<AsdfToolUpVersion>,
 ) -> Result<(), UpError>;
 
 pub fn asdf_path() -> String {
@@ -509,7 +510,7 @@ impl UpConfigAsdfBase {
 
                     for detect_version_func in detect_version_funcs.iter() {
                         if let Some(detected_version) =
-                            detect_version_func(self.tool.clone(), entry.path().to_path_buf())
+                            detect_version_func(self.name(), entry.path().to_path_buf())
                         {
                             let mut dir = entry
                                 .path()
@@ -586,6 +587,7 @@ impl UpConfigAsdfBase {
                         progress_handler,
                         self.config_value.clone(),
                         self.tool.clone(),
+                        self.name(),
                         self.version.clone(),
                         post_install_versions.clone(),
                     ) {
@@ -653,6 +655,7 @@ impl UpConfigAsdfBase {
                                 progress_handler,
                                 self.config_value.clone(),
                                 self.tool.clone(),
+                                self.name(),
                                 self.version.clone(),
                                 post_install_versions.clone(),
                             ) {

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -224,32 +224,35 @@ fn setup_individual_gopath(
     progress_handler: &dyn ProgressHandler,
     _config_value: Option<ConfigValue>,
     tool: String,
+    tool_real_name: String,
     _requested_version: String,
     versions: Vec<AsdfToolUpVersion>,
 ) -> Result<(), UpError> {
-    if tool != "golang" {
+    if tool_real_name != "golang" {
         panic!("setup_individual_gopath called with wrong tool: {}", tool);
     }
 
     // Get the data path for the work directory
     let workdir = workdir(".");
 
-    let workdir_id = if let Some(workdir_id) = workdir.id() {
-        workdir_id
-    } else {
-        return Err(UpError::Exec(format!(
-            "failed to get workdir id for {}",
-            current_dir().display()
-        )));
+    let workdir_id = match workdir.id() {
+        Some(workdir_id) => workdir_id,
+        None => {
+            return Err(UpError::Exec(format!(
+                "failed to get workdir id for {}",
+                current_dir().display()
+            )));
+        }
     };
 
-    let data_path = if let Some(data_path) = workdir.data_path() {
-        data_path
-    } else {
-        return Err(UpError::Exec(format!(
-            "failed to get data path for {}",
-            current_dir().display()
-        )));
+    let data_path = match workdir.data_path() {
+        Some(data_path) => data_path,
+        None => {
+            return Err(UpError::Exec(format!(
+                "failed to get data path for {}",
+                current_dir().display()
+            )));
+        }
     };
 
     // Handle each version individually


### PR DESCRIPTION
Since when passing a URL we get a different tool name, suffixed with a hash, this required adding support for that when calling the detect func (to always only use the real tool name) and the post install func (so it can decide which one it uses depending on what it wants to do).