### PR TITLE
feat(repo_path_format): ✨ can be configured per organization

### DIFF
--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -21,7 +21,7 @@ use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::omni_cmd_file;
 use crate::internal::env::shell_is_interactive;
-use crate::internal::git::format_path;
+use crate::internal::git::format_path_with_template;
 use crate::internal::git::package_path_from_git_url;
 use crate::internal::git::safe_git_url_parse;
 use crate::internal::git::ORG_LOADER;
@@ -207,7 +207,8 @@ impl CloneCommand {
                 {
                     let config = config(".");
                     let worktree = config.worktree();
-                    let clone_path = format_path(&worktree, &clone_url);
+                    let clone_path =
+                        format_path_with_template(&worktree, &clone_url, &config.repo_path_format);
                     let clone_path = if clone_as_package {
                         if let Some(clone_path) = package_path_from_git_url(&clone_url) {
                             clone_path

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -584,8 +584,7 @@ fn question_repo_path_format(worktree: String) -> (String, bool) {
 
         if !found {
             let git_url = full_git_url_parse("https://github.com/xaf/omni").unwrap();
-            let example =
-                format_path_with_template(&worktree, &git_url, current_repo_path_format.clone());
+            let example = format_path_with_template(&worktree, &git_url, &current_repo_path_format);
             let example_str = example.to_string_lossy().to_string();
 
             choices.insert(
@@ -942,6 +941,7 @@ fn question_org(worktree: &str) -> (Vec<OrgConfig>, bool) {
                 handle: org.clone(),
                 trusted,
                 worktree: worktree.cloned(),
+                repo_path_format: None,
             }
         })
         .collect();

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -21,7 +21,7 @@ use crate::internal::config::CommandSyntax;
 use crate::internal::config::ConfigSource;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::shell_is_interactive;
-use crate::internal::git::format_path;
+use crate::internal::git::format_path_with_template;
 use crate::internal::git::package_path_from_handle;
 use crate::internal::git::package_root_path;
 use crate::internal::git::path_entry_config;
@@ -712,7 +712,11 @@ impl TidyGitRepo {
                     {
                         let config = config(".");
                         let worktree = config.worktree();
-                        let repo_path = format_path(&worktree, &repo_url);
+                        let repo_path = format_path_with_template(
+                            &worktree,
+                            &repo_url,
+                            &config.repo_path_format,
+                        );
                         expected_path = Some(repo_path);
                     }
                 }

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -38,7 +38,7 @@ use crate::internal::config::ConfigLoader;
 use crate::internal::config::ConfigValue;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::env::shell_is_interactive;
-use crate::internal::git::format_path;
+use crate::internal::git::format_path_with_template;
 use crate::internal::git::package_path_from_git_url;
 use crate::internal::git::path_entry_config;
 use crate::internal::git::safe_git_url_parse;
@@ -767,7 +767,11 @@ impl UpCommand {
                         repo = Some(RepositoryToClone {
                             suggested_by: vec![repo_id.clone()],
                             clone_url: clone_url.clone(),
-                            clone_path: format_path(&worktree, &clone_url),
+                            clone_path: format_path_with_template(
+                                &worktree,
+                                &clone_url,
+                                &config.repo_path_format,
+                            ),
                             package_path: package_path_from_git_url(&clone_url),
                             clone_args: repo_config.args.clone(),
                             clone_as_package: repo_config.clone_as_package(),

--- a/src/internal/config/parser/org.rs
+++ b/src/internal/config/parser/org.rs
@@ -9,6 +9,8 @@ pub struct OrgConfig {
     pub trusted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worktree: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_path_format: Option<String>,
 }
 
 impl Default for OrgConfig {
@@ -17,6 +19,7 @@ impl Default for OrgConfig {
             handle: "".to_string(),
             trusted: false,
             worktree: None,
+            repo_path_format: None,
         }
     }
 }
@@ -30,6 +33,7 @@ impl OrgConfig {
             handle,
             trusted: true,
             worktree,
+            repo_path_format: None,
         }
     }
 
@@ -45,6 +49,7 @@ impl OrgConfig {
             handle: config_value.get_as_str("handle").unwrap().to_string(),
             trusted: config_value.get_as_bool("trusted").unwrap_or(false),
             worktree: config_value.get_as_str("worktree"),
+            repo_path_format: config_value.get_as_str("repo_path_format"),
         }
     }
 }

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -4,7 +4,6 @@ pub(crate) use org::Repo;
 pub(crate) use org::ORG_LOADER;
 
 mod utils;
-pub(crate) use utils::format_path;
 pub(crate) use utils::format_path_with_template;
 pub(crate) use utils::full_git_url_parse;
 pub(crate) use utils::id_from_git_url;

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -10,7 +10,6 @@ use tokio::time::timeout;
 use url::ParseError;
 use url::Url;
 
-use crate::internal::config;
 use crate::internal::config::parser::PathEntryConfig;
 use crate::internal::env::data_home;
 use crate::internal::git_env;
@@ -86,21 +85,7 @@ pub fn full_git_url_parse(url: &str) -> Result<GitUrl, <GitUrl as FromStr>::Err>
     Ok(git_url)
 }
 
-pub fn format_path(worktree: &str, git_url: &GitUrl) -> PathBuf {
-    // Get the configured path format
-    let path_format = config(".").repo_path_format.clone();
-
-    format_path_with_template(worktree, git_url, path_format)
-}
-
-pub fn format_path_with_data(worktree: &str, host: &str, owner: &str, repo: &str) -> PathBuf {
-    // Get the configured path format
-    let path_format = config(".").repo_path_format.clone();
-
-    format_path_with_template_and_data(worktree, host, owner, repo, path_format)
-}
-
-pub fn format_path_with_template(worktree: &str, git_url: &GitUrl, path_format: String) -> PathBuf {
+pub fn format_path_with_template(worktree: &str, git_url: &GitUrl, path_format: &str) -> PathBuf {
     let git_url = git_url.clone();
     format_path_with_template_and_data(
         worktree,
@@ -116,12 +101,13 @@ pub fn format_path_with_template_and_data(
     host: &str,
     owner: &str,
     repo: &str,
-    path_format: String,
+    path_format: &str,
 ) -> PathBuf {
     // Create a path object
     let mut path = PathBuf::from(worktree.to_string());
 
     // Replace %{host}, #{owner}, and %{repo} with the actual values
+    let path_format = path_format.to_string();
     let path_format = path_format.replace("%{host}", host);
     let path_format = path_format.replace("%{org}", owner);
     let path_format = path_format.replace("%{repo}", repo);
@@ -158,7 +144,7 @@ pub fn package_path_from_git_url(git_url: &GitUrl) -> Option<PathBuf> {
     let package_path = format_path_with_template(
         package_root_path().as_str(),
         git_url,
-        PACKAGE_PATH_FORMAT.to_string(),
+        &PACKAGE_PATH_FORMAT.to_string(),
     );
 
     Some(package_path)

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -141,11 +141,8 @@ pub fn package_path_from_git_url(git_url: &GitUrl) -> Option<PathBuf> {
         return None;
     }
 
-    let package_path = format_path_with_template(
-        package_root_path().as_str(),
-        git_url,
-        &PACKAGE_PATH_FORMAT.to_string(),
-    );
+    let package_path =
+        format_path_with_template(package_root_path().as_str(), git_url, &PACKAGE_PATH_FORMAT);
 
     Some(package_path)
 }

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -142,7 +142,7 @@ pub fn package_path_from_git_url(git_url: &GitUrl) -> Option<PathBuf> {
     }
 
     let package_path =
-        format_path_with_template(package_root_path().as_str(), git_url, &PACKAGE_PATH_FORMAT);
+        format_path_with_template(package_root_path().as_str(), git_url, PACKAGE_PATH_FORMAT);
 
     Some(package_path)
 }

--- a/website/contents/reference/01-configuration/0102-parameters/010250-org.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-org.md
@@ -13,7 +13,8 @@ This is expected to be a list of objects containing the following parameters:
 |------------|--------|-----------------------------------------------------------|
 | `handle` | string | the organization handle, e.g. `git@github.com:XaF`, `github.com/XaF` |
 | `trusted` | boolean | whether or not the organization is to be trusted automatically for `omni up` *(default: true)* |
-| `worktree` | dirpath | the path to the worktree for that organization, if different from the default one *(default: null)* |
+| `worktree` | dirpath | override the path to the worktree for that organization, see [`worktree`](parameters/worktree) *(default: null)* |
+| `repo_path_format` | string | override the format string for the path to the repository, see [`repo_path_format`](parameters/repo_path_format) *(default: null)* |
 
 ## Example
 
@@ -22,6 +23,7 @@ org:
   - handle: git@github.com:XaF
     trusted: true
     worktree: /home/xaf/my-stuff
+    repo_path_format: "%{repo}"
   - handle: github.com/omnicli
     trusted: true
 ```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-org.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-org.md
@@ -13,8 +13,8 @@ This is expected to be a list of objects containing the following parameters:
 |------------|--------|-----------------------------------------------------------|
 | `handle` | string | the organization handle, e.g. `git@github.com:XaF`, `github.com/XaF` |
 | `trusted` | boolean | whether or not the organization is to be trusted automatically for `omni up` *(default: true)* |
-| `worktree` | dirpath | override the path to the worktree for that organization, see [`worktree`](parameters/worktree) *(default: null)* |
-| `repo_path_format` | string | override the format string for the path to the repository, see [`repo_path_format`](parameters/repo_path_format) *(default: null)* |
+| `worktree` | dirpath | override the path to the worktree for that organization, see [`worktree`](worktree) *(default: null)* |
+| `repo_path_format` | string | override the format string for the path to the repository, see [`repo_path_format`](repo_path_format) *(default: null)* |
 
 ## Example
 


### PR DESCRIPTION
`repo_path_format` is used to define the format of the path to repositories inside a worktree. Until now, this was only available as a global configuration option, while it was possible to define a different worktree per organization.

This fixes that by adding a `repo_path_format` in the per-org configuration, which will apply to the specific organization only.

Closes https://github.com/XaF/omni/issues/561