### PR TITLE
refactor(shims): ♻️  shims are now always loaded but removed by dynenv

### DIFF
--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -359,9 +359,9 @@ fn dump_integration(args: HookInitCommandArgs, integration: &[u8]) {
     let integration = String::from_utf8_lossy(integration).to_string();
 
     let mut context = Context::new();
-    context.insert("OMNI_BIN", &escape(current_exe().to_string_lossy().into()));
+    context.insert("OMNI_BIN", &escape(current_exe().to_string_lossy()));
     context.insert("OMNI_DATA_HOME", &escape(data_home().into()));
-    context.insert("OMNI_SHIMS", &escape(shims_dir().to_string_lossy().into()));
+    context.insert("OMNI_SHIMS", &escape(shims_dir().to_string_lossy()));
     context.insert("OMNI_ALIASES", &args.aliases);
     context.insert("OMNI_COMMAND_ALIASES", &args.command_aliases);
     context.insert("SHIMS_ONLY", &args.shims);

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -12,6 +12,7 @@ use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::current_exe;
 use crate::internal::env::data_home;
+use crate::internal::env::shims_dir;
 use crate::internal::env::Shell;
 use crate::internal::user_interface::StringColor;
 use crate::omni_error;
@@ -22,6 +23,8 @@ struct HookInitCommandArgs {
     aliases: Vec<String>,
     command_aliases: Vec<InitHookAlias>,
     shims: bool,
+    keep_shims: bool,
+    print_shims_path: bool,
 }
 
 impl HookInitCommandArgs {
@@ -52,6 +55,23 @@ impl HookInitCommandArgs {
                     .action(clap::ArgAction::SetTrue)
                     .conflicts_with("aliases")
                     .conflicts_with("command_aliases"),
+            )
+            .arg(
+                clap::Arg::new("keep-shims")
+                    .long("keep-shims")
+                    .action(clap::ArgAction::SetTrue)
+                    .conflicts_with("aliases")
+                    .conflicts_with("command_aliases")
+                    .conflicts_with("shims"),
+            )
+            .arg(
+                clap::Arg::new("print-shims-path")
+                    .long("print-shims-path")
+                    .action(clap::ArgAction::SetTrue)
+                    .conflicts_with("aliases")
+                    .conflicts_with("command_aliases")
+                    .conflicts_with("shims")
+                    .conflicts_with("keep-shims"),
             )
             .try_get_matches_from(&parse_argv);
 
@@ -128,12 +148,18 @@ impl HookInitCommandArgs {
         );
 
         let shims = *matches.get_one::<bool>("shims").unwrap_or(&false);
+        let keep_shims = *matches.get_one::<bool>("keep-shims").unwrap_or(&false);
+        let print_shims_path = *matches
+            .get_one::<bool>("print-shims-path")
+            .unwrap_or(&false);
 
         Self {
             shell,
             aliases,
             command_aliases,
             shims,
+            keep_shims,
+            print_shims_path,
         }
     }
 }
@@ -253,6 +279,23 @@ impl BuiltinCommand for HookInitCommand {
                     required: false,
                 },
                 SyntaxOptArg {
+                    name: "--keep-shims-in-path".to_string(),
+                    desc: Some(concat!(
+                        "Prevent the dynamic environment from removing the shims directory from the PATH. ",
+                        "This can be useful if you are used to launch your IDE from the terminal and do ",
+                        "not have other means to load the shims in its environment."
+                    ).to_string()),
+                    required: false,
+                },
+                SyntaxOptArg {
+                    name: "--print-shims-path".to_string(),
+                    desc: Some(concat!(
+                        "Print the path to the shims directory and exit. This should not be ",
+                        "used to eval in a shell environment."
+                    ).to_string()),
+                    required: false,
+                },
+                SyntaxOptArg {
                     name: "shell".to_string(),
                     desc: Some(
                         "Which shell to initialize omni for. Can be one of bash, zsh or fish."
@@ -270,6 +313,11 @@ impl BuiltinCommand for HookInitCommand {
 
     fn exec(&self, argv: Vec<String>) {
         let args = HookInitCommandArgs::parse(argv);
+
+        if args.print_shims_path {
+            println!("{}", shims_dir().display());
+            exit(0);
+        }
 
         match args.shell.as_str() {
             "bash" => dump_integration(
@@ -311,16 +359,13 @@ fn dump_integration(args: HookInitCommandArgs, integration: &[u8]) {
     let integration = String::from_utf8_lossy(integration).to_string();
 
     let mut context = Context::new();
-    context.insert(
-        "OMNI_BIN",
-        &escape(std::borrow::Cow::Borrowed(
-            current_exe().to_string_lossy().as_ref(),
-        )),
-    );
+    context.insert("OMNI_BIN", &escape(current_exe().to_string_lossy().into()));
     context.insert("OMNI_DATA_HOME", &escape(data_home().into()));
+    context.insert("OMNI_SHIMS", &escape(shims_dir().to_string_lossy().into()));
     context.insert("OMNI_ALIASES", &args.aliases);
     context.insert("OMNI_COMMAND_ALIASES", &args.command_aliases);
     context.insert("SHIMS_ONLY", &args.shims);
+    context.insert("KEEP_SHIMS", &args.keep_shims);
 
     let result = Tera::one_off(&integration, &context, false)
         .expect("failed to render integration template");

--- a/src/internal/config/up/utils/shims.rs
+++ b/src/internal/config/up/utils/shims.rs
@@ -25,14 +25,12 @@ pub fn handle_shims() {
         None => return,
     };
 
-    // Load the current path environment variable
-    let path_env = env::var("PATH").unwrap_or_else(|_| "".to_string());
-
     // Check if argv0 is a path, or if it is just a binary name called from the PATH
     let path = if argv0.contains('/') {
         abs_path(&argv0)
     } else {
-        path_env
+        env::var("PATH")
+            .unwrap_or_else(|_| "".to_string())
             .split(':')
             .map(|path| PathBuf::from(path).join(&argv0))
             .find(|path| path.is_file())
@@ -53,14 +51,6 @@ pub fn handle_shims() {
 
     // Load the dynamic environment for the current directory
     update_dynamic_env_for_command(".");
-
-    // Make sure that the PATH does not contain the shims directory
-    let path_env = path_env
-        .split(':')
-        .filter(|path| !PathBuf::from(path).starts_with(shims_dir()))
-        .collect::<Vec<_>>()
-        .join(":");
-    env::set_var("PATH", path_env);
 
     // Resolve the binary full path
     let binary_path = match which::which(&binary) {

--- a/templates/shell_integration.bash.tmpl
+++ b/templates/shell_integration.bash.tmpl
@@ -1,8 +1,4 @@
-{% if SHIMS_ONLY -%}
-if [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
-	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
-fi
-{%- else -%}
+{% if not SHIMS_ONLY -%}
 # This function is used to run the omni command, and then operate on
 # the requested shell changes from the command (changing current
 # working directory, environment, etc.); this is why we require using
@@ -143,7 +139,7 @@ fi
 # Prepare omni's hook
 __omni_hook() {
 	local ppid=$$
-	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env "${@}")"
+	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env{% if KEEP_SHIMS %} --keep-shims{% endif %} "${@}")"
 }
 
 
@@ -159,11 +155,12 @@ __omni_hook() {
 	${PROMPT_COMMAND}"
 }
 
-
-# If we are not in an interactive shell, we will add the
-# shims directory to the PATH, so that the dynamic
-# environment can be used in non-interactive shells
-if [[ $- != *i* ]] && [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
-	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+{% endif -%}
+# Add the shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells.
+# This will automatically be removed from the PATH when the
+# dynamic environment is loaded, allowing to favor it over
+# the shims
+if [[ ":$PATH:" != *":{{ OMNI_SHIMS }}:"* ]]; then
+	export PATH="{{ OMNI_SHIMS }}:$PATH"
 fi
-{%- endif -%}

--- a/templates/shell_integration.fish.tmpl
+++ b/templates/shell_integration.fish.tmpl
@@ -1,10 +1,4 @@
-{% if SHIMS_ONLY -%}
-set -l omni_shims_path {{ OMNI_DATA_HOME }}/shims
-if not contains $omni_shims_path $PATH
-    set -l PATH $omni_shims_path $PATH
-    set -gx PATH $PATH
-end
-{%- else -%}
+{% if not SHIMS_ONLY -%}
 # This function is used to run the omni command, and then operate on
 # the requested shell changes from the command (changing current
 # working directory, environment, etc.); this is why we require using
@@ -104,20 +98,20 @@ complete -c {{alias.alias}} -a "(_omni_complete_fish)" -f
 
 # Setup the prompt hook to load the dynamic environment
 function __omni_hook --on-event fish_prompt --on-variable PWD
-    OMNI_SHELL=fish OMNI_SHELL_PPID=$fish_pid {{OMNI_BIN}} hook env fish \
+    OMNI_SHELL=fish OMNI_SHELL_PPID=$fish_pid {{OMNI_BIN}} hook env{% if KEEP_SHIMS %} --keep-shims{% endif %} fish \
         | while read line
             eval "$line" 2>/dev/null
         end
 end
 
-# If we are not in an interactive shell, we will add the
-# shims directory to the PATH, so that the dynamic
-# environment can be used in non-interactive shells
-if status is-interactive
-    set -l omni_shims_path {{ OMNI_DATA_HOME }}/shims
-    if not contains $omni_shims_path $PATH
-        set -l PATH $omni_shims_path $PATH
-        set -gx PATH $PATH
-    end
+{% endif -%}
+# Add the shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells.
+# This will automatically be removed from the PATH when the
+# dynamic environment is loaded, allowing to favor it over
+# the shims
+set -l omni_shims_path {{ OMNI_SHIMS }}
+if not contains $omni_shims_path $PATH
+    set -l PATH $omni_shims_path $PATH
+    set -gx PATH $PATH
 end
-{%- endif -%}

--- a/templates/shell_integration.zsh.tmpl
+++ b/templates/shell_integration.zsh.tmpl
@@ -1,8 +1,4 @@
-{% if SHIMS_ONLY -%}
-if [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
-	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
-fi
-{%- else -%}
+{% if not SHIMS_ONLY -%}
 # This function is used to run the omni command, and then operate on
 # the requested shell changes from the command (changing current
 # working directory, environment, etc.); this is why we require using
@@ -127,7 +123,7 @@ compdef _omni_complete_zsh {{ alias.alias }}
 # Prepare omni's hook
 __omni_hook() {
 	local ppid=$$
-	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env "${@}")"
+	eval "$(OMNI_SHELL_PPID="${ppid}" "{{ OMNI_BIN }}" hook env{% if KEEP_SHIMS %} --keep-shims{% endif %} "${@}")"
 }
 
 
@@ -137,11 +133,12 @@ if [[ ! ${precmd_functions[(r)__omni_hook_precmd]} ]]; then
 	precmd_functions+=("__omni_hook_precmd");
 fi
 
-
-# If we are not in an interactive shell, we will add the
-# shims directory to the PATH, so that the dynamic
-# environment can be used in non-interactive shells
-if [[ $- != *i* ]] && [[ ":$PATH:" != *":{{ OMNI_DATA_HOME }}/shims:"* ]]; then
-	export PATH="{{ OMNI_DATA_HOME }}/shims:$PATH"
+{% endif -%}
+# Add the shims directory to the PATH, so that the dynamic
+# environment can be used in non-interactive shells.
+# This will automatically be removed from the PATH when the
+# dynamic environment is loaded, allowing to favor it over
+# the shims
+if [[ ":$PATH:" != *":{{ OMNI_SHIMS }}:"* ]]; then
+	export PATH="{{ OMNI_SHIMS }}:$PATH"
 fi
-{%- endif -%}


### PR DESCRIPTION
This allows to make things work for any non-interactive shell, which would not load the dynamic environment, and still have the shims loaded.