### PR TITLE
feat(github release): ✨ suppport extended architectures with rosetta

### DIFF
--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
@@ -13,8 +13,12 @@ For this to work properly for a GitHub release, it will need to:
 
 Omni will download all the assets matching the current OS and architecture, verify checksums, extract them and move all the found binary files to a known location to be loaded in the repository environment.
 
+:::info
+If using a ARM Mac (M1, M2, etc.) with Rosetta installed, omni will try to download the `amd64` version of the asset if the `arm64` version is not available.
+:::
+
 :::note
-This supports authenticated requests using [the `gh` command line interface](https://cli.github.com/) if it is installed and authenticated, which allows for a higher rate limit and access to private repositories, as well as GitHub Enterprise instances.
+This supports authenticated requests using [the `gh` command line interface](https://cli.github.com/) if it is installed and authenticated, which allows for a higher rate limit and access to private repositories, as well as GitHub Enterprise instances. See the `auth` parameter to override the default behavior.
 :::
 
 ## Alternative names


### PR DESCRIPTION
If using an ARM Mac with Rosetta installed, omni will now default to download GitHub releases that are compatible with x86_64 if it fails to find an ARM release. This will ensure extended compatibility for systems that support those.

Closes https://github.com/XaF/omni/issues/647