### PR TITLE
feat(github release): ✨ read github auth token from `gh`

### DIFF
--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -744,7 +744,7 @@ impl UpConfigGithubRelease {
     fn get_auth_token(&self, progress_handler: &UpProgressHandler) -> Option<String> {
         // TODO: allow to fetch PAT from config too, so someone
         // could configure it if they don't have `gh` installed
-        if !which::which("gh").is_ok() {
+        if which::which("gh").is_err() {
             return None;
         }
 


### PR DESCRIPTION
This allows to handle downloading releases from private repositories, since they require a token to get access, and `gh` can provide that token, both for the regular `github.com` host, but also for GitHub enterprise hosts.

Closes https://github.com/XaF/omni/issues/478