### PR TITLE
feat(homebrew): ✨ auto-extract taps from formulas

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -594,6 +594,16 @@ impl UpConfigAsdfBase {
                             dir.pop();
                         }
 
+                        progress_handler.progress(format!(
+                            "detected required version {} {}",
+                            detected_version,
+                            if dir != "" {
+                                format!("in {}", dir)
+                            } else {
+                                "at root".to_string()
+                            }
+                        ));
+
                         if let Some(dirs) = detected_versions.get_mut(&detected_version) {
                             dirs.insert(dir);
                         } else {

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -597,10 +597,10 @@ impl UpConfigAsdfBase {
                         progress_handler.progress(format!(
                             "detected required version {} {}",
                             detected_version,
-                            if dir != "" {
-                                format!("in {}", dir)
-                            } else {
+                            if dir.is_empty() {
                                 "at root".to_string()
+                            } else {
+                                format!("in {}", dir)
                             }
                         ));
 

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -453,7 +453,7 @@ pub struct HomebrewTap {
 
 impl PartialOrd for HomebrewTap {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
     }
 }
 
@@ -468,6 +468,7 @@ impl HomebrewTap {
         config_value: Option<&ConfigValue>,
         installs: &[HomebrewInstall],
     ) -> Vec<Self> {
+        #[allow(clippy::mutable_key_type)]
         let mut taps = BTreeSet::new();
 
         if let Some(config_value) = config_value {


### PR DESCRIPTION
Homebrew supports auto-tapping formulas using the long format `tap-owner/tap-name/formula`, which will automatically tap the formula when calling `brew install`. However, this won't allow for omni to keep track of what's being tapped and what needs to be cleaned up.

To solve that problem, omni will now automatically extract the tap when using that format, so that taps can be automatically untapped when not used anymore (if omni triggered the initial tapping).

Closes https://github.com/XaF/omni/issues/516