### PR TITLE
feat: Add `--local` global flag

### DIFF
--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -99,7 +99,7 @@ impl PathCommand {
                     }
                 }
 
-                return None;
+                None
             })
             .collect::<Vec<String>>();
 

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -5,6 +5,7 @@ use std::io::BufRead;
 use std::io::BufReader;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 
 use once_cell::sync::OnceCell;
@@ -13,9 +14,15 @@ use serde::Serialize;
 use walkdir::WalkDir;
 
 use crate::internal::commands::path::omnipath;
+use crate::internal::config;
+use crate::internal::config::config_loader;
 use crate::internal::config::utils::is_executable;
 use crate::internal::config::CommandSyntax;
+use crate::internal::config::ConfigExtendOptions;
+use crate::internal::config::OmniConfig;
 use crate::internal::config::SyntaxOptArg;
+use crate::internal::git::package_path_from_handle;
+use crate::internal::workdir;
 
 #[derive(Debug, Clone)]
 pub struct PathCommand {
@@ -27,10 +34,83 @@ pub struct PathCommand {
 
 impl PathCommand {
     pub fn all() -> Vec<Self> {
+        Self::aggregate_commands_from_path(&omnipath())
+    }
+
+    pub fn local() -> Vec<Self> {
+        // Check if we are in a work directory
+        let workdir = workdir(".");
+        let (wd_id, wd_root) = match (workdir.id(), workdir.root()) {
+            (Some(id), Some(root)) => (id, root),
+            _ => return vec![],
+        };
+
+        // Since we're prioritizing local, we want to make sure we consider
+        // the local suggestions for the configuration; this means we will
+        // handle suggested configuration even if not applied globally before
+        // going over the omnipath.
+        let cfg = config(".");
+        let suggest_config_value = cfg.suggest_config.config();
+        let local_config = if suggest_config_value.is_null() {
+            cfg
+        } else {
+            let mut local_config = config_loader(".").raw_config.clone();
+            local_config.extend(
+                suggest_config_value.clone(),
+                ConfigExtendOptions::new(),
+                vec![],
+            );
+            OmniConfig::from_config_value(&local_config)
+        };
+
+        // Get the package and worktree paths for the current repo
+        // TODO: make it work from a package path to include existing
+        //       paths from the worktree too
+        let worktree_path = Some(PathBuf::from(wd_root));
+        let package_path = package_path_from_handle(&wd_id);
+        let expected_path = PathBuf::from(wd_root);
+
+        // Now we can extract the different values that would be applied to
+        // the path that are actually matching the current work directory;
+        // note we will consider both path that are matching the current work
+        // directory but also convert any path that would match the package
+        // path for the same work directory.
+        let local_paths = local_config
+            .path
+            .prepend
+            .iter()
+            .chain(local_config.path.append.iter())
+            .filter_map(|path_entry| {
+                if !path_entry.is_valid() {
+                    return None;
+                }
+
+                let pathbuf = PathBuf::from(&path_entry.full_path);
+
+                if let Some(worktree_path) = &worktree_path {
+                    if let Ok(suffix) = pathbuf.strip_prefix(worktree_path) {
+                        return Some(expected_path.join(suffix).to_string_lossy().to_string());
+                    }
+                }
+
+                if let Some(package_path) = &package_path {
+                    if let Ok(suffix) = pathbuf.strip_prefix(package_path) {
+                        return Some(expected_path.join(suffix).to_string_lossy().to_string());
+                    }
+                }
+
+                return None;
+            })
+            .collect::<Vec<String>>();
+
+        Self::aggregate_commands_from_path(&local_paths)
+    }
+
+    fn aggregate_commands_from_path(paths: &Vec<String>) -> Vec<Self> {
         let mut all_commands: Vec<PathCommand> = Vec::new();
         let mut known_sources: HashMap<String, usize> = HashMap::new();
 
-        for path in &omnipath() {
+        for path in paths {
             // Aggregate all the files first, since WalkDir does not sort the list
             let mut files_to_process = Vec::new();
             for entry in WalkDir::new(path).follow_links(true).into_iter().flatten() {

--- a/src/internal/config/parser/path.rs
+++ b/src/internal/config/parser/path.rs
@@ -157,6 +157,14 @@ impl PathEntryConfig {
         PathBuf::from(&self.full_path).starts_with(&path_entry.full_path)
     }
 
+    pub fn starts_with_path(&self, path: PathBuf) -> bool {
+        if !self.is_valid() {
+            return false;
+        }
+
+        PathBuf::from(&self.full_path).starts_with(&path)
+    }
+
     pub fn includes_path(&self, path: PathBuf) -> bool {
         if !self.is_valid() {
             return false;

--- a/src/internal/config/parser/path.rs
+++ b/src/internal/config/parser/path.rs
@@ -162,7 +162,7 @@ impl PathEntryConfig {
             return false;
         }
 
-        PathBuf::from(&self.full_path).starts_with(&path)
+        PathBuf::from(&self.full_path).starts_with(path)
     }
 
     pub fn includes_path(&self, path: PathBuf) -> bool {

--- a/website/contents/reference/01-configuration/0103-environment.md
+++ b/website/contents/reference/01-configuration/0103-environment.md
@@ -4,6 +4,8 @@ description: Environment variables that can be used with omni
 
 # Environment variables
 
+## Writeable
+
 Omni supports a number of environment variables for its configuration. Setting those will generally override equivalent configuration options or precede them.
 
 | Variable                | Type | Description                                                            |
@@ -16,3 +18,8 @@ Omni supports a number of environment variables for its configuration. Setting t
 | `OMNI_ORG` | comma-delimited list of strings | Prepend organizations to be considered by omni. e.g.: `OMNI_ORG="git@github.com:XaF,github.com/XaF"`. See [parameters/org](parameters/org#environment) for more details. |
 | `OMNI_SKIP_SELF_UPDATE` | `string` | Disables self updates when set to anything but an empty string, even if it should have triggered. It is recommended to either set to `1` or empty/unset. |
 | `OMNI_SKIP_UPDATE` | `string` | Disables omnipath and self updates when set to anything but an empty string, even if it should have triggered. It is recommended to either set to `1` or empty/unset. |
+
+## Read-only
+
+| Variable                | Type | Description                                                            |
+| `OMNI_LOCAL_LOOKUP` | `boolean` | When using `omni --local` to prioritize local commands lookup over global ones, this variable will be set to `true`. It is not used by omni in any way, but can be used by scripts to determine if omni is running in local mode. |


### PR DESCRIPTION
This new flag makes the current omni process lookup for commands in the current directory first. It also follows any `suggest_config` that exists in the repository configuration, even if those suggestions have not been applied to the user configuration.

Note that this flag does not get inherited when `omni` is then called from a command called through `omni --local`. The absence of propagation is done on purpose so that `omni --local` is _required_ for prioritizing local commands over global ones. We do however set a `OMNI_LOCAL_LOOKUP` environment variable that can be consumed by subcommands if needed, but that is ignored by `omni` itself.

Closes https://github.com/XaF/omni/issues/577