### PR TITLE
feat(homebrew): ✨ update taps using git

### DIFF
--- a/src/internal/config/parser/cache/homebrew.rs
+++ b/src/internal/config/parser/cache/homebrew.rs
@@ -7,6 +7,7 @@ use crate::internal::config::ConfigValue;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HomebrewCacheConfig {
     pub update_expire: u64,
+    pub tap_update_expire: u64,
     pub install_update_expire: u64,
     pub install_check_expire: u64,
     pub cleanup_after: u64,
@@ -16,6 +17,7 @@ impl Default for HomebrewCacheConfig {
     fn default() -> Self {
         Self {
             update_expire: Self::DEFAULT_UPDATE_EXPIRE,
+            tap_update_expire: Self::DEFAULT_TAP_UPDATE_EXPIRE,
             install_update_expire: Self::DEFAULT_INSTALL_UPDATE_EXPIRE,
             install_check_expire: Self::DEFAULT_INSTALL_CHECK_EXPIRE,
             cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
@@ -25,6 +27,7 @@ impl Default for HomebrewCacheConfig {
 
 impl HomebrewCacheConfig {
     const DEFAULT_UPDATE_EXPIRE: u64 = 86400; // 1 day
+    const DEFAULT_TAP_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_INSTALL_UPDATE_EXPIRE: u64 = 86400; // 1 day
     const DEFAULT_INSTALL_CHECK_EXPIRE: u64 = 43200; // 12 hours
     const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
@@ -38,6 +41,11 @@ impl HomebrewCacheConfig {
         let update_expire = parse_duration_or_default(
             config_value.get("update_expire").as_ref(),
             Self::DEFAULT_UPDATE_EXPIRE,
+        );
+
+        let tap_update_expire = parse_duration_or_default(
+            config_value.get("tap_update_expire").as_ref(),
+            Self::DEFAULT_TAP_UPDATE_EXPIRE,
         );
 
         let install_update_expire = parse_duration_or_default(
@@ -57,6 +65,7 @@ impl HomebrewCacheConfig {
 
         Self {
             update_expire,
+            tap_update_expire,
             install_update_expire,
             install_check_expire,
             cleanup_after,


### PR DESCRIPTION
Up until now, omni was depending on homebrew to update taps before calling `brew update` on a specific formula. This however does not work when homebrew defaults to disabling updating of all taps automatically, leading to versions never being updated in such case.

This changes this by using `git pull` in the repository where the tap is checked out before calling any `brew update`, which leads to making sure these are updated. Moreover, it adds environment variables to prevent calls to `brew update` to update _all_ the taps available.

Closes https://github.com/XaF/omni/issues/611