### PR TITLE
feat(up): ✨ synchronize 'omni up' operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,12 +1655,14 @@ dependencies = [
  "tera",
  "term_cursor",
  "term_size",
+ "thiserror",
  "time",
  "tokio",
  "url",
  "uuid",
  "walkdir",
  "which",
+ "whoami",
  "zip-extract",
 ]
 
@@ -3060,6 +3062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3154,17 @@ dependencies = [
  "home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,12 @@ tempfile = "3.12.0"
 tera = "1.20.0"
 term_cursor = "0.2.1"
 term_size = "0.3.2"
+thiserror = "1.0.63"
 time = { version = "0.3.36", features = ["serde-well-known"] }
 tokio = { version = "1.39.1", features = ["full"] }
 url = "2.5.2"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 walkdir = "2.4.0"
 which = "6.0.2"
+whoami = "1.5.2"
 zip-extract = "0.2.1"

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -479,4 +479,9 @@ impl Command {
 
         std::cmp::Ordering::Equal
     }
+
+    pub fn requires_sync_update(&self) -> bool {
+        // TODO: Implement this to delegate to the command types as needed
+        false
+    }
 }

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -481,7 +481,9 @@ impl Command {
     }
 
     pub fn requires_sync_update(&self) -> bool {
-        // TODO: Implement this to delegate to the command types as needed
-        false
+        match self {
+            Command::FromPath(command) => command.requires_sync_update(),
+            _ => false,
+        }
     }
 }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -963,9 +963,8 @@ impl UpConfigAsdfBase {
                         progress_handler,
                     )?;
 
-                    self.resolve_version(&versions).map_err(|err| {
+                    self.resolve_version(&versions).inspect_err(|err| {
                         progress_handler.error_with_message(err.message());
-                        err
                     })?
                 } else {
                     progress_handler.error_with_message(err.message());

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -181,9 +181,8 @@ impl UpConfigGithubReleases {
                 )
                 .light_yellow(),
             );
-            release.up(options, &subhandler).map_err(|err| {
+            release.up(options, &subhandler).inspect_err(|_err| {
                 progress_handler.error();
-                err
             })?;
         }
 
@@ -771,9 +770,8 @@ impl UpConfigGithubRelease {
                         progress_handler,
                     )?;
 
-                    self.resolve_release(&releases).map_err(|err| {
+                    self.resolve_release(&releases).inspect_err(|err| {
                         progress_handler.error_with_message(err.message());
-                        err
                     })?
                 } else {
                     progress_handler.error_with_message(err.message());

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -319,7 +319,7 @@ fn setup_individual_npm_prefix(
                     let mut npm_install = TokioCommand::new("npm");
                     npm_install.arg("install");
                     npm_install.arg("-g");
-                    npm_install.arg(&format!("{}@{}", engine, version_range));
+                    npm_install.arg(format!("{}@{}", engine, version_range));
                     npm_install.stdout(std::process::Stdio::piped());
                     npm_install.stderr(std::process::Stdio::piped());
 

--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -2,23 +2,26 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct UpOptions {
+pub struct UpOptions<'a> {
     pub read_cache: bool,
     pub write_cache: bool,
     pub fail_on_upgrade: bool,
+    #[serde(skip)]
+    pub lock_file: Option<&'a std::fs::File>,
 }
 
-impl Default for UpOptions {
+impl Default for UpOptions<'_> {
     fn default() -> Self {
         Self {
             read_cache: true,
             write_cache: true,
             fail_on_upgrade: false,
+            lock_file: None,
         }
     }
 }
 
-impl UpOptions {
+impl<'a> UpOptions<'a> {
     pub fn new() -> Self {
         Self::default()
     }
@@ -36,6 +39,11 @@ impl UpOptions {
 
     pub fn fail_on_upgrade(mut self, fail_on_upgrade: bool) -> Self {
         self.fail_on_upgrade = fail_on_upgrade;
+        self
+    }
+
+    pub fn lock_file(mut self, lock_file: &'a std::fs::File) -> Self {
+        self.lock_file = Some(lock_file);
         self
     }
 }

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -28,6 +28,8 @@ pub(crate) mod spinner_progress_handler;
 pub(crate) use spinner_progress_handler::SpinnerProgressHandler;
 
 pub(crate) mod up_progress_handler;
+pub(crate) use up_progress_handler::SyncUpdateListener;
+pub(crate) use up_progress_handler::SyncUpdateOperation;
 pub(crate) use up_progress_handler::UpProgressHandler;
 
 pub(crate) mod version;

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use spinner_progress_handler::SpinnerProgressHandler;
 
 pub(crate) mod up_progress_handler;
 pub(crate) use up_progress_handler::SyncUpdateInit;
+pub(crate) use up_progress_handler::SyncUpdateInitOption;
 pub(crate) use up_progress_handler::SyncUpdateListener;
 pub(crate) use up_progress_handler::SyncUpdateOperation;
 pub(crate) use up_progress_handler::UpProgressHandler;

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod spinner_progress_handler;
 pub(crate) use spinner_progress_handler::SpinnerProgressHandler;
 
 pub(crate) mod up_progress_handler;
+pub(crate) use up_progress_handler::SyncUpdateInit;
 pub(crate) use up_progress_handler::SyncUpdateListener;
 pub(crate) use up_progress_handler::SyncUpdateOperation;
 pub(crate) use up_progress_handler::UpProgressHandler;

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -1,32 +1,70 @@
+use std::collections::BTreeMap;
+use std::io::BufRead;
+use std::io::Write;
+use std::process::exit;
+
+use fs4::FileExt;
 use once_cell::sync::OnceCell;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::internal::config::up::utils::PrintProgressHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::env::shell_is_interactive;
+use crate::internal::user_interface::colors::StringColor;
+use crate::omni_error;
+use crate::omni_info;
+use crate::omni_warning;
 
 pub struct UpProgressHandler<'a> {
     handler: OnceCell<Box<dyn ProgressHandler>>,
+    handler_id: Option<String>,
     step: Option<(usize, usize)>,
     prefix: String,
     parent: Option<&'a UpProgressHandler<'a>>,
     allow_ending: bool,
+    sync_file: Option<&'a std::fs::File>,
+    desc: OnceCell<String>,
 }
 
 impl<'a> UpProgressHandler<'a> {
     pub fn new(progress: Option<(usize, usize)>) -> Self {
+        // Generate a random handler ID
+        let handler_id = uuid::Uuid::new_v4().to_string();
+
         UpProgressHandler {
             handler: OnceCell::new(),
+            handler_id: Some(handler_id),
             step: progress,
             prefix: "".to_string(),
             parent: None,
             allow_ending: true,
+            sync_file: None,
+            desc: OnceCell::new(),
         }
+    }
+
+    pub fn desc(&self) -> &str {
+        if let Some(parent) = self.parent {
+            return parent.desc();
+        }
+
+        self.desc
+            .get_or_init(|| {
+                let desc = "".to_string();
+                desc
+            })
+            .as_str()
     }
 
     pub fn init(&self, desc: String) -> bool {
         if self.handler.get().is_some() || self.parent.is_some() {
             return false;
+        }
+
+        if self.desc.set(desc.clone()).is_err() {
+            panic!("failed to set progress description");
         }
 
         #[cfg(not(test))]
@@ -64,13 +102,28 @@ impl<'a> UpProgressHandler<'a> {
             .as_ref()
     }
 
+    fn handler_id(&self) -> String {
+        if let Some(handler_id) = &self.handler_id {
+            return handler_id.clone();
+        }
+
+        if let Some(parent) = self.parent {
+            return parent.handler_id();
+        }
+
+        "".to_string()
+    }
+
     pub fn subhandler(&'a self, prefix: &dyn ToString) -> UpProgressHandler<'a> {
         UpProgressHandler {
             handler: OnceCell::new(),
+            handler_id: None,
             step: None,
             prefix: prefix.to_string(),
             parent: Some(self),
             allow_ending: false,
+            sync_file: None,
+            desc: OnceCell::new(),
         }
     }
 
@@ -79,6 +132,51 @@ impl<'a> UpProgressHandler<'a> {
             parent.step()
         } else {
             self.step
+        }
+    }
+
+    pub fn set_sync_file(&mut self, sync_file: &'a std::fs::File) {
+        self.sync_file = Some(sync_file);
+    }
+
+    fn update_sync_file(&self, action: SyncUpdateProgressAction) {
+        if let Some(mut sync_file) = self.sync_file {
+            // Overwrite the handler id and description with the current ones
+            let update = SyncUpdateOperation::Progress(SyncUpdateProgress {
+                handler_id: self.handler_id(),
+                desc: self.desc().to_string(),
+                step: self.step(),
+                action,
+            });
+
+            if let Err(err) = update.dump_to_file(&mut sync_file) {
+                panic!("failed to write progress update to file: {}", err);
+            }
+        } else if let Some(parent) = self.parent {
+            parent.update_sync_file(action);
+        }
+    }
+
+    pub fn perform_sync_action(&self, action: &SyncUpdateProgressAction) {
+        match action {
+            SyncUpdateProgressAction::Progress(message) => self.handler().progress(message.clone()),
+            SyncUpdateProgressAction::Success(message) => {
+                if let Some(message) = message {
+                    self.handler().success_with_message(message.clone());
+                } else {
+                    self.handler().success();
+                }
+            }
+            SyncUpdateProgressAction::Error(message) => {
+                if let Some(message) = message {
+                    self.handler().error_with_message(message.clone());
+                } else {
+                    self.handler().error();
+                }
+            }
+            SyncUpdateProgressAction::Hide => self.handler().hide(),
+            SyncUpdateProgressAction::Show => self.handler().show(),
+            SyncUpdateProgressAction::Println(message) => self.handler().println(message.clone()),
         }
     }
 
@@ -94,24 +192,29 @@ impl<'a> UpProgressHandler<'a> {
 impl ProgressHandler for UpProgressHandler<'_> {
     fn progress(&self, message: String) {
         let message = self.format_message(message);
+        self.update_sync_file(SyncUpdateProgressAction::Progress(message.clone()));
         self.handler().progress(message);
     }
 
     fn success(&self) {
+        self.update_sync_file(SyncUpdateProgressAction::Success(None));
         self.handler().success();
     }
 
     fn success_with_message(&self, message: String) {
         let message = self.format_message(message);
         if self.allow_ending {
+            self.update_sync_file(SyncUpdateProgressAction::Success(Some(message.clone())));
             self.handler().success_with_message(message);
         } else {
+            self.update_sync_file(SyncUpdateProgressAction::Progress(message.clone()));
             self.handler().progress(message);
         }
     }
 
     fn error(&self) {
         if self.allow_ending {
+            self.update_sync_file(SyncUpdateProgressAction::Error(None));
             self.handler().error();
         }
     }
@@ -119,22 +222,271 @@ impl ProgressHandler for UpProgressHandler<'_> {
     fn error_with_message(&self, message: String) {
         let message = self.format_message(message);
         if self.allow_ending {
+            self.update_sync_file(SyncUpdateProgressAction::Error(Some(message.clone())));
             self.handler().error_with_message(message);
         } else {
+            self.update_sync_file(SyncUpdateProgressAction::Progress(message.clone()));
             self.handler().progress(message);
         }
     }
 
     fn hide(&self) {
+        self.update_sync_file(SyncUpdateProgressAction::Hide);
         self.handler().hide();
     }
 
     fn show(&self) {
+        self.update_sync_file(SyncUpdateProgressAction::Show);
         self.handler().show();
     }
 
     fn println(&self, message: String) {
         let message = self.format_message(message);
+        self.update_sync_file(SyncUpdateProgressAction::Println(message.clone()));
         self.handler().println(message);
+    }
+}
+
+pub struct SyncUpdateListener<'a> {
+    current_handler: Option<UpProgressHandler<'a>>,
+    current_handler_id: Option<String>,
+}
+
+impl SyncUpdateListener<'_> {
+    pub fn new() -> Self {
+        Self {
+            current_handler: None,
+            current_handler_id: None,
+        }
+    }
+
+    pub fn follow(&mut self, file: &std::fs::File) -> Result<(), std::io::Error> {
+        let mut lines = std::io::BufReader::new(file).lines();
+
+        self.current_handler = None;
+        self.current_handler_id = None;
+
+        loop {
+            while let Some(line) = lines.next() {
+                if let Ok(line) = line {
+                    if let Err(err) = self.handle_line(&line) {
+                        omni_warning!(format!("failed to handle line: {}", err));
+                    }
+                }
+            }
+            if file.try_lock_exclusive().is_ok() {
+                file.unlock()?;
+                break Ok(());
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    }
+
+    fn handle_line(&mut self, line: &str) -> Result<(), String> {
+        // JSON deserialize the line into a SyncUpdateOperation object
+        // If the line is not valid JSON, return an error
+        let sync_update = match serde_json::from_str::<SyncUpdateOperation>(&line) {
+            Ok(sync_update) => sync_update,
+            Err(err) => return Err(format!("failed to parse JSON: {}", err)),
+        };
+
+        match sync_update {
+            SyncUpdateOperation::Exit(exit_code) => {
+                exit(exit_code);
+            }
+            SyncUpdateOperation::OmniError(error) => {
+                omni_error!(error);
+            }
+            SyncUpdateOperation::OmniWarning(warning) => {
+                omni_warning!(warning);
+            }
+            SyncUpdateOperation::OmniInfo(info) => {
+                omni_info!(info);
+            }
+            SyncUpdateOperation::Progress(progress) => {
+                let need_new_handler = match self.current_handler_id {
+                    Some(ref current_handler_id) => current_handler_id != progress.handler_id(),
+                    _ => true,
+                };
+
+                if need_new_handler {
+                    // Create a new handler for the new handler id
+                    let new_handler = UpProgressHandler::new(progress.step());
+                    new_handler.init(progress.desc().to_string());
+
+                    self.current_handler = Some(new_handler);
+                    self.current_handler_id = Some(progress.handler_id().to_string());
+                }
+
+                if let Some(ref mut handler) = self.current_handler {
+                    handler.perform_sync_action(progress.action());
+                } else {
+                    return Err("no handler found".to_string());
+                }
+            }
+        }
+
+        return Ok(());
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncUpdateOperation {
+    Exit(i32),
+    Progress(SyncUpdateProgress),
+    OmniError(String),
+    OmniWarning(String),
+    OmniInfo(String),
+}
+
+impl SyncUpdateOperation {
+    pub fn dump_to_file(&self, mut file: &std::fs::File) -> Result<(), std::io::Error> {
+        // Serialize the update to JSON in a single line
+        let update_json = serde_json::to_string(self)?;
+
+        // Add a line return at the end of the JSON
+        let update_json = format!("{}\n", update_json);
+
+        // Write the JSON to the file
+        file.write_all(update_json.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncUpdateProgress {
+    #[serde(skip_serializing_if = "str::is_empty")]
+    handler_id: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    desc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    step: Option<(usize, usize)>,
+    #[serde(flatten)]
+    action: SyncUpdateProgressAction,
+}
+
+impl SyncUpdateProgress {
+    pub fn handler_id(&self) -> &str {
+        &self.handler_id
+    }
+
+    pub fn desc(&self) -> &str {
+        &self.desc
+    }
+
+    pub fn step(&self) -> Option<(usize, usize)> {
+        self.step
+    }
+
+    pub fn action(&self) -> &SyncUpdateProgressAction {
+        &self.action
+    }
+}
+
+#[derive(Debug)]
+pub enum SyncUpdateProgressAction {
+    Progress(String),
+    Success(Option<String>),
+    Error(Option<String>),
+    Hide,
+    Show,
+    Println(String),
+}
+
+impl SyncUpdateProgressAction {
+    fn from_map(map: BTreeMap<String, String>) -> Option<SyncUpdateProgressAction> {
+        let action = match map.get("action") {
+            Some(action) => action,
+            None => return None,
+        };
+
+        match action.as_str() {
+            "progress" => {
+                if let Some(message) = map.get("message") {
+                    Some(SyncUpdateProgressAction::Progress(message.clone()))
+                } else {
+                    None
+                }
+            }
+            "success" => {
+                let message = map.get("message").cloned();
+                Some(SyncUpdateProgressAction::Success(message))
+            }
+            "error" => {
+                let message = map.get("message").cloned();
+                Some(SyncUpdateProgressAction::Error(message))
+            }
+            "hide" => Some(SyncUpdateProgressAction::Hide),
+            "show" => Some(SyncUpdateProgressAction::Show),
+            "println" => {
+                if let Some(message) = map.get("message") {
+                    Some(SyncUpdateProgressAction::Println(message.clone()))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn as_map(&self) -> BTreeMap<String, String> {
+        let mut as_map = BTreeMap::new();
+        match self {
+            SyncUpdateProgressAction::Progress(message) => {
+                as_map.insert("action".to_string(), "progress".to_string());
+                as_map.insert("message".to_string(), message.clone());
+            }
+            SyncUpdateProgressAction::Success(message) => {
+                as_map.insert("action".to_string(), "success".to_string());
+                if let Some(message) = message {
+                    as_map.insert("message".to_string(), message.clone());
+                }
+            }
+            SyncUpdateProgressAction::Error(message) => {
+                as_map.insert("action".to_string(), "error".to_string());
+                if let Some(message) = message {
+                    as_map.insert("message".to_string(), message.clone());
+                }
+            }
+            SyncUpdateProgressAction::Hide => {
+                as_map.insert("action".to_string(), "hide".to_string());
+            }
+            SyncUpdateProgressAction::Show => {
+                as_map.insert("action".to_string(), "show".to_string());
+            }
+            SyncUpdateProgressAction::Println(message) => {
+                as_map.insert("action".to_string(), "println".to_string());
+                as_map.insert("message".to_string(), message.clone());
+            }
+        }
+        as_map
+    }
+}
+
+impl Serialize for SyncUpdateProgressAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        self.as_map().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncUpdateProgressAction {
+    fn deserialize<D>(deserializer: D) -> Result<SyncUpdateProgressAction, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        // Deserialize the JSON value into a BTreeMap<String, String>
+        let map = BTreeMap::<String, String>::deserialize(deserializer)?;
+
+        // Convert the map into a SyncUpdateProgressAction using the from_map method
+        match SyncUpdateProgressAction::from_map(map) {
+            Some(action) => Ok(action),
+            None => Err(serde::de::Error::custom("invalid SyncUpdateProgressAction")),
+        }
     }
 }

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -319,7 +319,7 @@ impl SyncUpdateListener<'_> {
 
                 if let Some(ref expected_init) = self.expected_init {
                     if expected_init != &init {
-                        return Err(SyncUpdateError::MismatchedInit(init, expected_init.clone()));
+                        return Err(SyncUpdateError::MismatchedInit(Box::new(init), Box::new(expected_init.clone())));
                     }
                     self.missing_options = !expected_init.options_difference(&init).is_empty();
                 }

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -474,6 +474,7 @@ impl Display for SyncUpdateInit {
 /// enable to know if a command needs to go over the suggestions or if
 /// nothing is left to do after synchronizing with a running process.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
+#[serde(rename_all = "snake_case")]
 pub enum SyncUpdateInitOption {
     SuggestConfig,
     SuggestClone,

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -159,6 +159,11 @@ pub fn git_env_flush_cache<T: AsRef<str>>(path: T) {
     git_env.remove(&path);
 }
 
+pub fn git_env_fresh<T: AsRef<str>>(path: T) -> GitRepoEnv {
+    git_env_flush_cache(&path);
+    git_env(&path)
+}
+
 pub fn workdir<T: AsRef<str>>(path: T) -> WorkDirEnv {
     let path: &str = path.as_ref();
     let path = std::fs::canonicalize(path)
@@ -1030,7 +1035,7 @@ impl WorkDirEnv {
                             // If the init operation is mismatched, we need to wait for the lock to be released
                             omni_info!(format!(
                                 "waiting for running {} operation to finish",
-                                actual.light_yellow()
+                                actual.name().light_yellow()
                             ));
 
                             // Grab the lock in a blocking way

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SyncUpdateError {
+    #[error("error during file operation: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("actual init operation `{0}` is different from expected `{1}`")]
+    MismatchedInit(String, String),
+    #[error("already initialized, but read another init operation")]
+    AlreadyInit,
+    #[error("invalid format: {0}")]
+    InvalidFormat(#[from] serde_json::Error),
+    #[error("progress handler was not initialized")]
+    NoProgressHandler,
+}

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -8,6 +8,8 @@ pub enum SyncUpdateError {
     IO(#[from] std::io::Error),
     #[error("actual init operation `{0}` is different from expected `{1}`")]
     MismatchedInit(SyncUpdateInit, SyncUpdateInit),
+    #[error("the expected run has more options than the attached run")]
+    MissingInitOptions,
     #[error("already initialized, but read another init operation")]
     AlreadyInit,
     #[error("invalid format: {0}")]

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -1,11 +1,13 @@
 use thiserror::Error;
 
+use crate::internal::config::up::utils::SyncUpdateInit;
+
 #[derive(Error, Debug)]
 pub enum SyncUpdateError {
     #[error("error during file operation: {0}")]
     IO(#[from] std::io::Error),
     #[error("actual init operation `{0}` is different from expected `{1}`")]
-    MismatchedInit(String, String),
+    MismatchedInit(SyncUpdateInit, SyncUpdateInit),
     #[error("already initialized, but read another init operation")]
     AlreadyInit,
     #[error("invalid format: {0}")]

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -7,7 +7,7 @@ pub enum SyncUpdateError {
     #[error("error during file operation: {0}")]
     IO(#[from] std::io::Error),
     #[error("actual init operation `{0}` is different from expected `{1}`")]
-    MismatchedInit(SyncUpdateInit, SyncUpdateInit),
+    MismatchedInit(Box<SyncUpdateInit>, Box<SyncUpdateInit>),
     #[error("the expected run has more options than the attached run")]
     MissingInitOptions,
     #[error("already initialized, but read another init operation")]

--- a/src/internal/git/org.rs
+++ b/src/internal/git/org.rs
@@ -6,6 +6,7 @@ use git_url_parse::GitUrl;
 use git_url_parse::Scheme;
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
 use strsim::normalized_damerau_levenshtein;
@@ -656,13 +657,12 @@ impl OrgLoader {
         // if there's a match that they want to use
         let mut with_score = all_repos
             .iter_mut()
-            .map(|found| {
+            .update(|found| {
                 // TODO: set scores related to <host>/<org>/<repo>, <org>/<repo>, and <repo> formats too
                 let absscore =
                     normalized_damerau_levenshtein(repo, found.abspath.to_str().unwrap());
                 let relscore = normalized_damerau_levenshtein(repo, found.relpath.as_str());
                 found.score = absscore.max(relscore);
-                found
             })
             .filter(|found| found.score > config(".").cd.path_match_min_score)
             .collect::<Vec<_>>();

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -31,6 +31,7 @@ use crate::internal::env::shell_is_interactive;
 use crate::internal::git::full_git_url_parse;
 use crate::internal::git::path_entry_config;
 use crate::internal::git_env;
+use crate::internal::git_env_flush_cache;
 use crate::internal::self_update;
 use crate::internal::user_interface::ensure_newline;
 use crate::internal::user_interface::StringColor;
@@ -848,6 +849,10 @@ fn update_git_branch(
                 Ok(false)
             } else {
                 progress_handler.success_with_message("updated".light_green());
+                git_env_flush_cache(match repo_path {
+                    Some(repo_path) => repo_path,
+                    None => ".",
+                });
                 Ok(true)
             }
         }
@@ -1037,6 +1042,10 @@ fn update_git_tag(
     }
 
     progress_handler.success_with_message("updated".light_green());
+    git_env_flush_cache(match repo_path {
+        Some(repo_path) => repo_path,
+        None => ".",
+    });
 
     Ok(true)
 }

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -88,7 +88,7 @@ pub fn auto_update_async(called_command: &Command) {
     if called_command.requires_sync_update() && called_command.has_source() {
         let called_command_path_str = called_command.source();
         let called_command_path = Path::new(&called_command_path_str);
-        options.add_sync_path(&called_command_path);
+        options.add_sync_path(called_command_path);
     }
 
     update(&options);
@@ -849,10 +849,7 @@ fn update_git_branch(
                 Ok(false)
             } else {
                 progress_handler.success_with_message("updated".light_green());
-                git_env_flush_cache(match repo_path {
-                    Some(repo_path) => repo_path,
-                    None => ".",
-                });
+                git_env_flush_cache(repo_path.unwrap_or("."));
                 Ok(true)
             }
         }
@@ -1042,10 +1039,7 @@ fn update_git_tag(
     }
 
     progress_handler.success_with_message("updated".light_green());
-    git_env_flush_cache(match repo_path {
-        Some(repo_path) => repo_path,
-        None => ".",
-    });
+    git_env_flush_cache(repo_path.unwrap_or("."));
 
     Ok(true)
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use config::ConfigValue;
 
 pub(crate) mod env;
 pub(crate) use env::git_env;
+pub(crate) use env::git_env_flush_cache;
+pub(crate) use env::git_env_fresh;
 pub(crate) use env::workdir;
 pub(crate) use env::workdir_flush_cache;
 pub(crate) use env::workdir_or_init;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -14,6 +14,8 @@ pub(crate) use env::workdir;
 pub(crate) use env::workdir_flush_cache;
 pub(crate) use env::workdir_or_init;
 
+pub(crate) mod errors;
+
 pub(crate) mod git;
 pub(crate) use git::ORG_LOADER;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,11 +246,7 @@ fn run_omni_subcommand(parsed: &MainArgs) {
             });
         }
 
-        auto_update_async(if omni_cmd.has_source() {
-            Some(omni_cmd.source().into())
-        } else {
-            None
-        });
+        auto_update_async(omni_cmd);
 
         set_cleanup_handler();
         omni_cmd.exec(argv, Some(called_as));

--- a/website/contents/reference/03-custom-commands/0302-path/030201-metadata-headers.md
+++ b/website/contents/reference/03-custom-commands/0302-path/030201-metadata-headers.md
@@ -62,6 +62,17 @@ This can be provided as follows:
 
 Which would instruct omni to forward autocompletion requests to the path command. See [autocompletion](autocompletion) for how to handle autocompletion in a path command.
 
+### `sync_update`
+
+The sync update header indicates that if the repository requires an update, it should be done synchronously before running the command. This is particularly useful if the command depends on some environment setup from the repository that could change often. Any other value than `true` is ignored and will be considered as `false`, as is done by default.
+
+This can be provided as follows:
+```bash
+# sync_update: true
+```
+
+Which would instruct omni to update the repository synchronously before running the command, if an update is required.
+
 ### `arg`
 
 The `arg` header allows to define arguments that the command takes. These are not being parsed by omni, but will be shown when running `omni help <command>`. When using the `arg` header, you need to define the argument name or format, and the description/help for that argument.


### PR DESCRIPTION
Until now, `omni up` could be run multiple times in parallel, this
also meant that if a repository is already being updated in the
background, it would be updated a second time synchronously by calling
`omni up`. This changes that by allowing any new `omni up` to attach
to a currently-running `omni up` operation.

This effectively allows to move all updates to be background-only
updates, as it is now possible for an up operation to run in the
background, but to be attached to the current process if necessary.

Closes https://github.com/XaF/omni/issues/686