### PR TITLE
feat(up)!: add `--upgrade` parameter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             suffix: arm64-darwin
-            run_tests: false
+            run_tests: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             suffix: x86_64-linux
@@ -65,7 +65,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             suffix: x86_64-darwin
-            run_tests: true
+            run_tests: false
 
     uses: ./.github/workflows/build-and-test-target.yaml
     with:

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -57,10 +57,8 @@ where
 
     let absolute_path = if path.is_absolute() {
         path.to_path_buf()
-    } else if path.starts_with("~") {
-        let home_dir = std::env::var("HOME").expect("Failed to determine user's home directory");
-        let path = path.strip_prefix("~").expect("Failed to strip prefix");
-        PathBuf::from(home_dir).join(path)
+    } else if let Ok(path) = path.strip_prefix("~") {
+        PathBuf::from(user_home()).join(path)
     } else {
         match frompath {
             Some(frompath) => frompath.as_ref().join(path),

--- a/src/internal/config/parser/askpass.rs
+++ b/src/internal/config/parser/askpass.rs
@@ -39,13 +39,13 @@ impl AskPassConfig {
 
         Self {
             enabled: config_value
-                .get_as_bool("enabled")
+                .get_as_bool_forced("enabled")
                 .unwrap_or(Self::DEFAULT_ENABLED),
             enable_gui: config_value
-                .get_as_bool("enable_gui")
+                .get_as_bool_forced("enable_gui")
                 .unwrap_or(Self::DEFAULT_ENABLE_GUI),
             prefer_gui: config_value
-                .get_as_bool("prefer_gui")
+                .get_as_bool_forced("prefer_gui")
                 .unwrap_or(Self::DEFAULT_PREFER_GUI),
         }
     }

--- a/src/internal/config/parser/cd.rs
+++ b/src/internal/config/parser/cd.rs
@@ -27,7 +27,7 @@ impl CdConfig {
 
         Self {
             fast_search: config_value
-                .get_as_bool("fast_search")
+                .get_as_bool_forced("fast_search")
                 .unwrap_or(Self::DEFAULT_FAST_SEARCH),
             path_match_min_score: config_value
                 .get_as_float("path_match_min_score")

--- a/src/internal/config/parser/clone.rs
+++ b/src/internal/config/parser/clone.rs
@@ -34,7 +34,7 @@ impl CloneConfig {
 
         Self {
             auto_up: config_value
-                .get_as_bool("auto_up")
+                .get_as_bool_forced("auto_up")
                 .unwrap_or(Self::DEFAULT_AUTO_UP),
             ls_remote_timeout,
         }

--- a/src/internal/config/parser/org.rs
+++ b/src/internal/config/parser/org.rs
@@ -47,7 +47,7 @@ impl OrgConfig {
 
         Self {
             handle: config_value.get_as_str("handle").unwrap().to_string(),
-            trusted: config_value.get_as_bool("trusted").unwrap_or(false),
+            trusted: config_value.get_as_bool_forced("trusted").unwrap_or(false),
             worktree: config_value.get_as_str("worktree"),
             repo_path_format: config_value.get_as_str("repo_path_format"),
         }

--- a/src/internal/config/parser/path_repo_updates.rs
+++ b/src/internal/config/parser/path_repo_updates.rs
@@ -104,16 +104,16 @@ impl PathRepoUpdatesConfig {
 
         Self {
             enabled: config_value
-                .get_as_bool("enabled")
+                .get_as_bool_forced("enabled")
                 .unwrap_or(Self::DEFAULT_ENABLED),
             self_update,
             on_command_not_found,
             pre_auth: config_value
-                .get_as_bool("pre_auth")
+                .get_as_bool_forced("pre_auth")
                 .unwrap_or(Self::DEFAULT_PRE_AUTH),
             pre_auth_timeout,
             background_updates: config_value
-                .get_as_bool("background_updates")
+                .get_as_bool_forced("background_updates")
                 .unwrap_or(Self::DEFAULT_BACKGROUND_UPDATES),
             background_updates_timeout,
             interval,

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -37,34 +37,37 @@ impl UpCommandConfig {
             None => return Self::default(),
         };
 
-        let config_value = match config_value.reject_scope(&ConfigScope::Workdir) {
+        let config_value_global = match config_value.reject_scope(&ConfigScope::Workdir) {
             Some(config_value) => config_value,
-            None => return Self::default(),
+            None => ConfigValue::default(),
         };
 
         let preferred_tools =
-            if let Some(preferred_tools) = config_value.get_as_array("preferred_tools") {
+            if let Some(preferred_tools) = config_value_global.get_as_array("preferred_tools") {
                 preferred_tools
                     .iter()
                     .filter_map(|value| value.as_str().map(|value| value.to_string()))
                     .collect()
-            } else if let Some(preferred_tool) = config_value.get_as_str_forced("preferred_tools") {
+            } else if let Some(preferred_tool) =
+                config_value_global.get_as_str_forced("preferred_tools")
+            {
                 vec![preferred_tool]
             } else {
                 Vec::new()
             };
 
         Self {
-            auto_bootstrap: config_value
+            auto_bootstrap: config_value_global
                 .get_as_bool_forced("auto_bootstrap")
                 .unwrap_or(Self::DEFAULT_AUTO_BOOTSTRAP),
-            notify_workdir_config_updated: config_value
+            notify_workdir_config_updated: config_value_global
                 .get_as_bool_forced("notify_workdir_config_updated")
                 .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED),
-            notify_workdir_config_available: config_value
+            notify_workdir_config_available: config_value_global
                 .get_as_bool_forced("notify_workdir_config_available")
                 .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE),
             preferred_tools,
+            // The upgrade option is fine to handle as a workdir option too
             upgrade: config_value
                 .get_as_bool_forced("upgrade")
                 .unwrap_or(Self::DEFAULT_UPGRADE),

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -37,10 +37,10 @@ impl UpCommandConfig {
             None => return Self::default(),
         };
 
-        let config_value_global = match config_value.reject_scope(&ConfigScope::Workdir) {
-            Some(config_value) => config_value,
-            None => ConfigValue::default(),
-        };
+        // For the values that we don't support overriding in the workdir
+        let config_value_global = config_value
+            .reject_scope(&ConfigScope::Workdir)
+            .unwrap_or_default();
 
         let preferred_tools =
             if let Some(preferred_tools) = config_value_global.get_as_array("preferred_tools") {

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -10,6 +10,7 @@ pub struct UpCommandConfig {
     pub notify_workdir_config_updated: bool,
     pub notify_workdir_config_available: bool,
     pub preferred_tools: Vec<String>,
+    pub upgrade: bool,
 }
 
 impl Default for UpCommandConfig {
@@ -19,6 +20,7 @@ impl Default for UpCommandConfig {
             notify_workdir_config_updated: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED,
             notify_workdir_config_available: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE,
             preferred_tools: Vec::new(),
+            upgrade: Self::DEFAULT_UPGRADE,
         }
     }
 }
@@ -27,6 +29,7 @@ impl UpCommandConfig {
     const DEFAULT_AUTO_BOOTSTRAP: bool = true;
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED: bool = true;
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE: bool = true;
+    const DEFAULT_UPGRADE: bool = false;
 
     pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
         let config_value = match config_value {
@@ -53,15 +56,18 @@ impl UpCommandConfig {
 
         Self {
             auto_bootstrap: config_value
-                .get_as_bool("auto_bootstrap")
+                .get_as_bool_forced("auto_bootstrap")
                 .unwrap_or(Self::DEFAULT_AUTO_BOOTSTRAP),
             notify_workdir_config_updated: config_value
-                .get_as_bool("notify_workdir_config_updated")
+                .get_as_bool_forced("notify_workdir_config_updated")
                 .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED),
             notify_workdir_config_available: config_value
-                .get_as_bool("notify_workdir_config_available")
+                .get_as_bool_forced("notify_workdir_config_available")
                 .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE),
             preferred_tools,
+            upgrade: config_value
+                .get_as_bool_forced("upgrade")
+                .unwrap_or(Self::DEFAULT_UPGRADE),
         }
     }
 }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -985,7 +985,7 @@ impl UpConfigAsdfBase {
         // If the options do not include upgrade, then we can try using
         // an already-installed version if any matches the requirements
         if !self.upgrade_version(options) {
-            if let Some(installed_versions) =
+            if let Ok(installed_versions) =
                 self.list_installed_versions_from_plugin(progress_handler)
             {
                 let resolve_str = match self.version.as_str() {

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -15,6 +15,7 @@ use crate::internal::cache::CacheObject;
 use crate::internal::cache::HomebrewInstalled;
 use crate::internal::cache::HomebrewOperationCache;
 use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::config;
 use crate::internal::config::up::utils::get_command_output;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::ProgressHandler;
@@ -674,7 +675,7 @@ impl HomebrewTap {
     }
 
     fn upgrade_tap(&self, options: &UpOptions) -> bool {
-        self.upgrade || options.upgrade || global_config().up_command.upgrade
+        self.upgrade || options.upgrade || config(".").up_command.upgrade
     }
 
     fn update_tap(
@@ -1440,7 +1441,7 @@ impl HomebrewInstall {
     }
 
     fn upgrade_install(&self, options: &UpOptions) -> bool {
-        self.upgrade || options.upgrade || global_config().up_command.upgrade
+        self.upgrade || options.upgrade || config(".").up_command.upgrade
     }
 
     fn install(

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod asdf_base;
 pub(crate) use asdf_base::asdf_tool_path;
 pub(crate) use asdf_base::AsdfToolUpVersion;
 pub(crate) use asdf_base::UpConfigAsdfBase;
+pub(crate) use asdf_base::UpConfigAsdfBaseParams;
 
 pub(crate) mod error;
 pub(crate) use error::UpError;

--- a/src/internal/config/up/nodejs.rs
+++ b/src/internal/config/up/nodejs.rs
@@ -56,11 +56,11 @@ impl UpConfigNodejsParams {
         let mut params = Self::default();
 
         if let Some(config_value) = &config_value {
-            if let Some(value) = config_value.get_as_bool("install_engines") {
+            if let Some(value) = config_value.get_as_bool_forced("install_engines") {
                 params.install_engines = value;
             }
 
-            if let Some(value) = config_value.get_as_bool("install_packages") {
+            if let Some(value) = config_value.get_as_bool_forced("install_packages") {
                 params.install_packages = value;
             }
         }

--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -6,6 +6,7 @@ pub struct UpOptions<'a> {
     pub read_cache: bool,
     pub write_cache: bool,
     pub fail_on_upgrade: bool,
+    pub upgrade: bool,
     #[serde(skip)]
     pub lock_file: Option<&'a std::fs::File>,
 }
@@ -16,6 +17,7 @@ impl Default for UpOptions<'_> {
             read_cache: true,
             write_cache: true,
             fail_on_upgrade: false,
+            upgrade: false,
             lock_file: None,
         }
     }
@@ -39,6 +41,11 @@ impl<'a> UpOptions<'a> {
 
     pub fn fail_on_upgrade(mut self, fail_on_upgrade: bool) -> Self {
         self.fail_on_upgrade = fail_on_upgrade;
+        self
+    }
+
+    pub fn upgrade(mut self, upgrade: bool) -> Self {
+        self.upgrade = upgrade;
         self
     }
 

--- a/src/internal/config/up/python.rs
+++ b/src/internal/config/up/python.rs
@@ -256,7 +256,11 @@ fn setup_python_venv_per_dir(
             RunConfig::default(),
         )?;
 
-        progress_handler.progress(format!("venv created for python {} in {}", version, dir,));
+        progress_handler.progress(format!(
+            "venv created for python {} in {}",
+            version,
+            if dir.is_empty() { "." } else { &dir }
+        ));
     }
 
     // Update the cache

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -150,7 +150,6 @@ impl UpConfigTool {
                     config_value,
                     UpConfigAsdfBaseParams {
                         tool_url: Some("https://github.com/xaf/asdf-bash".into()),
-                        ..UpConfigAsdfBaseParams::default()
                     },
                 ),
             )),

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -10,6 +10,7 @@ use crate::internal::config::global_config;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfig;
 use crate::internal::config::up::UpConfigAsdfBase;
+use crate::internal::config::up::UpConfigAsdfBaseParams;
 use crate::internal::config::up::UpConfigBundler;
 use crate::internal::config::up::UpConfigCustom;
 use crate::internal::config::up::UpConfigGithubReleases;
@@ -144,10 +145,13 @@ impl UpConfigTool {
                 }
             }
             "bash" => Some(UpConfigTool::Bash(
-                UpConfigAsdfBase::from_config_value_with_url(
+                UpConfigAsdfBase::from_config_value_with_params(
                     "bash",
-                    "https://github.com/XaF/asdf-bash",
                     config_value,
+                    UpConfigAsdfBaseParams {
+                        tool_url: Some("https://github.com/xaf/asdf-bash".into()),
+                        ..UpConfigAsdfBaseParams::default()
+                    },
                 ),
             )),
             "bundler" | "bundle" => Some(UpConfigTool::Bundler(

--- a/src/internal/config/up/utils/version.rs
+++ b/src/internal/config/up/utils/version.rs
@@ -138,6 +138,10 @@ impl VersionParser {
         version.build = vec![];
         version.satisfies(requirements)
     }
+
+    pub fn major(&self) -> u64 {
+        self.version.major
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/tests/test_omni_help.bats
+++ b/tests/test_omni_help.bats
@@ -264,7 +264,7 @@ omni - omnipotent tool (v$version)
 
 Sets up or tear down a repository depending on its up configuration
 
-Usage: omni down [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggested] [--prompt] [--prompt-all] [--trust] [--update-repository] [--update-user-config]
+Usage: omni down [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggested] [--prompt] [--prompt-all] [--trust] [--update-repository] [--update-user-config] [--upgrade]
 
   --no-cache            Whether we should disable the cache while running the command
                         (default: no)
@@ -296,6 +296,12 @@ Usage: omni down [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggest
                         repository if any (yes/ask/no); When using up, the suggest_config
                         configuration will be copied to the home directory of the user to be
                         loaded on every omni call (default: no)
+
+  --upgrade             Whether we should upgrade the resources when the currently-installed
+                        version already matches version constraints. If false, this also means
+                        that if an already installed version for another repository matches
+                        version contraints, we will avoid downloading and building a more
+                        recent version (default: false)
 
 Source: builtin
 EOF
@@ -399,7 +405,7 @@ omni - omnipotent tool (v$version)
 
 Sets up or tear down a repository depending on its up configuration
 
-Usage: omni up [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggested] [--prompt] [--prompt-all] [--trust] [--update-repository] [--update-user-config]
+Usage: omni up [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggested] [--prompt] [--prompt-all] [--trust] [--update-repository] [--update-user-config] [--upgrade]
 
   --no-cache            Whether we should disable the cache while running the command
                         (default: no)
@@ -431,6 +437,12 @@ Usage: omni up [--no-cache] [--fail-on-upgrade] [--bootstrap] [--clone-suggested
                         repository if any (yes/ask/no); When using up, the suggest_config
                         configuration will be copied to the home directory of the user to be
                         loaded on every omni call (default: no)
+
+  --upgrade             Whether we should upgrade the resources when the currently-installed
+                        version already matches version constraints. If false, this also means
+                        that if an already installed version for another repository matches
+                        version contraints, we will avoid downloading and building a more
+                        recent version (default: false)
 
 Source: builtin
 EOF

--- a/tests/test_omni_up_homebrew.bats
+++ b/tests/test_omni_up_homebrew.bats
@@ -40,7 +40,7 @@ EOF
 }
 
 # bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
-@test "omni up homebrew operation calls to upgrade formula" {
+@test "omni up homebrew operation calls to upgrade formula when upgrade is passed on the command line" {
   cat > .omni.yaml <<EOF
 up:
   - homebrew:
@@ -50,6 +50,69 @@ EOF
 
   add_command brew list --formula fakeformula
   add_command brew upgrade --formula fakeformula
+  add_command brew --prefix --installed fakeformula
+  add_command brew --prefix
+
+  run omni up --trust --upgrade 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation calls to upgrade formula when upgrade is configured at the work directory level" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - fakeformula
+
+up_command:
+  upgrade: true
+EOF
+
+  add_command brew list --formula fakeformula
+  add_command brew upgrade --formula fakeformula
+  add_command brew --prefix --installed fakeformula
+  add_command brew --prefix
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation calls to upgrade formula when upgrade is configured for the formula" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - formula: fakeformula
+        upgrade: true
+EOF
+
+  add_command brew list --formula fakeformula
+  add_command brew upgrade --formula fakeformula
+  add_command brew --prefix --installed fakeformula
+  add_command brew --prefix
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation does not upgrade formula if it is already installed and upgrade is not configured" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - formula: fakeformula
+EOF
+
+  add_command brew list --formula fakeformula
   add_command brew --prefix --installed fakeformula
   add_command brew --prefix
 
@@ -79,7 +142,7 @@ EOF
 }
 
 # bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
-@test "omni up homebrew operation calls to upgrade cask" {
+@test "omni up homebrew operation calls to upgrade cask when upgrade is passed on the command line" {
   cat > .omni.yaml <<EOF
 up:
   - homebrew:
@@ -89,6 +152,66 @@ EOF
 
   add_command brew list --cask fakecask
   add_command brew upgrade --cask fakecask
+  add_command brew --prefix
+
+  run omni up --trust --upgrade 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation calls to upgrade cask when upgrade is configured at the work directory level" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - cask: fakecask
+
+up_command:
+  upgrade: true
+EOF
+
+  add_command brew list --cask fakecask
+  add_command brew upgrade --cask fakecask
+  add_command brew --prefix
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation calls to upgrade cask when upgrade is configured for the cask" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - cask: fakecask
+        upgrade: true
+EOF
+
+  add_command brew list --cask fakecask
+  add_command brew upgrade --cask fakecask
+  add_command brew --prefix
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:homebrew,omni:up:homebrew:install
+@test "omni up homebrew operation does not upgrade cask if it is already installed and upgrade is not configured" {
+  cat > .omni.yaml <<EOF
+up:
+  - homebrew:
+      install:
+      - cask: fakecask
+EOF
+
+  add_command brew list --cask fakecask
   add_command brew --prefix
 
   run omni up --trust 3>&-

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -28,6 +28,7 @@ add_asdf_python_calls() {
   venv=true
   cache_versions=false
   list_versions=true
+  upgrade=false
 
   for arg in "$@"; do
     case $arg in
@@ -63,6 +64,10 @@ add_asdf_python_calls() {
         list_versions="${arg#list_versions=}"
         shift
         ;;
+      upgrade=*)
+        upgrade="${arg#upgrade=}"
+        shift
+        ;;
       *)
         echo "Unknown argument: $arg"
         return 1
@@ -95,6 +100,10 @@ add_asdf_python_calls() {
     add_command asdf plugin list <<EOF
 python
 EOF
+  fi
+
+  if [ "$upgrade" = "false" ]; then
+    add_command asdf plugin list python
   fi
 
   if [ "$list_versions" = "true" ]; then

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -29,6 +29,7 @@ add_asdf_python_calls() {
   cache_versions=false
   list_versions=true
   upgrade=false
+  no_upgrade_installed=false
 
   for arg in "$@"; do
     case $arg in
@@ -68,6 +69,10 @@ add_asdf_python_calls() {
         upgrade="${arg#upgrade=}"
         shift
         ;;
+      no_upgrade_installed=*)
+        no_upgrade_installed="${arg#no_upgrade_installed=}"
+        shift
+        ;;
       *)
         echo "Unknown argument: $arg"
         return 1
@@ -103,7 +108,13 @@ EOF
   fi
 
   if [ "$upgrade" = "false" ]; then
-    add_command asdf plugin list python
+    if [ "$no_upgrade_installed" = "false" ]; then
+      add_command asdf list python
+    else
+      add_command asdf list python <<EOF
+$(for v in $(echo "${no_upgrade_installed}" | perl -pe 's/,+/,/g' | sort -u); do echo "  ${v}"; done)
+EOF
+    fi
   fi
 
   if [ "$list_versions" = "true" ]; then
@@ -117,11 +128,11 @@ EOF
   fi
 
   if [ "$installed" = "true" ]; then
-    if [ "$others_installed" = "false" ]; then
-      installed_versions="${version}"
-    else
-      installed_versions=$(echo "${others_installed},${version}" | tr ',' '\n' | sort -u)
-    fi
+    installed_versions=$(echo "${others_installed},${no_upgrade_installed},${version}" | \
+      perl -pe 's/(^|,)false(?=,|$)/,/g' | \
+      perl -pe 's/,+/\n/g' | \
+      perl -pe '/^$/d' | \
+      sort -u)
     add_command asdf list python "${version}" exit=0 <<EOF
 $(for v in ${installed_versions}; do echo "  ${v}"; done)
 EOF
@@ -404,6 +415,123 @@ EOF
 
   add_brew_python_calls
   add_asdf_python_calls cache_versions=expired list_versions=fail-update
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (latest) with upgrade configured for the python version" {
+  cat > .omni.yaml <<EOF
+up:
+  - python:
+      upgrade: true
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls upgrade=true
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (latest) with upgrade configured at the work directory level" {
+  cat > .omni.yaml <<EOF
+up:
+  - python
+
+up_command:
+  upgrade: true
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls upgrade=true
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (latest) with upgrade configured as a command-line parameter" {
+  cat > .omni.yaml <<EOF
+up:
+  - python
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls upgrade=true
+
+  run omni up --trust --upgrade 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (latest) with upgrade disabled and only an older major installed" {
+  cat > .omni.yaml <<EOF
+up:
+  - python
+EOF
+
+  add_brew_python_calls
+  # Expect that it won't match latest since older major, and install is required
+  add_asdf_python_calls no_upgrade_installed="2.7.18"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (2) with upgrade disabled and a version 2 installed" {
+  cat > .omni.yaml <<EOF
+up:
+  - python: 2
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls installed=true list_versions=false version="2.7.9" no_upgrade_installed="2.7.9" venv=false
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (latest) with upgrade disabled and the current major installed" {
+  cat > .omni.yaml <<EOF
+up:
+  - python
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls installed=true version="3.7.1" no_upgrade_installed="3.7.1"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:python,omni:up:python:brew
+@test "omni up python operation (3) with upgrade disabled and a version 3 installed" {
+  cat > .omni.yaml <<EOF
+up:
+  - python: 3
+EOF
+
+  add_brew_python_calls
+  add_asdf_python_calls installed=true list_versions=false version="3.7.1" no_upgrade_installed="3.7.1"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-asdf.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-asdf.md
@@ -19,6 +19,7 @@ The following parameters can be used:
 | `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -35,8 +36,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions`, `.node-version`, `.nodejs-version`, `package.json` or `.nvmrc`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-bash.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-bash.md
@@ -23,6 +23,7 @@ The following parameters can be used:
 | `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -39,8 +40,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.bash-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-github-release.md
@@ -37,6 +37,7 @@ This supports authenticated requests using [the `gh` command line interface](htt
 |------------------|-----------|-------------------------------------------------------|
 | `repository` | string | The name of the repository to download the release from, in the `<owner>/<name>` format; can also be provided as an object with the `owner` and `name` keys |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching release, even if an already-installed version matches the requirements *(default: false)* |
 | `prerelease` | boolean | Whether to download a prerelease version or only match stable releases; this will also apply to versions with prerelease specification, e.g. `1.2.3-alpha` *(default: `false`)* |
 | `build` | boolean | Whether to download a version with build specification, e.g. `1.2.3+build` *(default: `false`)* |
 | `binary` | boolean | Whether to download an asset that is not archived and consider it a binary file *(default: `true`)* |
@@ -72,8 +73,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions`, `.go-version`, `.golang-version` or `.go.mod`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-go.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-go.md
@@ -24,6 +24,7 @@ The following parameters can be used:
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
 | `version_file` | path | Relative path to the `go.mod` file where the golang version to install can be read from |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -40,8 +41,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions`, `.go-version`, `.golang-version` or `.go.mod`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-homebrew.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-homebrew.md
@@ -33,6 +33,7 @@ If `brew` is not available on the system, this step will be ignored.
 |------------------|-----------|-------------------------------------------------------|
 | `repo` | string | The name of the repository to tap, in the `<owner>/<repo>` format |
 | `url` | string | The URL to tap the repository from (necessary if not following the `https://github.com/<owner>/homebrew-<repo>` format) |
+| `upgrade` | boolean | whether or not to always try and update the tap *(default: false)* |
 
 
 ### `install`
@@ -42,6 +43,8 @@ If `brew` is not available on the system, this step will be ignored.
 | `formula` | string | The name of the formula to install (cannot be used along with `cask`) |
 | `cask` | string | The name of the cask to install (cannot be used along with `formula`) |
 | `version` | string | The version to install for the formula or cask |
+| `upgrade` | boolean | whether or not to always try and update the formula or cask *(default: false)* |
+
 
 ## Examples
 

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-node.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-node.md
@@ -25,6 +25,7 @@ The following parameters can be used:
 | `install_packages` | boolean | If set to `true`, the packages specified in the `package.json` file will be installed, using the preferred package manager between `npm`, `yarn` and `pnpm`. The preferred package manager is determined from any lock file found in the project directory, as well as from the `engines` section of the `package.json` file. *(default: `true`)* |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -41,8 +42,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions`, `.node-version`, `.nodejs-version`, `package.json` or `.nvmrc`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-python.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-python.md
@@ -20,6 +20,7 @@ The following parameters can be used:
 | `pip` | path | Relative path (or list of relative paths) to the requirements files to be used as parameter to `pip install -r` for installing dependencies; if using the word `auto`, omni will try to install the `requirements.txt` file in each specified `dir` (or in each discovered directory with `version: auto`) if it exists |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -36,8 +37,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release (default) |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.python-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-ruby.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-ruby.md
@@ -19,6 +19,7 @@ The following parameters can be used:
 | `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -35,8 +36,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.ruby-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-rust.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-rust.md
@@ -19,6 +19,7 @@ The following parameters can be used:
 | `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -35,8 +36,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.rust-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-terraform.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-terraform.md
@@ -19,6 +19,7 @@ The following parameters can be used:
 | `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use the node version |
 | `url` | string | The URL to download the tool from, in case the tool is not registered in [`asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) or if you want to use a custom version. |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version, even if an already-installed version matches the requirements *(default: false)* |
 
 ### Version handling
 
@@ -35,8 +36,8 @@ The following strings can be used to specify the version:
 | `<1.2.3`  | Must be lower than `1.2.3` |
 | `<=1.2.3` | Must be lower or equal to `1.2.3` |
 | `1.2.x`   | Accepts `1.2.0`, `1.2.1`, etc. but will not accept `1.3.0` |
-| `*`       | Matches any version (will default to `latest`) |
-| `latest`  | Latest release |
+| `*`       | Matches any version (same as `latest`, except that when `upgrade` is `false`, will match any installed version) |
+| `latest`  | Latest release (when `upgrade` is set to `false`, will only match with installed versions of the latest major) |
 | `auto`    | Lookup for any version files in the project directory (`.tool-versions` or `.terraform-version`) and apply version parsing |
 
 The version also supports the `||` operator to specify ranges. This operator is not compatible with the `latest` and `auto` keywords. For instance, `1.2.x || >1.3.5 <=1.4.0` will match any version between `1.2.0` included and `1.3.0` excluded, or between `1.3.5` excluded and `1.4.0` included.

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -14,6 +14,7 @@ Configuration related to the `omni up` command.
 | `notify_workdir_config_updated` | boolean | whether or not to print a message on the prompt if the `up` configuration of the work directory has been updated since the last `omni up` *(default: true)* |
 | `notify_workdir_config_available` | boolean | whether or not to print a message on the prompt if the current work directory has an available `up` configuration but `omni up` has not been run yet *(default: true)* |
 | `preferred_tools` | list | list of preferred tools for [`any` operations](up/any) when running `omni up`; those tools will be preferred over others, in the order they are defined |
+| `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version of the dependencies when running `omni up`, even if an already-installed version matches the requirements *(default: false)* |
 
 ## Example
 


### PR DESCRIPTION
`omni up` now takes a new `--upgrade` parameter which forces checking new available versions of tools matching any requested tool and version constraint, and installing them if it is not already the case.

This affects any tool which can be upgraded, e.g. this affects the `homebrew` operation, the `github release` operation, and any `asdf`-backed operation. For each of those, a new `upgrade` boolean parameter has been added and can be set to `true` to force the `--upgrade` behavior in all cases. When using `latest` as the version, this will only match with any version of the latest `major`.

A new `up_command`/`upgrade` option is also available in the global/repo configuration and can be set to `true` to force upgrading all tools even without the `--upgrade` parameter.

BREAKING CHANGE: This changes the default behavior which would now be the equivalent of setting `up_command`/`upgrade` to `true`. The default behavior was changed to speed up the operations.

Closes https://github.com/XaF/omni/issues/705