### PR TITLE
feat(github release): ✨ configurable github auth token

### DIFF
--- a/src/internal/config/parser/github.rs
+++ b/src/internal/config/parser/github.rs
@@ -1,0 +1,280 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::cache::utils::Empty;
+use crate::internal::config::ConfigValue;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct GithubConfig {
+    #[serde(default, rename = "auth", skip_serializing_if = "Vec::is_empty")]
+    auth_list: Vec<GithubAuthConfigWithFilters>,
+}
+
+impl Empty for GithubConfig {
+    fn is_empty(&self) -> bool {
+        self.auth_list.is_empty()
+    }
+}
+
+impl GithubConfig {
+    pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        Self {
+            auth_list: GithubAuthConfigWithFilters::from_config_value_multi(
+                config_value.get("auth"),
+            ),
+        }
+    }
+
+    pub fn auth_for(&self, repo: &str, api_hostname: &str) -> GithubAuthConfig {
+        self.auth_list
+            .iter()
+            .find(|auth| auth.matches(repo, api_hostname))
+            .map(|auth| auth.auth.clone())
+            .unwrap_or(GithubAuthConfig::default())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct GithubAuthConfigWithFilters {
+    #[serde(
+        default,
+        with = "serde_yaml::with::singleton_map",
+        skip_serializing_if = "StringFilter::is_default"
+    )]
+    pub repo: StringFilter,
+    #[serde(
+        default,
+        with = "serde_yaml::with::singleton_map",
+        skip_serializing_if = "StringFilter::is_default"
+    )]
+    pub hostname: StringFilter,
+    #[serde(flatten)]
+    pub auth: GithubAuthConfig,
+}
+
+impl GithubAuthConfigWithFilters {
+    pub fn matches(&self, repo: &str, api_hostname: &str) -> bool {
+        self.repo.matches(repo) && self.hostname.matches(api_hostname)
+    }
+
+    pub(super) fn from_config_value_multi(config_value: Option<ConfigValue>) -> Vec<Self> {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return vec![],
+        };
+
+        if let Some(array) = config_value.as_array() {
+            array
+                .iter()
+                .map(|config_value| GithubAuthConfigWithFilters::from_config_value(config_value))
+                .collect()
+        } else {
+            vec![GithubAuthConfigWithFilters::from_config_value(
+                &config_value,
+            )]
+        }
+    }
+
+    fn from_config_value(config_value: &ConfigValue) -> Self {
+        Self {
+            repo: StringFilter::from_config_value(config_value.get("repo")),
+            hostname: StringFilter::from_config_value(config_value.get("hostname")),
+            auth: GithubAuthConfig::from_config_value(Some(config_value.clone())),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubAuthConfig {
+    Token(String),
+    TokenEnvVar(String),
+    #[serde(rename = "gh")]
+    GhCli {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hostname: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
+    },
+    Skip(bool),
+}
+
+impl Default for GithubAuthConfig {
+    fn default() -> Self {
+        GithubAuthConfig::GhCli {
+            hostname: None,
+            user: None,
+        }
+    }
+}
+
+impl GithubAuthConfig {
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    pub(in crate::internal::config) fn from_config_value(
+        config_value: Option<ConfigValue>,
+    ) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        if let Some(string) = config_value.as_str() {
+            return match string.as_str() {
+                "skip" => Self::Skip(true),
+                "gh" => Self::default(),
+                _ => {
+                    // If all caps and underscores, consider it's an environment variable
+                    if string.chars().all(|c| c.is_uppercase() || c == '_') {
+                        Self::TokenEnvVar(string.to_string())
+                    } else {
+                        Self::Token(string.to_string())
+                    }
+                }
+            };
+        } else if let Some(table) = config_value.as_table() {
+            if let Some(skip) = table.get("skip") {
+                if skip.as_bool().unwrap_or(false) {
+                    return Self::Skip(true);
+                }
+            }
+
+            if let Some(token_env_var) = table.get("token_env_var") {
+                if let Some(token_env_var) = token_env_var.as_str_forced() {
+                    return Self::TokenEnvVar(token_env_var.to_string());
+                }
+            }
+
+            if let Some(token) = table.get("token") {
+                if let Some(token) = token.as_str_forced() {
+                    return Self::Token(token.to_string());
+                }
+            }
+
+            if let Some(gh_value) = table.get("gh") {
+                let mut hostname = None;
+                let mut user = None;
+
+                if let Some(gh_table) = gh_value.as_table() {
+                    if let Some(hostname_value) = gh_table.get("hostname") {
+                        hostname = hostname_value.as_str_forced();
+                    }
+                    if let Some(user_value) = gh_table.get("user") {
+                        user = user_value.as_str_forced();
+                    }
+                } else if let Some(gh_string) = gh_value.as_str_forced() {
+                    hostname = Some(gh_string.to_string());
+                }
+
+                return Self::GhCli { hostname, user };
+            }
+        }
+
+        Self::default()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StringFilter {
+    Contains(String),
+    StartsWith(String),
+    EndsWith(String),
+    Regex(String),
+    Glob(String),
+    Exact(String),
+    #[default]
+    Any,
+}
+
+impl StringFilter {
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    pub fn matches(&self, value: &str) -> bool {
+        match self {
+            StringFilter::Any => true,
+            StringFilter::Contains(pattern) => {
+                value.to_lowercase().contains(&pattern.to_lowercase())
+            }
+            StringFilter::StartsWith(pattern) => {
+                value.to_lowercase().starts_with(&pattern.to_lowercase())
+            }
+            StringFilter::EndsWith(pattern) => {
+                value.to_lowercase().ends_with(&pattern.to_lowercase())
+            }
+            StringFilter::Regex(pattern) => match regex::Regex::new(pattern) {
+                Ok(regex) => regex.is_match(value),
+                Err(_) => false,
+            },
+            StringFilter::Glob(pattern) => match glob::Pattern::new(&pattern.to_lowercase()) {
+                Ok(glob) => glob.matches(&value.to_lowercase()),
+                Err(_) => false,
+            },
+            StringFilter::Exact(pattern) => value.to_lowercase() == pattern.to_lowercase(),
+        }
+    }
+
+    pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        if let Some(string) = config_value.as_str() {
+            // If a string is provided, use it as a glob pattern by default
+            StringFilter::Glob(string.to_string())
+        } else if let Some(table) = config_value.as_table() {
+            if let Some(entry) = table.get("contains") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::Contains(value)
+                } else {
+                    Self::default()
+                }
+            } else if let Some(entry) = table.get("starts_with") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::StartsWith(value)
+                } else {
+                    Self::default()
+                }
+            } else if let Some(entry) = table.get("ends_with") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::EndsWith(value)
+                } else {
+                    Self::default()
+                }
+            } else if let Some(entry) = table.get("regex") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::Regex(value)
+                } else {
+                    Self::default()
+                }
+            } else if let Some(entry) = table.get("glob") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::Glob(value)
+                } else {
+                    Self::default()
+                }
+            } else if let Some(entry) = table.get("exact") {
+                if let Some(value) = entry.as_str_forced() {
+                    StringFilter::Exact(value)
+                } else {
+                    Self::default()
+                }
+            } else {
+                Self::default()
+            }
+        } else {
+            Self::default()
+        }
+    }
+}

--- a/src/internal/config/parser/github.rs
+++ b/src/internal/config/parser/github.rs
@@ -72,7 +72,7 @@ impl GithubAuthConfigWithFilters {
         if let Some(array) = config_value.as_array() {
             array
                 .iter()
-                .map(|config_value| GithubAuthConfigWithFilters::from_config_value(config_value))
+                .map(GithubAuthConfigWithFilters::from_config_value)
                 .collect()
         } else {
             vec![GithubAuthConfigWithFilters::from_config_value(

--- a/src/internal/config/parser/mod.rs
+++ b/src/internal/config/parser/mod.rs
@@ -28,6 +28,10 @@ pub(crate) use env::EnvConfig;
 pub(crate) use env::EnvOperationConfig;
 pub(crate) use env::EnvOperationEnum;
 
+mod github;
+pub(crate) use github::GithubAuthConfig;
+pub(crate) use github::GithubConfig;
+
 mod makefile_commands;
 pub(crate) use makefile_commands::MakefileCommandsConfig;
 

--- a/src/internal/config/parser/omniconfig.rs
+++ b/src/internal/config/parser/omniconfig.rs
@@ -12,6 +12,7 @@ use crate::internal::config::parser::CloneConfig;
 use crate::internal::config::parser::CommandDefinition;
 use crate::internal::config::parser::ConfigCommandsConfig;
 use crate::internal::config::parser::EnvConfig;
+use crate::internal::config::parser::GithubConfig;
 use crate::internal::config::parser::MakefileCommandsConfig;
 use crate::internal::config::parser::MatchSkipPromptIfConfig;
 use crate::internal::config::parser::PathConfig;
@@ -60,6 +61,8 @@ pub struct OmniConfig {
     pub config_commands: ConfigCommandsConfig,
     #[serde(skip_serializing_if = "EnvConfig::is_empty")]
     pub env: EnvConfig,
+    #[serde(skip_serializing_if = "GithubConfig::is_empty")]
+    pub github: GithubConfig,
     pub makefile_commands: MakefileCommandsConfig,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub org: Vec<OrgConfig>,
@@ -127,6 +130,7 @@ impl OmniConfig {
                 config_value.get("config_commands"),
             ),
             env: EnvConfig::from_config_value(config_value.get("env")),
+            github: GithubConfig::from_config_value(config_value.get("github")),
             makefile_commands: MakefileCommandsConfig::from_config_value(
                 config_value.get("makefile_commands"),
             ),

--- a/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
+++ b/website/contents/reference/01-configuration/0102-parameters/0102-overview.md
@@ -20,6 +20,7 @@ Omni configuration files accept the following parameters:
 | `commands` | [commands](parameters/commands) (map) | Commands made available through omni |
 | `config_commands` | [config_commands](parameters/config_commands) | Configuration related to the commands defined in the config file |
 | `env` | [env](parameters/env) | Definition of the environment variables to be set when running omni commands |
+| `github` | [github](parameters/github) | Configuration related to the GitHub API |
 | `makefile_commands` | [makefile_commands](parameters/makefile_commands) | Configuration related to the commands generated from Makefile targets |
 | `org` | [org](parameters/org) (list) | Configuration for the default organizations |
 | `path_repo_updates` | [path_repo_updates](parameters/path_repo_updates) | Configuration for the automated updates of the repositories in omni path |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-github.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-github.md
@@ -1,0 +1,78 @@
+---
+description: Configuration of the `github` parameter
+---
+
+# `github`
+
+## Parameters
+
+Configuration related to the GitHub API.
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `auth` | list of [`Auth`](#auth-object) objects | How to handle authentication with the GitHub API; the first matching object is used, or the default authentication process is used (pulling an auth token from `gh` if available) |
+
+### `Auth` object
+
+This must contain one of the following parameters:
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `skip` | boolean | If `true`, this authentication object will be skipped |
+| `token` | string | The GitHub API token to use for authentication |
+| `token_env_var` | string | The environment variable containing the GitHub API token to use for authentication |
+| `gh` | [`Gh`](#gh-object) object | Configuration for using the `gh` CLI for authentication. Depends on the `gh` CLI being installed and logged in, but won't error if it isn't. |
+
+If specifying multiple of those for a single object, only the first matching one will be used, in the order they are listed above. If none is specified, the default authentication process is used (pulling an auth token from `gh` if available).
+
+If provided in a list, it can also contain any or all of the following parameters:
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `repo` | [`Filter`](#filter-object) object | A filter on the repository, if the filter does not match the repository, this authentication object will be skipped. If the filter is not specified, the authentication object will always match. The repository is defined as the `<owner>/<name>` format |
+| `hostname` | [`Filter`](#filter-object) object | A filter on the hostname of the GitHub API, if the filter does not match the hostname of the repository, this authentication object will be skipped. If the filter is not specified, the authentication object will always match. The hostname is defined as only the hostname part of the URL, e.g. `github.com` |
+
+### `Gh` object
+
+Can contain any or all of the following parameters:
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `hostname` | string | The hostname of the GitHub API to fetch the token for, if different from the repository's API URL |
+| `user` | string | The username of the `gh` logged-in session to fetch the token for, if different than the default one |
+
+The parameters that are not specified will simply be resolved automatically when using the `gh` command.
+
+### `Filter` object
+
+Can contain one of the following parameters:
+
+| Parameter        | Type      | Description                                           |
+|------------------|-----------|-------------------------------------------------------|
+| `contains` | string | A substring to match against the value of the filter |
+| `starts_with` | string | A prefix to match against the value of the filter |
+| `ends_with` | string | A suffix to match against the value of the filter |
+| `regex` | string | A regular expression to match against the value of the filter |
+| `glob` | string | A glob pattern to match against the value of the filter |
+| `exact` | string | An exact string to match against the value of the filter |
+
+If specifying multiple of those for a single object, only the first matching one will be used, in the order they are listed above.
+
+If not specifying any of those, the filter will always match.
+
+## Example
+
+```yaml
+github:
+  auth:
+    - repo:
+        starts_with: 'omnicli/some-'
+      token: gho_1234567890abcdef
+    - repo:
+        glob: 'omni*/no-auth-repo'
+      skip: true
+    - repo:
+        contains: 'secret-env'
+      token_env_var: GITHUB_TOKEN
+    - gh
+```

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
@@ -41,6 +41,7 @@ This supports authenticated requests using [the `gh` command line interface](htt
 | `skip_arch_matching` | boolean | Whether to skip the architecture matching when downloading assets. If set to `true`, this will download all assets regardless of the architecture *(default: `false`)* |
 | `api_url` | string | The URL of the GitHub API to use, useful to use GitHub Enterprise (e.g. `https://github.example.com/api/v3`); defaults to `https://api.github.com` |
 | `checksum` | object | The configuration to verify the checksum of the downloaded asset; see [checksum configuration](#checksum-configuration) below |
+| `auth` | [`Auth`](../github#auth-object) object | The configuration to authenticate the GitHub API requests for this release; if specified, will override the global configuration |
 
 ### Checksum configuration
 


### PR DESCRIPTION
The auth token was previously only pulled from the `gh` tool, by calls to `gh auth token` which weren't configurable.

This changes that by allowing to configure things at different levels. First, it can be configured in the user and/or system configuration by using the new `github:` configuration section:

```yaml
github:
  auth:
    token: <token value>
```

This can also be a list, with matching for the repository and/or the used API URL, e.g.:

```yaml
github:
  auth:
    - repo:
        glob: XaF/*
      skip: true  # Skip authentication
   - gh  # Use `gh` by default
```

Note that if going through the list, no match is found, it will default to use the `gh` command line. To skip all authentication by default, you can use `- skip` as the last value of the list for instance (without `repo` or `api_url` filter.

Second, it is possible to configure on a per-github-release basis, in the `up` configuration for a repository:

```yaml
up:
  - github-releases:
      XaF/omni:
        version: latest
        auth:
          token: xxx  # To use a token
      omnicli/xxx:
        auth: skip
```

This allows to apply this setting for that entry, which will take precedence over the global configuration.

Closes https://github.com/XaF/omni/issues/670
Closes https://github.com/XaF/omni/issues/512