### PR TITLE
fix: 🐛 `env` config parameter of type `path` now resolves properly

### DIFF
--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::path::PathBuf;
 
 use itertools::Itertools;
 use serde::Deserialize;
@@ -156,11 +157,18 @@ impl EnvOperationConfig {
                 // to determine the current scope.
                 if value_type == "path" {
                     match config_value.get_source() {
-                        ConfigSource::File(path) => Some(
-                            abs_path_from_path(&value, Some(path))
+                        ConfigSource::File(path) => {
+                            let parent_path = PathBuf::from(path)
+                                .parent()
+                                .expect("config file path has no parent")
                                 .to_string_lossy()
-                                .to_string(),
-                        ),
+                                .to_string();
+                            Some(
+                                abs_path_from_path(&value, Some(&parent_path))
+                                    .to_string_lossy()
+                                    .to_string(),
+                            )
+                        }
                         // Unsupported source type for the "path" value type
                         _ => Some(value.to_string()),
                     }


### PR DESCRIPTION
The `env` parameters of type `path` were keeping the configuration file in the resolves relative path, which was obviously not working and there were no directory of the name of the config file.

This is fixed by resolving the parent of the config file path, which is thus the directory in which the config file is, and applying the relative path resolution from there.

Fixes https://github.com/XaF/omni/issues/564