### PR TITLE
feat(update): ✨ ask before updating on command not found

### DIFF
--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use utils::safe_normalize_url;
 
 mod updater;
 pub(crate) use updater::auto_update_async;
-pub(crate) use updater::auto_update_sync;
+pub(crate) use updater::auto_update_on_command_not_found;
 pub(crate) use updater::exec_update;
 pub(crate) use updater::exec_update_and_log_on_error;
 pub(crate) use updater::report_update_error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use internal::config::up::utils::handle_shims;
 use internal::config::up::utils::AskPassRequest;
 use internal::env::tmpdir_cleanup;
 use internal::git::auto_update_async;
-use internal::git::auto_update_sync;
+use internal::git::auto_update_on_command_not_found;
 use internal::git::exec_update;
 use internal::git::exec_update_and_log_on_error;
 use internal::StringColor;
@@ -239,7 +239,7 @@ fn run_omni_subcommand(parsed: &MainArgs) {
     }
 
     // We didn't find the command, so let's try to update synchronously
-    if auto_update_sync() {
+    if auto_update_on_command_not_found() {
         // If any updates were done, let's check again if we can serve the command
         if let Some((omni_cmd, called_as, argv)) = command_loader.to_serve(&parsed.args) {
             set_cleanup_handler();

--- a/website/contents/reference/01-configuration/0102-parameters/010250-path_repo_updates/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-path_repo_updates/010250-self.md
@@ -17,6 +17,7 @@ Configuration for the automated updates of the repositories in omni path.
 | `pre_auth_timeout` | duration | the duration after which a pre-auth timeouts *(default: 2m)* |
 | `background_updates` | boolean | whether or not to allow background updates of the repositories *(default: true)* |
 | `background_updates_timeout` | duration | the number of seconds after which a background update timeouts *(default: 1h)* |
+| `on_command_not_found` | enum: `true`, `false`, `ask` | whether to trigger an update when a command is not found *(default: ask)* |
 | `interval` | duration | the number of seconds to wait between two updates of the repositories *(default: 12h)* |
 | `ref_type` | enum: `branch` or `tag` | the type of ref that is being used for updates *(default: branch)* |
 | `ref_match` | regex |  a string representing the regular expression to match the ref name when doing an update; using `null` is equivalent to matching everything *(default: null)* |
@@ -32,6 +33,7 @@ path_repo_updates:
   pre_auth_timeout: 120 # 2 minutes
   background_updates: true
   background_updates_timeout: 3600 # 1 hour
+  on_command_not_found: ask
   interval: 43200 # 12 hours
   ref_type: "branch" # branch or tag
   ref_match: null # regex or null


### PR DESCRIPTION
`omni` was automatically triggering a synchroneous update on command not found (if due) in order to make sure to run the command if available.

The new `path_repo_updates`/`on_command_not_found` option in the configuration can be set to either one of `true`, `false` or `ask`. If set to `ask`, which is the default, it will ask the user before running any sync update -- Note that answering 'no' will still trigger updates, but in the background. If set to `true`, sync updates will be triggered without any question. If set to `false`, no update will be triggered at all.

Closes https://github.com/XaF/omni/issues/482