### PR TITLE
feat(nix): ✨ handle flakes

### DIFF
--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 use itertools::Itertools;
@@ -12,6 +13,7 @@ use crate::internal::cache::CacheObject;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::config::parser::EnvOperationEnum;
+use crate::internal::config::up::utils::get_command_output;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
@@ -24,6 +26,25 @@ use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
 use crate::omni_warning;
 
+fn nix_command<T: AsRef<str>>(name: T) -> TokioCommand {
+    let mut command = TokioCommand::new("nix");
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    command.arg("--extra-experimental-features");
+    command.arg("nix-command flakes");
+    command.arg(name.as_ref());
+    command
+}
+
+fn nix_gcroot_command<T: AsRef<Path>>(tmp_profile: T, perm_profile: T) -> TokioCommand {
+    let mut command = nix_command("build");
+    command.arg("--print-out-paths");
+    command.arg("--out-link");
+    command.arg(perm_profile.as_ref());
+    command.arg(tmp_profile.as_ref());
+    command
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct UpConfigNix {
     /// List of nix packages to install.
@@ -34,9 +55,9 @@ pub struct UpConfigNix {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nixfile: Option<String>,
 
-    /// Path to the nix profile that was configured.
+    /// Path to the nix profile(s) stored in the data path
     #[serde(skip)]
-    pub profile_path: OnceCell<PathBuf>,
+    pub data_paths: OnceCell<Vec<PathBuf>>,
 }
 
 impl UpConfigNix {
@@ -44,7 +65,7 @@ impl UpConfigNix {
         UpConfigNix {
             packages,
             nixfile: None,
-            profile_path: OnceCell::new(),
+            data_paths: OnceCell::new(),
         }
     }
 
@@ -91,7 +112,7 @@ impl UpConfigNix {
                         return UpConfigNix {
                             packages: Vec::new(),
                             nixfile: Some(nixfile.to_string()),
-                            profile_path: OnceCell::new(),
+                            data_paths: OnceCell::new(),
                         };
                     }
                 }
@@ -104,7 +125,7 @@ impl UpConfigNix {
                                 .filter_map(|v| v.as_str_forced())
                                 .collect::<Vec<_>>(),
                             nixfile: None,
-                            profile_path: OnceCell::new(),
+                            data_paths: OnceCell::new(),
                         };
                     }
                 }
@@ -115,13 +136,13 @@ impl UpConfigNix {
                         .filter_map(|v| v.as_str_forced())
                         .collect::<Vec<_>>(),
                     nixfile: None,
-                    profile_path: OnceCell::new(),
+                    data_paths: OnceCell::new(),
                 };
             } else if let Some(nixfile) = config_value.as_str_forced() {
                 return UpConfigNix {
                     packages: Vec::new(),
                     nixfile: Some(nixfile.to_string()),
-                    profile_path: OnceCell::new(),
+                    data_paths: OnceCell::new(),
                 };
             }
         }
@@ -134,115 +155,16 @@ impl UpConfigNix {
         options: &UpOptions,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
-        let wd = workdir(".");
-        let wd_root = match wd.root() {
-            Some(wd_root) => PathBuf::from(wd_root),
-            None => {
-                let msg = format!(
-                    "failed to get work directory root for {}",
-                    current_dir().display()
-                );
-                return Err(UpError::Exec(msg));
-            }
-        };
-
-        let nixfile = if let Some(nixfile) = &self.nixfile {
-            Some(abs_path(nixfile))
-        } else if !self.packages.is_empty() {
-            None
-        } else {
-            let mut nixfile = None;
-
-            for file in &["shell.nix", "default.nix"] {
-                let absfile = wd_root.join(file);
-                if absfile.exists() && absfile.is_file() {
-                    nixfile = Some(absfile);
-                    break;
-                }
-            }
-
-            // If no nix file was found, we fail, since if there is a `nix` step
-            // we expect to have to install some dependencies.
-            match nixfile {
-                Some(nixfile) => Some(abs_path(nixfile)),
-                None => {
-                    return Err(UpError::Exec(format!(
-                        "no nix file found in {}",
-                        wd_root.display()
-                    )))
-                }
-            }
-        };
-
-        if let Some(nixfile) = &nixfile {
-            // Check if path is in current dir
-            if !nixfile.starts_with(&wd_root) {
-                return Err(UpError::Exec(format!(
-                    "file {} is not in work directory",
-                    nixfile.display()
-                )));
-            }
-        }
+        let nix_handler = NixHandler::new(&self.nixfile, &self.packages)?;
 
         // Prepare the progress handler
-        progress_handler.init(
-            format!(
-                "nix ({}):",
-                nixfile.as_ref().map_or("packages".to_string(), |nixfile| {
-                    match nixfile.file_name() {
-                        Some(file_name) => file_name.to_string_lossy().to_string(),
-                        None => "nixfile".to_string(),
-                    }
-                })
-            )
-            .light_blue(),
-        );
-
-        // Generate a profile id either by hashing the list of packages
-        // or the contents of the nix file.
-        let mut config_hasher = blake3::Hasher::new();
-        let profile_suffix = if let Some(nixfile) = &nixfile {
-            // Load the file contents into the hasher
-            match std::fs::read(nixfile) {
-                Ok(contents) => config_hasher.update(&contents),
-                Err(e) => {
-                    let msg = format!("failed to read nix file: {}", e);
-                    return Err(UpError::Exec(msg));
-                }
-            };
-
-            match nixfile.file_name() {
-                Some(file_name) => file_name.to_string_lossy().to_string(),
-                None => "nixfile".to_string(),
-            }
-        } else {
-            // Get a hash of the sorted, unique list of packages
-            let mut packages = BTreeSet::new();
-            packages.extend(self.packages.iter());
-            let packages = packages.iter().join("\n");
-            config_hasher.update(packages.as_bytes());
-
-            "pkgs".to_string()
-        };
-        let profile_hash = config_hasher.finalize().to_hex()[..16].to_string();
-        let profile_id = format!("profile-{}-{}", profile_suffix, profile_hash);
-
-        // Generate the full path to the permanent nix profile
-        let data_path = match wd.data_path() {
-            Some(data_path) => data_path,
-            None => {
-                let msg = format!("failed to get data path for {}", current_dir().display());
-                progress_handler.error_with_message(msg.clone());
-                return Err(UpError::Exec(msg));
-            }
-        };
-        let nix_path = data_path.join("nix");
-        let profile_path = nix_path.join(profile_id);
+        progress_handler.init(format!("nix ({}):", nix_handler.nix_source.name()).light_blue());
 
         // If the profile already exists, we don't need to do anything
-        if profile_path.exists() && options.read_cache {
-            if let Err(e) = self.profile_path.set(profile_path) {
-                omni_warning!(format!("failed to save nix profile path: {:?}", e));
+        if options.read_cache && nix_handler.exists()? {
+            let paths = nix_handler.paths(progress_handler)?;
+            if self.data_paths.set(paths).is_err() {
+                omni_warning!("failed to save nix profile path".to_string());
             }
 
             self.update_cache(progress_handler)?;
@@ -251,136 +173,9 @@ impl UpConfigNix {
             return Ok(());
         }
 
-        // We want to generate a nix profile from either the package or the nix file;
-        // we do that first in a temporary directory so that if any issue happens, we
-        // don't overwrite the permanent file for now, protecting against an unexpected
-        // garbage collection.
-        //
-        // We want to call:
-        //    nix --extra-experimental-features "nix-command flakes" \
-        //          print-dev-env --profile "$tmp_profile" --impure $expression
-        //
-        // Where $expression is either:
-        //  - For a nixfile:
-        //      --file "$nixfile"
-        //  - For a nixfile with attribute:
-        //      --expr "(import ${nixfile} {}).${attribute}"
-        //      Where attribute is a string that can be either: "devShell", "shell", "buildInputs", etc.
-        //  - For a list of packages:
-        //      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }"
-        //  - For multiple files: (to verify)
-        //      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ (import ./file1.nix {}) (import ./file2.nix {}) ]; }"
-
-        // Generate a temporary file to store the nix profile, we want a directory as
-        // a second file will be generated in the same directory as our temp profile,
-        // and we want to remove both of them once we're done. Using a temporary
-        // directory will make sure that the directory is removed automatically
-        // with all its content.
-        let tmp_dir = match tempfile::Builder::new().prefix("omni_up_nix.").tempdir() {
-            Ok(tmp_dir) => tmp_dir,
-            Err(e) => {
-                let msg = format!("failed to create temporary directory: {}", e);
-                progress_handler.error_with_message(msg.clone());
-                return Err(UpError::Exec(msg));
-            }
-        };
-        let tmp_profile = tmp_dir.path().join("profile");
-
-        progress_handler.progress("preparing nix environment".to_string());
-
-        let mut nix_print_dev_env = TokioCommand::new("nix");
-        nix_print_dev_env.stdout(std::process::Stdio::piped());
-        nix_print_dev_env.stderr(std::process::Stdio::piped());
-        nix_print_dev_env.arg("--extra-experimental-features");
-        nix_print_dev_env.arg("nix-command flakes");
-        nix_print_dev_env.arg("print-dev-env");
-        nix_print_dev_env.arg("--verbose");
-        nix_print_dev_env.arg("--print-build-logs");
-        nix_print_dev_env.arg("--profile");
-        nix_print_dev_env.arg(&tmp_profile);
-        nix_print_dev_env.arg("--impure");
-
-        let packages_message;
-        if let Some(nixfile) = &nixfile {
-            nix_print_dev_env.arg("--file");
-            nix_print_dev_env.arg(nixfile);
-            packages_message = format!(
-                "packages from {}",
-                nixfile
-                    .strip_prefix(&wd_root)
-                    .unwrap_or(nixfile)
-                    .display()
-                    .light_yellow()
-            );
-        } else if !self.packages.is_empty() {
-            let mut context = tera::Context::new();
-            context.insert("packages", &self.packages.join(" "));
-            let tmpl = r#"with import <nixpkgs> {}; mkShell { buildInputs = [ {{ packages }} ]; }"#;
-            let expr = match tera::Tera::one_off(tmpl, &context, false) {
-                Ok(expr) => expr,
-                Err(e) => {
-                    let msg = format!("failed to render nix expression: {}", e);
-                    progress_handler.error_with_message(msg.clone());
-                    return Err(UpError::Exec(msg));
-                }
-            };
-
-            nix_print_dev_env.arg("--expr");
-            nix_print_dev_env.arg(&expr);
-            packages_message = format!(
-                "{} package{}",
-                self.packages.len().to_string().light_yellow(),
-                if self.packages.len() > 1 { "s" } else { "" },
-            );
-        } else {
-            unreachable!();
-        }
-        progress_handler.progress(format!("installing {}", packages_message));
-
-        let result = run_progress(
-            &mut nix_print_dev_env,
-            Some(progress_handler),
-            RunConfig::default(),
-        );
-        if let Err(e) = result {
-            let msg = format!("failed to install nix packages: {}", e);
-            progress_handler.error_with_message(msg.clone());
-            return Err(UpError::Exec(msg));
-        }
-
-        // Now we want to build the nix profile and add it to the gcroots
-        // so that the packages don't get garbage collected.
-        //
-        // We want to call:
-        //      nix --extra-experimental-features "nix-command flakes" \
-        //          build --out-link "$perm_profile" "$tmp_profile"
-        //
-        // And we will put the permanent profile in the data directory
-        // of the work directory, so that its life is tied to the work
-        // directory cache.
-
-        progress_handler.progress("protecting dependencies with gcroots".to_string());
-
-        let mut nix_build = TokioCommand::new("nix");
-        nix_build.arg("--extra-experimental-features");
-        nix_build.arg("nix-command flakes");
-        nix_build.arg("build");
-        nix_build.arg("--print-out-paths");
-        nix_build.arg("--out-link");
-        nix_build.arg(&profile_path);
-        nix_build.arg(&tmp_profile);
-        nix_build.stdout(std::process::Stdio::piped());
-        nix_build.stderr(std::process::Stdio::piped());
-
-        let result = run_progress(&mut nix_build, Some(progress_handler), RunConfig::default());
-        if let Err(e) = result {
-            let msg = format!("failed to build nix profile: {}", e);
-            progress_handler.error_with_message(msg.clone());
-            return Err(UpError::Exec(msg));
-        }
-
-        if let Err(e) = self.profile_path.set(profile_path) {
-            omni_warning!(format!("failed to save nix profile path: {:?}", e));
+        let paths = nix_handler.build(progress_handler)?;
+        if self.data_paths.set(paths).is_err() {
+            omni_warning!("failed to save nix profile path".to_string());
         }
 
         self.update_cache(progress_handler)?;
@@ -388,7 +183,8 @@ impl UpConfigNix {
         // We are all done, the temporary directory will be removed automatically,
         // so we don't need to worry about it, hence removing our temporary profile
         // for us.
-        progress_handler.success_with_message(format!("installed {}", packages_message));
+        progress_handler
+            .success_with_message(format!("installed {}", nix_handler.nix_source.desc()));
 
         Ok(())
     }
@@ -404,15 +200,15 @@ impl UpConfigNix {
 
     fn update_cache(&self, progress_handler: &dyn ProgressHandler) -> Result<(), UpError> {
         // Get the nix profile path
-        let profile_path = match self.profile_path.get() {
-            Some(profile_path) => profile_path,
+        let profile_path = match self.data_paths.get() {
+            Some(data_paths) => data_paths[0].clone(),
             None => {
                 return Err(UpError::Exec("nix profile path not set".to_string()));
             }
         };
 
         // Load it into a nix profile struct
-        let profile = match NixProfile::from_file(profile_path) {
+        let profile = match NixProfile::from_file(&profile_path) {
             Ok(profile) => profile,
             Err(e) => {
                 return Err(UpError::Exec(format!("failed to load nix profile: {}", e)));
@@ -480,13 +276,483 @@ impl UpConfigNix {
     }
 
     pub fn was_upped(&self) -> bool {
-        self.profile_path.get().is_some()
+        self.data_paths.get().is_some()
     }
 
     pub fn data_paths(&self) -> Vec<PathBuf> {
-        match self.profile_path.get() {
-            Some(profile_path) => vec![profile_path.clone()],
+        match self.data_paths.get() {
+            Some(data_paths) => data_paths.clone(),
             None => vec![],
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct NixHandler {
+    nix_source: NixSource,
+    nix_data_path: OnceCell<PathBuf>,
+}
+
+impl NixHandler {
+    fn new(nixfile: &Option<String>, packages: &Vec<String>) -> Result<Self, UpError> {
+        let nix_source = NixSource::new(nixfile, packages)?;
+
+        Ok(Self {
+            nix_source,
+            ..Self::default()
+        })
+    }
+
+    fn nix_data_path(&self) -> Result<PathBuf, UpError> {
+        let nix_data_path = match self.nix_data_path.get() {
+            Some(nix_data_path) => nix_data_path.clone(),
+            None => {
+                let wd = workdir(".");
+                let data_path = match wd.data_path() {
+                    Some(data_path) => data_path,
+                    None => {
+                        let msg =
+                            format!("failed to get data path for {}", current_dir().display());
+                        return Err(UpError::Exec(msg));
+                    }
+                };
+                let nix_data_path = data_path.join("nix");
+                if self.nix_data_path.set(nix_data_path.clone()).is_err() {
+                    return Err(UpError::Exec("failed to save nix data path".to_string()));
+                }
+                nix_data_path
+            }
+        };
+
+        Ok(nix_data_path)
+    }
+
+    fn exists(&self) -> Result<bool, UpError> {
+        Ok(self
+            .nix_data_path()?
+            .join(self.nix_source.profile_id()?)
+            .exists())
+    }
+
+    fn build(&self, progress_handler: &dyn ProgressHandler) -> Result<Vec<PathBuf>, UpError> {
+        // Generate a temporary file to store the nix profile, we want a directory as
+        // a second file will be generated in the same directory as our temp profile,
+        // and we want to remove both of them once we're done. Using a temporary
+        // directory will make sure that the directory is removed automatically
+        // with all its content.
+        let tmp_dir = match tempfile::Builder::new().prefix("omni_up_nix.").tempdir() {
+            Ok(tmp_dir) => tmp_dir,
+            Err(e) => {
+                let msg = format!("failed to create temporary directory: {}", e);
+                progress_handler.error_with_message(msg.clone());
+                return Err(UpError::Exec(msg));
+            }
+        };
+        let tmp_profile = tmp_dir.path().join("profile");
+
+        // Prepare the nix profile
+        self.nix_source
+            .print_dev_env(&tmp_profile, progress_handler)?;
+
+        // Build and return the built paths
+        self.nix_source
+            .build(&tmp_profile, &self.nix_data_path()?, progress_handler)
+    }
+
+    fn paths(&self, progress_handler: &dyn ProgressHandler) -> Result<Vec<PathBuf>, UpError> {
+        self.nix_source
+            .paths(&self.nix_data_path()?, progress_handler)
+    }
+}
+
+/// NixSource is an enum that represents the different ways to specify
+/// nix dependencies: either by listing packages, by specifying a nix
+/// file, or by specifying a flake.
+#[derive(Debug)]
+enum NixSource {
+    Packages(BTreeSet<String>),
+    NixFile(PathBuf),
+    Flake(PathBuf),
+}
+
+impl Default for NixSource {
+    fn default() -> Self {
+        Self::Packages(BTreeSet::new())
+    }
+}
+
+impl NixSource {
+    fn new(nixfile: &Option<String>, packages: &Vec<String>) -> Result<Self, UpError> {
+        let wd = workdir(".");
+        let wd_root = match wd.root() {
+            Some(wd_root) => PathBuf::from(wd_root),
+            None => {
+                let msg = format!(
+                    "failed to get work directory root for {}",
+                    current_dir().display()
+                );
+                return Err(UpError::Exec(msg));
+            }
+        };
+
+        let nixfile = if let Some(nixfile) = &nixfile {
+            Some(abs_path(nixfile))
+        } else if !packages.is_empty() {
+            None
+        } else {
+            let mut nixfile = None;
+
+            for file in &["shell.nix", "default.nix", "flake.nix"] {
+                let absfile = wd_root.join(file);
+                if absfile.exists() && absfile.is_file() {
+                    nixfile = Some(absfile);
+                    break;
+                }
+            }
+
+            // If no nix file was found, we fail, since if there is a `nix` step
+            // we expect to have to install some dependencies.
+            match nixfile {
+                Some(nixfile) => Some(abs_path(nixfile)),
+                None => {
+                    return Err(UpError::Exec(format!(
+                        "no nix file found in {}",
+                        wd_root.display()
+                    )))
+                }
+            }
+        };
+
+        match &nixfile {
+            Some(nixfile) => {
+                if !nixfile.starts_with(&wd_root) {
+                    return Err(UpError::Exec(format!(
+                        "file {} is not in work directory",
+                        nixfile.display()
+                    )));
+                }
+
+                let is_flake = nixfile
+                    .file_name()
+                    .map_or(false, |file_name| file_name == "flake.nix");
+
+                if is_flake {
+                    Ok(Self::Flake(nixfile.clone()))
+                } else {
+                    Ok(Self::NixFile(nixfile.clone()))
+                }
+            }
+            None => Ok(Self::Packages(packages.iter().cloned().collect())),
+        }
+    }
+
+    fn name(&self) -> String {
+        match *self {
+            Self::Packages(_) => "packages".to_string(),
+            Self::NixFile(ref nixfile) => {
+                nixfile.file_name().map_or("nixfile".into(), |file_name| {
+                    file_name.to_string_lossy().to_string()
+                })
+            }
+            Self::Flake(ref nixfile) => nixfile.file_name().map_or("flake".into(), |file_name| {
+                file_name.to_string_lossy().to_string()
+            }),
+        }
+    }
+
+    fn hash_file(hasher: &mut blake3::Hasher, file: &PathBuf) -> Result<(), UpError> {
+        match std::fs::read(file) {
+            Ok(contents) => hasher.update(&contents),
+            Err(e) => {
+                let msg = format!("failed to read {}: {}", file.display(), e);
+                return Err(UpError::Exec(msg));
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Generate a profile id either by hashing the list of packages
+    /// or the contents of the nix file.
+    fn profile_id(&self) -> Result<String, UpError> {
+        let mut config_hasher = blake3::Hasher::new();
+
+        let profile_suffix = match *self {
+            Self::Packages(ref packages) => {
+                let packages = packages.iter().join("\n");
+                config_hasher.update(packages.as_bytes());
+
+                "pkgs".to_string()
+            }
+            Self::NixFile(ref nixfile) => {
+                Self::hash_file(&mut config_hasher, nixfile)?;
+
+                match nixfile.file_name() {
+                    Some(file_name) => file_name.to_string_lossy().to_string(),
+                    None => "nixfile".to_string(),
+                }
+            }
+            Self::Flake(ref nixfile) => {
+                Self::hash_file(&mut config_hasher, nixfile)?;
+
+                let dirname = nixfile.parent().ok_or_else(|| {
+                    UpError::Exec(format!(
+                        "failed to get parent directory of {}",
+                        nixfile.display()
+                    ))
+                })?;
+                for extra_file in ["flake.lock", "devshell.toml"] {
+                    let extra_file = dirname.join(extra_file);
+                    if extra_file.exists() {
+                        Self::hash_file(&mut config_hasher, &extra_file)?;
+                    }
+                }
+
+                "flake".to_string()
+            }
+        };
+        let profile_hash = config_hasher.finalize().to_hex()[..16].to_string();
+        let profile_id = format!("profile-{}-{}", profile_suffix, profile_hash);
+
+        Ok(profile_id)
+    }
+
+    fn desc(&self) -> String {
+        match *self {
+            Self::Packages(ref packages) => format!(
+                "{} package{}",
+                packages.len().to_string().light_yellow(),
+                if packages.len() > 1 { "s" } else { "" },
+            ),
+            Self::NixFile(ref nixfile) => {
+                let wd = workdir(".");
+                let wd_root = match wd.root() {
+                    Some(wd_root) => PathBuf::from(wd_root),
+                    None => unreachable!("should be in a work directory"),
+                };
+
+                format!(
+                    "packages from {}",
+                    nixfile
+                        .strip_prefix(&wd_root)
+                        .unwrap_or(nixfile)
+                        .display()
+                        .light_yellow()
+                )
+            }
+            Self::Flake(ref _nixfile) => "packages from flake".to_string(),
+        }
+    }
+
+    /// We want to generate a nix profile from either the package or the nix file;
+    /// we do that first in a temporary directory so that if any issue happens, we
+    /// don't overwrite the permanent file for now, protecting against an unexpected
+    /// garbage collection.
+    ///
+    /// We want to call:
+    ///    nix --extra-experimental-features "nix-command flakes" \
+    ///          print-dev-env --profile "$tmp_profile" --impure $expression
+    ///
+    /// Where $expression is either:
+    ///  - For a nixfile:
+    ///      --file "$nixfile"
+    ///  - For a nixfile with attribute:
+    ///      --expr "(import ${nixfile} {}).${attribute}"
+    ///      Where attribute is a string that can be either: "devShell", "shell", "buildInputs", etc.
+    ///  - For a list of packages:
+    ///      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }"
+    ///  - For multiple files: (to verify)
+    ///      --expr "with import <nixpkgs> {}; mkShell { buildInputs = [ (import ./file1.nix {}) (import ./file2.nix {}) ]; }"
+    fn print_dev_env(
+        &self,
+        tmp_profile: &PathBuf,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<(), UpError> {
+        progress_handler.progress("preparing nix environment".to_string());
+
+        let mut nix_print_dev_env = nix_command("print-dev-env");
+        nix_print_dev_env.arg("--verbose");
+        nix_print_dev_env.arg("--print-build-logs");
+        nix_print_dev_env.arg("--profile");
+        nix_print_dev_env.arg(&tmp_profile);
+
+        match *self {
+            Self::Packages(ref packages) => {
+                nix_print_dev_env.arg("--impure");
+
+                let mut context = tera::Context::new();
+                context.insert("packages", &packages.iter().join(" "));
+                let tmpl =
+                    r#"with import <nixpkgs> {}; mkShell { buildInputs = [ {{ packages }} ]; }"#;
+                let expr = match tera::Tera::one_off(tmpl, &context, false) {
+                    Ok(expr) => expr,
+                    Err(e) => {
+                        let msg = format!("failed to render nix expression: {}", e);
+                        progress_handler.error_with_message(msg.clone());
+                        return Err(UpError::Exec(msg));
+                    }
+                };
+
+                nix_print_dev_env.arg("--expr");
+                nix_print_dev_env.arg(&expr);
+            }
+            Self::NixFile(ref nixfile) => {
+                nix_print_dev_env.arg("--impure");
+
+                nix_print_dev_env.arg("--file");
+                nix_print_dev_env.arg(nixfile);
+            }
+            Self::Flake(ref _nixfile) => {}
+        };
+        progress_handler.progress(format!("installing {}", self.desc()));
+
+        let result = run_progress(
+            &mut nix_print_dev_env,
+            Some(progress_handler),
+            RunConfig::default(),
+        );
+
+        if let Err(e) = result {
+            let msg = format!("failed to install nix packages: {}", e);
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        Ok(())
+    }
+
+    /// Now we want to build the nix profile and add it to the gcroots
+    /// so that the packages don't get garbage collected.
+    ///
+    /// We want to call:
+    ///      nix --extra-experimental-features "nix-command flakes" \
+    ///          build --out-link "$perm_profile" "$tmp_profile"
+    ///
+    /// And we will put the permanent profile in the data directory
+    /// of the work directory, so that its life is tied to the work
+    /// directory cache.
+    fn build(
+        &self,
+        tmp_profile: &PathBuf,
+        nix_data_path: &PathBuf,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<Vec<PathBuf>, UpError> {
+        progress_handler.progress("protecting dependencies with gcroots".to_string());
+
+        let profile_id = self.profile_id()?;
+        let profile_path = nix_data_path.join(&profile_id);
+
+        let mut built_paths = Vec::new();
+        built_paths.push(profile_path.clone());
+
+        let mut nix_build = nix_gcroot_command(tmp_profile, &profile_path);
+
+        let result = run_progress(&mut nix_build, Some(progress_handler), RunConfig::default());
+        if let Err(e) = result {
+            let msg = format!("failed to build nix profile: {}", e);
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        let paths = self.flake_archive_paths(progress_handler)?;
+        for path in paths {
+            let perm_path = nix_data_path.join(format!(
+                "{}.{}",
+                profile_id,
+                path.file_name()
+                    .expect("path has no file name")
+                    .to_string_lossy()
+            ));
+            let mut nix_build = nix_gcroot_command(&path, &perm_path);
+
+            let result = run_progress(&mut nix_build, Some(progress_handler), RunConfig::default());
+            if let Err(e) = result {
+                let msg = format!("failed to build flake archive: {}", e);
+                progress_handler.error_with_message(msg.clone());
+                return Err(UpError::Exec(msg));
+            }
+
+            built_paths.push(perm_path);
+        }
+
+        Ok(built_paths)
+    }
+
+    fn paths(
+        &self,
+        nix_data_path: &PathBuf,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<Vec<PathBuf>, UpError> {
+        let profile_id = self.profile_id()?;
+        let profile_path = nix_data_path.join(&profile_id);
+
+        let mut built_paths = Vec::new();
+        built_paths.push(profile_path.clone());
+
+        let paths = self.flake_archive_paths(progress_handler)?;
+        for path in paths {
+            let perm_path = nix_data_path.join(format!(
+                "{}.{}",
+                profile_id,
+                path.file_name()
+                    .expect("path has no file name")
+                    .to_string_lossy()
+            ));
+
+            built_paths.push(perm_path);
+        }
+
+        Ok(built_paths)
+    }
+
+    fn flake_archive_paths(
+        &self,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<Vec<PathBuf>, UpError> {
+        match *self {
+            Self::Flake(ref nixfile) => {
+                let nixfile_parent_path = nixfile
+                    .parent()
+                    .expect("nixfile has no parent")
+                    .to_path_buf();
+
+                let mut nix_flake = nix_command("flake");
+                nix_flake.arg("archive");
+                nix_flake.arg("--json");
+                nix_flake.arg("--no-write-lock-file");
+                nix_flake.arg(nixfile_parent_path);
+
+                let output = match get_command_output(&mut nix_flake, RunConfig::default()) {
+                    Ok(output) => output,
+                    Err(e) => {
+                        let msg = format!("failed to archive nix flake: {}", e);
+                        progress_handler.error_with_message(msg.clone());
+                        return Err(UpError::Exec(msg));
+                    }
+                };
+
+                if !output.status.success() {
+                    let msg = format!(
+                        "failed to archive nix flake: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    progress_handler.error_with_message(msg.clone());
+                    return Err(UpError::Exec(msg));
+                }
+
+                let archive = String::from_utf8_lossy(&output.stdout);
+
+                // Get all the /nix/store/... paths found in the archive
+                let re = regex::Regex::new(r#""/nix/store/[^"]+""#).expect("invalid regex");
+                let paths = re
+                    .find_iter(&archive)
+                    .map(|m| m.as_str().trim_matches('"').to_string())
+                    .map(PathBuf::from)
+                    .collect::<Vec<_>>();
+
+                Ok(paths)
+            }
+            _ => Ok(Vec::new()),
         }
     }
 }

--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -630,7 +630,7 @@ impl NixSource {
     ///
     /// And we will put the permanent profile in the data directory
     /// of the work directory, so that its life is tied to the work
-    /// directory cache.
+    /// directory data.
     fn build(
         &self,
         tmp_profile: &PathBuf,
@@ -654,6 +654,7 @@ impl NixSource {
             return Err(UpError::Exec(msg));
         }
 
+        // For flakes, we can also add the sources to the garbage collection root
         let paths = self.flake_archive_paths(progress_handler)?;
         for path in paths {
             let perm_path = nix_data_path.join(format!(

--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -382,7 +382,7 @@ impl Default for NixSource {
 }
 
 impl NixSource {
-    fn new(nixfile: &Option<String>, packages: &Vec<String>) -> Result<Self, UpError> {
+    fn new(nixfile: &Option<String>, packages: &[String]) -> Result<Self, UpError> {
         let wd = workdir(".");
         let wd_root = match wd.root() {
             Some(wd_root) => PathBuf::from(wd_root),
@@ -574,7 +574,7 @@ impl NixSource {
         nix_print_dev_env.arg("--verbose");
         nix_print_dev_env.arg("--print-build-logs");
         nix_print_dev_env.arg("--profile");
-        nix_print_dev_env.arg(&tmp_profile);
+        nix_print_dev_env.arg(tmp_profile);
 
         match *self {
             Self::Packages(ref packages) => {
@@ -633,8 +633,8 @@ impl NixSource {
     /// directory data.
     fn build(
         &self,
-        tmp_profile: &PathBuf,
-        nix_data_path: &PathBuf,
+        tmp_profile: &Path,
+        nix_data_path: &Path,
         progress_handler: &dyn ProgressHandler,
     ) -> Result<Vec<PathBuf>, UpError> {
         progress_handler.progress("protecting dependencies with gcroots".to_string());
@@ -681,7 +681,7 @@ impl NixSource {
 
     fn paths(
         &self,
-        nix_data_path: &PathBuf,
+        nix_data_path: &Path,
         progress_handler: &dyn ProgressHandler,
     ) -> Result<Vec<PathBuf>, UpError> {
         let profile_id = self.profile_id()?;

--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -294,7 +294,7 @@ struct NixHandler {
 }
 
 impl NixHandler {
-    fn new(nixfile: &Option<String>, packages: &Vec<String>) -> Result<Self, UpError> {
+    fn new(nixfile: &Option<String>, packages: &[String]) -> Result<Self, UpError> {
         let nix_source = NixSource::new(nixfile, packages)?;
 
         Ok(Self {

--- a/tests/fixtures/bin/generic.sh
+++ b/tests/fixtures/bin/generic.sh
@@ -93,9 +93,9 @@ fi
 
 # Get the expected response
 response=()
-while read -r line; do
+while IFS= read -r line; do
     response+=("$line")
-done <<< $(echo "$expected" | tail -n +4)
+done < <(echo "$expected" | tail -n +4)
 
 # If the first line of the response is '#omni-test-bash-function', then
 # we want to eval the response as a bash function, and then check that

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -125,7 +125,7 @@ add_nix_python_calls() {
 
   local nix=(nix --extra-experimental-features "nix-command flakes")
 
-  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ gawk gnused openssl readline bzip2 gcc gdbm gnumake libffi lzma ncurses pkg-config sqlite zlib ]; }'
+  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ bzip2 gawk gcc gdbm gnumake gnused libffi lzma ncurses openssl pkg-config readline sqlite zlib ]; }'
   add_command "${nix[@]}" build --print-out-paths --out-link "regex:${HOME}/\.local/share/omni/wd/.*/nix/profile-pkgs-.*" "regex:${tmpdir}/omni_up_nix\..*/profile" <<EOF
 #omni-test-bash-function
 function process_response() {

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-nix.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-nix.md
@@ -25,8 +25,8 @@ Contains a list of objects with the following parameters:
 
 ```yaml
 up:
-  # Will look for `shell.nix` or `default.nix` at the
-  # root of the work directory and use it to build
+  # Will look for `shell.nix`, `default.nix` or `flake.nix`
+  # at the root of the work directory and use it to build
   # dependencies
   - nix
 
@@ -38,6 +38,9 @@ up:
 
   # Will install the packages defined in `file.nix`
   - nix: file.nix
+
+  # Will install the packages defined in the flake `flake.nix`
+  - nix: flake.nix
 ```
 
 ## Dynamic environment


### PR DESCRIPTION
Nix flakes are slightly different than nix profiles and require special handling. This adds omni support for nix flakes by behaving differently when using the `flake.nix` file, which can also be automatically-detected in a work directory.

Closes https://github.com/XaF/omni/issues/466