### PR TITLE
build(status): 👷 fix check of test results

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -257,13 +257,24 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
-      - deploy-website
       - build-and-test-binaries
       - rust-clippy-analysis
+      - deploy-website
 
     if: '!cancelled()'
 
     steps:
+      - name: Print status
+        run: |
+          echo "== RESULTS"
+          echo "Build and test binaries: ${{ needs.build-and-test-binaries.result }}"
+          echo "Rust clippy analysis: ${{ needs.rust-clippy-analysis.result }}"
+          echo "Deploy website: ${{ needs.deploy-website.result }}"
+          echo "== CONCLUSIONS"
+          echo "Build and test binaries: ${{ needs.build-and-test-binaries.conclusion }}"
+          echo "Rust clippy analysis: ${{ needs.rust-clippy-analysis.conclusion }}"
+          echo "Deploy website: ${{ needs.deploy-website.conclusion }}"
+
       - name: Fail if tests failed
         if: needs.build-and-test-binaries.result == 'failure'
         run: exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -264,27 +264,16 @@ jobs:
     if: '!cancelled()'
 
     steps:
-      - name: Print status
-        run: |
-          echo "== RESULTS"
-          echo "Build and test binaries: ${{ needs.build-and-test-binaries.result }}"
-          echo "Rust clippy analysis: ${{ needs.rust-clippy-analysis.result }}"
-          echo "Deploy website: ${{ needs.deploy-website.result }}"
-          echo "== CONCLUSIONS"
-          echo "Build and test binaries: ${{ needs.build-and-test-binaries.conclusion }}"
-          echo "Rust clippy analysis: ${{ needs.rust-clippy-analysis.conclusion }}"
-          echo "Deploy website: ${{ needs.deploy-website.conclusion }}"
-
       - name: Fail if tests failed
-        if: needs.build-and-test-binaries.result == 'failure'
+        if: needs.build-and-test-binaries.result == 'failure' || needs.build-and-test-binaries.result == 'cancelled'
         run: exit 1
 
       - name: Fail if CodeQL failed
-        if: needs.rust-clippy-analysis.result == 'failure'
+        if: needs.rust-clippy-analysis.result == 'failure' || needs.rust-clippy-analysis.result == 'cancelled'
         run: exit 1
 
       - name: Fail if website building/deployment failed
-        if: needs.deploy-website.result == 'failure'
+        if: needs.deploy-website.result == 'failure' || needs.deploy-website.result == 'cancelled'
         run: exit 1
 
 

--- a/tests/test_omni_up_homebrew.bats
+++ b/tests/test_omni_up_homebrew.bats
@@ -106,6 +106,8 @@ up:
       - fakerepo/fake/fakeformula
 EOF
 
+  add_command brew tap
+  add_command brew tap fakerepo/fake
   add_command brew list --formula fakerepo/fake/fakeformula exit=1
   add_command brew install --formula fakerepo/fake/fakeformula
   add_command brew --prefix --installed fakerepo/fake/fakeformula


### PR DESCRIPTION
One of the `bats` tests failed, but the `check test results` step of the tests did not fail, which led to the code being merged. This should have blocked the merge until the tests passed.

This should fix that situation, as well as the broken test.