### PR TITLE
feat(askpass): add `enable_gui` configuration

### DIFF
--- a/src/internal/config/parser/askpass.rs
+++ b/src/internal/config/parser/askpass.rs
@@ -7,6 +7,7 @@ use crate::internal::config::ConfigValue;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AskPassConfig {
     pub enabled: bool,
+    pub enable_gui: bool,
     pub prefer_gui: bool,
 }
 
@@ -14,6 +15,7 @@ impl Default for AskPassConfig {
     fn default() -> Self {
         Self {
             enabled: Self::DEFAULT_ENABLED,
+            enable_gui: Self::DEFAULT_ENABLE_GUI,
             prefer_gui: Self::DEFAULT_PREFER_GUI,
         }
     }
@@ -21,6 +23,7 @@ impl Default for AskPassConfig {
 
 impl AskPassConfig {
     const DEFAULT_ENABLED: bool = true;
+    const DEFAULT_ENABLE_GUI: bool = true;
     const DEFAULT_PREFER_GUI: bool = false;
 
     pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
@@ -38,6 +41,9 @@ impl AskPassConfig {
             enabled: config_value
                 .get_as_bool("enabled")
                 .unwrap_or(Self::DEFAULT_ENABLED),
+            enable_gui: config_value
+                .get_as_bool("enable_gui")
+                .unwrap_or(Self::DEFAULT_ENABLE_GUI),
             prefer_gui: config_value
                 .get_as_bool("prefer_gui")
                 .unwrap_or(Self::DEFAULT_PREFER_GUI),

--- a/src/internal/config/up/utils/askpass.rs
+++ b/src/internal/config/up/utils/askpass.rs
@@ -207,7 +207,11 @@ impl AskPassListener {
         );
         context.insert("SOCKET_PATH", socket_path.to_string_lossy().as_ref());
         context.insert("INTERACTIVE", &shell_is_interactive());
-        context.insert("PREFER_GUI", &config.askpass.prefer_gui);
+        context.insert(
+            "PREFER_GUI",
+            &(config.askpass.prefer_gui && config.askpass.enable_gui),
+        );
+        context.insert("ENABLE_GUI", &config.askpass.enable_gui);
         context.insert("COMMAND", command);
 
         // Render the script for all the required askpass tools

--- a/templates/askpass.sh.tmpl
+++ b/templates/askpass.sh.tmpl
@@ -4,7 +4,11 @@
 # of password requests during omni operations. It is not meant to be
 # run directly by the user.
 
-{% if not INTERACTIVE or PREFER_GUI -%}
+{% if not INTERACTIVE and not ENABLE_GUI -%}
+exit 1
+{%- endif %}
+
+{% if ENABLE_GUI and (not INTERACTIVE or PREFER_GUI) -%}
 get_password_gui() {
     if [[ -z "$OMNI_SUBCOMMAND" ]]; then
 	echo "This was not called from omni" >&2
@@ -96,11 +100,13 @@ get_password_cli() {
 }
 {%- endif %}
 
-{% if INTERACTIVE -%}
-{%   if PREFER_GUI -%}
-get_password_gui
-{%   endif -%}
-get_password_cli
+{% if INTERACTIVE and PREFER_GUI -%}
+{%   set functions = ["get_password_gui", "get_password_cli"] -%}
+{% elif INTERACTIVE and not PREFER_GUI -%}
+{%   set functions = ["get_password_cli", "get_password_gui"] -%}
 {% else -%}
-get_password_gui
-{%- endif -%}
+{%   set functions = ["get_password_gui"] -%}
+{% endif -%}
+{% for function in functions -%}
+{{ function }}
+{% endfor %}

--- a/website/contents/reference/01-configuration/0102-parameters/010250-askpass.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-askpass.md
@@ -13,6 +13,7 @@ At this time, only `SSH_ASKPASS` and `SUDO_ASKPASS` are supported.
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
 | `enabled` | boolean | whether or not omni should try handling askpass environment variables if unset *(default: true)* |
+| `enable_gui` | boolean | whether or not omni should enable using a gui tooling to ask for password if available *(default: true)* |
 | `prefer_gui` | boolean | whether or not a gui tooling to ask for password should be preferred if available (only supported on MacOS for now) *(default: false)* |
 
 ## Example
@@ -20,5 +21,6 @@ At this time, only `SSH_ASKPASS` and `SUDO_ASKPASS` are supported.
 ```yaml
 askpass:
   enabled: true
-  prefer_gui: true
+  enable_gui: true
+  prefer_gui: false
 ```


### PR DESCRIPTION
This allows to disable the GUI by setting the configuration to `false`. In which case, if the shell is not interactive when a password is requested, the askpass command will simply fail, leading to the calling command failure.

Closes https://github.com/XaF/omni/issues/581