### PR TITLE
feat(cleanup): ✨ add delay before removing unused resources

### DIFF
--- a/src/internal/config/parser/cache/asdf.rs
+++ b/src/internal/config/parser/cache/asdf.rs
@@ -9,6 +9,7 @@ pub struct AsdfCacheConfig {
     pub update_expire: u64,
     pub plugin_update_expire: u64,
     pub plugin_versions_expire: u64,
+    pub cleanup_after: u64,
 }
 
 impl Default for AsdfCacheConfig {
@@ -17,6 +18,7 @@ impl Default for AsdfCacheConfig {
             update_expire: Self::DEFAULT_UPDATE_EXPIRE,
             plugin_update_expire: Self::DEFAULT_PLUGIN_UPDATE_EXPIRE,
             plugin_versions_expire: Self::DEFAULT_PLUGIN_VERSIONS_EXPIRE,
+            cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
         }
     }
 }
@@ -25,6 +27,7 @@ impl AsdfCacheConfig {
     const DEFAULT_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_PLUGIN_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_PLUGIN_VERSIONS_EXPIRE: u64 = 3600; // 1 hour
+    const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
 
     pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
         let config_value = match config_value {
@@ -47,10 +50,16 @@ impl AsdfCacheConfig {
             Self::DEFAULT_PLUGIN_VERSIONS_EXPIRE,
         );
 
+        let cleanup_after = parse_duration_or_default(
+            config_value.get("cleanup_after").as_ref(),
+            Self::DEFAULT_CLEANUP_AFTER,
+        );
+
         Self {
             update_expire,
             plugin_update_expire,
             plugin_versions_expire,
+            cleanup_after,
         }
     }
 }

--- a/src/internal/config/parser/cache/github_release.rs
+++ b/src/internal/config/parser/cache/github_release.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::config::utils::parse_duration_or_default;
+use crate::internal::config::ConfigValue;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GithubReleaseCacheConfig {
+    pub versions_expire: u64,
+    pub cleanup_after: u64,
+}
+
+impl Default for GithubReleaseCacheConfig {
+    fn default() -> Self {
+        Self {
+            versions_expire: Self::DEFAULT_VERSIONS_EXPIRE,
+            cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
+        }
+    }
+}
+
+impl GithubReleaseCacheConfig {
+    const DEFAULT_VERSIONS_EXPIRE: u64 = 86400; // 1 day
+    const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
+
+    pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let versions_expire = parse_duration_or_default(
+            config_value.get("versions_expire").as_ref(),
+            Self::DEFAULT_VERSIONS_EXPIRE,
+        );
+
+        let cleanup_after = parse_duration_or_default(
+            config_value.get("cleanup_after").as_ref(),
+            Self::DEFAULT_CLEANUP_AFTER,
+        );
+
+        Self {
+            versions_expire,
+            cleanup_after,
+        }
+    }
+}

--- a/src/internal/config/parser/cache/homebrew.rs
+++ b/src/internal/config/parser/cache/homebrew.rs
@@ -9,6 +9,7 @@ pub struct HomebrewCacheConfig {
     pub update_expire: u64,
     pub install_update_expire: u64,
     pub install_check_expire: u64,
+    pub cleanup_after: u64,
 }
 
 impl Default for HomebrewCacheConfig {
@@ -17,6 +18,7 @@ impl Default for HomebrewCacheConfig {
             update_expire: Self::DEFAULT_UPDATE_EXPIRE,
             install_update_expire: Self::DEFAULT_INSTALL_UPDATE_EXPIRE,
             install_check_expire: Self::DEFAULT_INSTALL_CHECK_EXPIRE,
+            cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
         }
     }
 }
@@ -25,6 +27,7 @@ impl HomebrewCacheConfig {
     const DEFAULT_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_INSTALL_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_INSTALL_CHECK_EXPIRE: u64 = 43200; // 12 hours
+    const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
 
     pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
         let config_value = match config_value {
@@ -47,10 +50,16 @@ impl HomebrewCacheConfig {
             Self::DEFAULT_INSTALL_CHECK_EXPIRE,
         );
 
+        let cleanup_after = parse_duration_or_default(
+            config_value.get("cleanup_after").as_ref(),
+            Self::DEFAULT_CLEANUP_AFTER,
+        );
+
         Self {
             update_expire,
             install_update_expire,
             install_check_expire,
+            cleanup_after,
         }
     }
 }

--- a/src/internal/config/parser/cache/mod.rs
+++ b/src/internal/config/parser/cache/mod.rs
@@ -4,5 +4,8 @@ pub(crate) use root::CacheConfig;
 mod asdf;
 pub(crate) use asdf::AsdfCacheConfig;
 
+mod github_release;
+pub(crate) use github_release::GithubReleaseCacheConfig;
+
 mod homebrew;
 pub(crate) use homebrew::HomebrewCacheConfig;

--- a/src/internal/config/parser/cache/root.rs
+++ b/src/internal/config/parser/cache/root.rs
@@ -2,8 +2,8 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::config::parser::cache::AsdfCacheConfig;
+use crate::internal::config::parser::cache::GithubReleaseCacheConfig;
 use crate::internal::config::parser::cache::HomebrewCacheConfig;
-use crate::internal::config::utils::parse_duration_or_default;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::cache_home;
 
@@ -11,7 +11,7 @@ use crate::internal::env::cache_home;
 pub struct CacheConfig {
     pub path: String,
     pub asdf: AsdfCacheConfig,
-    pub github_release_versions_expire: u64,
+    pub github_release: GithubReleaseCacheConfig,
     pub homebrew: HomebrewCacheConfig,
 }
 
@@ -20,15 +20,13 @@ impl Default for CacheConfig {
         Self {
             path: cache_home(),
             asdf: AsdfCacheConfig::default(),
-            github_release_versions_expire: Self::DEFAULT_GITHUB_RELEASE_VERSIONS_EXPIRE,
+            github_release: GithubReleaseCacheConfig::default(),
             homebrew: HomebrewCacheConfig::default(),
         }
     }
 }
 
 impl CacheConfig {
-    const DEFAULT_GITHUB_RELEASE_VERSIONS_EXPIRE: u64 = 86400; // 1 day
-
     pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
         let config_value = match config_value {
             Some(config_value) => config_value,
@@ -41,18 +39,14 @@ impl CacheConfig {
         };
 
         let asdf = AsdfCacheConfig::from_config_value(config_value.get("asdf"));
-
-        let github_release_versions_expire = parse_duration_or_default(
-            config_value.get("github_release_versions_expire").as_ref(),
-            Self::DEFAULT_GITHUB_RELEASE_VERSIONS_EXPIRE,
-        );
-
+        let github_release =
+            GithubReleaseCacheConfig::from_config_value(config_value.get("github_release"));
         let homebrew = HomebrewCacheConfig::from_config_value(config_value.get("homebrew"));
 
         Self {
             path,
             asdf,
-            github_release_versions_expire,
+            github_release,
             homebrew,
         }
     }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -961,12 +961,13 @@ impl UpConfigAsdfBase {
 
             for (idx, exists) in asdf_cache.installed.iter_mut().enumerate() {
                 if exists.required_by.contains(&workdir_id)
+                    && exists.stale()
                     && !expected_tools.contains(&(exists.tool.clone(), exists.version.clone()))
                 {
                     exists.required_by.retain(|id| id != &workdir_id);
                     updated = true;
                 }
-                if exists.required_by.is_empty() {
+                if exists.removable() {
                     to_remove.push((idx, exists.clone()));
                 }
             }

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -275,7 +275,7 @@ impl UpConfigGithubReleases {
                     // Only return the path if the github release is
                     // expected, as we will clear the bin path from
                     // all unexpected github releases
-                    if install.required_by.is_empty() {
+                    if install.removable() {
                         None
                     } else {
                         Some(
@@ -699,7 +699,7 @@ impl UpConfigGithubRelease {
             if let Some(releases) = cache.get_releases(&self.repository) {
                 let releases = releases.clone();
                 let config = global_config();
-                let expire = config.cache.github_release_versions_expire;
+                let expire = config.cache.github_release.versions_expire;
                 if !releases.is_stale(expire) {
                     progress_handler.progress("using cached release list".light_black());
                     return Ok(releases);
@@ -767,7 +767,7 @@ impl UpConfigGithubRelease {
         };
 
         progress_handler.progress(format!(
-            "getting auth token from {} and hostname {}",
+            "getting auth token from {} for hostname {}",
             "gh".light_yellow(),
             hostname.light_yellow()
         ));

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -263,7 +263,7 @@ impl UpConfigHomebrew {
                 .enumerate()
                 .rev() // reverse so we can remove from the end
                 .filter_map(|(idx, install)| {
-                    if install.required_by.is_empty() && install.installed {
+                    if install.installed && install.removable() {
                         Some((idx, HomebrewInstall::from_cache(install)))
                     } else {
                         None
@@ -299,9 +299,7 @@ impl UpConfigHomebrew {
             }
 
             let current_installed = brew_cache.installed.len();
-            brew_cache
-                .installed
-                .retain(|install| !install.required_by.is_empty() || install.installed);
+            brew_cache.installed.retain(|install| !install.removable());
             if current_installed != brew_cache.installed.len() {
                 updated = true;
             }
@@ -314,7 +312,7 @@ impl UpConfigHomebrew {
                 .enumerate()
                 .rev() // reverse so we can remove from the end
                 .filter_map(|(idx, tap)| {
-                    if tap.required_by.is_empty() && tap.tapped {
+                    if tap.tapped && tap.removable() {
                         Some((idx, HomebrewTap::from_name(&tap.name)))
                     } else {
                         None
@@ -349,9 +347,7 @@ impl UpConfigHomebrew {
             }
 
             let current_tapped = brew_cache.tapped.len();
-            brew_cache
-                .tapped
-                .retain(|tap| !tap.required_by.is_empty() || tap.tapped);
+            brew_cache.tapped.retain(|tap| !tap.removable());
             if current_tapped != brew_cache.tapped.len() {
                 updated = true;
             }

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -237,7 +237,7 @@ lazy_static! {
 /// itself in a subprocess, the subprocess will have a time
 /// greater or equal to the one of the calling process.
 pub fn now() -> OffsetDateTime {
-    (*NOW).clone()
+    *NOW
 }
 
 /// Cleanup temporary directories created by omni in the system's

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -14,6 +14,7 @@ use git_url_parse::GitUrl;
 use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
+use time::OffsetDateTime;
 
 use crate::internal::config::parser::PathEntryConfig;
 use crate::internal::config::up::utils::force_remove_dir_all;
@@ -225,6 +226,18 @@ lazy_static! {
 
         format!("omnitmp-{}", short_uuid)
     };
+
+    #[derive(Debug)]
+    static ref NOW: OffsetDateTime = OffsetDateTime::now_utc();
+}
+
+/// Get the time of the current execution of omni in UTC.
+/// This is only computed once and the same time will keep
+/// being returned for the same run of omni. If omni calls
+/// itself in a subprocess, the subprocess will have a time
+/// greater or equal to the one of the calling process.
+pub fn now() -> OffsetDateTime {
+    (*NOW).clone()
 }
 
 /// Cleanup temporary directories created by omni in the system's

--- a/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-asdf.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-asdf.md
@@ -13,6 +13,7 @@ Configuration of the cache for `asdf` operations.
 | `update_expire` | duration | How long to cache the fact that updates for `asdf` itself have been checked. This allows to avoid checking for updates on each `omni up` call. |
 | `plugin_update_expire` | duration | How long to cache the fact that updates for a given `asdf` plugin have been checked. This allows to avoid checking for updates on each `omni up` call. |
 | `plugin_versions_expire` | duration | How long to cache a given `asdf` plugin versions for. This allows to avoid listing available versions on each `omni up` call. |
+| `cleanup_after` | duration | The grace period before cleaning up the resources that are no longer needed. |
 
 ## Example
 
@@ -21,4 +22,5 @@ asdf:
   update_expire: 1d
   plugin_update_expire: 1d
   plugin_versions_expire: 1h
+  cleanup_after: 1w
 ```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-github_release.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-github_release.md
@@ -1,0 +1,22 @@
+---
+description: Configuration of the `asdf` parameter
+---
+
+# `asdf`
+
+## Parameters
+
+Configuration of the cache for `asdf` operations.
+
+| Operation | Type | Description                                                    |
+|-----------|------|---------------------------------------------------------|
+| `versions_expire` | duration | How long to cache a given GitHub repository versions for. This allows to avoid listing available versions on each `omni up` call. The versions are automatically re-listed if the cache does not contain any matching version. |
+| `cleanup_after` | duration | The grace period before cleaning up the resources that are no longer needed. |
+
+## Example
+
+```yaml
+asdf:
+  versions_expire: 1d
+  cleanup_after: 1w
+```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-homebrew.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-homebrew.md
@@ -13,6 +13,7 @@ Configuration of the cache for `homebrew` operations.
 | `update_expire` | duration | How long to cache the fact that `brew update` has been run. This allows to avoid running it on each `omni up` call. |
 | `install_update_expire` | duration | How long to cache the fact that `brew upgrade` has been run for a given formulae or cask. This allows to avoid running it on each `omni up` call. |
 | `install_check_expire` | duration | How long to cache that we have seen a given formulae or cask as installed. This allows to avoid checking it on each `omni up` call. |
+| `cleanup_after` | duration | The grace period before cleaning up the resources that are no longer needed. |
 
 ## Example
 
@@ -21,4 +22,5 @@ homebrew:
   update_expire: 1d
   install_update_expire: 1d
   install_check_expire: 12h
+  cleanup_after: 1w
 ```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-cache/010250-self.md
@@ -13,6 +13,7 @@ Configuration of the cache.
 |-----------|------|---------------------------------------------------------|
 | `path` | path | The path to the cache directory *(default: `~/.cache/omni`)* |
 | `asdf` | [asdf](cache/asdf) | Configuration of the cache for `asdf` operations |
+| `github_release` | [github_release](cache/github_release) | Configuration of the cache for `github_release` operations |
 | `homebrew`  | [homebrew](cache/homebrew) | Configuration of the cache for `homebrew` operations |
 
 ## Example
@@ -24,8 +25,13 @@ cache:
     update_expire: 1d
     plugin_update_expire: 1d
     plugin_versions_expire: 1h
+    clean_after: 1w
+  github_release:
+    versions_expire: 1d
+    cleanup_after: 1w
   homebrew:
     update_expire: 1d
     install_update_expire: 1d
     install_check_expire: 12h
+    cleanup_after: 1w
 ```


### PR DESCRIPTION
Resources cleanup is done as soon as a resource is not in use. However, when switching between branches, this might lead to a lot of resources being cleaned-up and reinstalled, etc.

This adds a grace period between a resource not being used anymore and it being cleaned up; it defaults to 1 week, but can be changed to `0` to restore previous behavior, or to any other discretionary period of time.

Individual configuration options are available depending on the resource type, so that they can each behave differently:
- `cache`/`asdf`/`cleanup_after` for the cleanup of asdf versions
- `cache`/`homebrew`/`cleanup_after` for the cleanup of homebrew taps and formulae
- `cache`/`github_release`/`cleanup_after` for the cleanup of GitHub releases

Closes https://github.com/XaF/omni/issues/435