### PR TITLE
fix(python): replace lzma with xz when using nix

### DIFF
--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -1299,7 +1299,7 @@ impl UpConfigAsdfBase {
                     "gdbm",
                     "gnumake",
                     "libffi",
-                    "lzma",
+                    "xz",
                     "ncurses",
                     "pkg-config",
                     "sqlite",

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -1299,10 +1299,10 @@ impl UpConfigAsdfBase {
                     "gdbm",
                     "gnumake",
                     "libffi",
-                    "xz",
                     "ncurses",
                     "pkg-config",
                     "sqlite",
+                    "xz",
                     "zlib",
                 ]);
             }

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -194,7 +194,7 @@ add_nix_python_calls() {
 
   local nix=(nix --extra-experimental-features "nix-command flakes")
 
-  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ bzip2 gawk gcc gdbm gnumake gnused libffi xz ncurses openssl pkg-config readline sqlite zlib ]; }'
+  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ bzip2 gawk gcc gdbm gnumake gnused libffi ncurses openssl pkg-config readline sqlite xz zlib ]; }'
   add_command "${nix[@]}" build --print-out-paths --out-link "regex:${HOME}/\.local/share/omni/wd/.*/nix/profile-pkgs-.*" "regex:${tmpdir}/omni_up_nix\..*/profile" <<EOF
 #omni-test-bash-function
 function process_response() {

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -194,7 +194,7 @@ add_nix_python_calls() {
 
   local nix=(nix --extra-experimental-features "nix-command flakes")
 
-  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ bzip2 gawk gcc gdbm gnumake gnused libffi lzma ncurses openssl pkg-config readline sqlite zlib ]; }'
+  add_command "${nix[@]}" print-dev-env --verbose --print-build-logs --profile "regex:${tmpdir}/omni_up_nix\..*/profile" --impure --expr 'with import <nixpkgs> {}; mkShell { buildInputs = [ bzip2 gawk gcc gdbm gnumake gnused libffi xz ncurses openssl pkg-config readline sqlite zlib ]; }'
   add_command "${nix[@]}" build --print-out-paths --out-link "regex:${HOME}/\.local/share/omni/wd/.*/nix/profile-pkgs-.*" "regex:${tmpdir}/omni_up_nix\..*/profile" <<EOF
 #omni-test-bash-function
 function process_response() {


### PR DESCRIPTION
I encountered the following problem today when omni attempted to install python in the background:
```
[1/5] - python (3): deps: evaluating file '/nix/store/93haqkb7bl8l90vpfqgkygrd5l13gafm-source/pkgs/by-name/gd/gdbm/package.nix'
[1/5] - python (3): deps: error:
[1/5] - python (3): deps:        … while calling the 'derivationStrict' builtin
[1/5] - python (3): deps:          at <nix/derivation-internal.nix>:34:12:
[1/5] - python (3): deps:            33|
[1/5] - python (3): deps:            34|   strict = derivationStrict drvAttrs;
[1/5] - python (3): deps:              |            ^
[1/5] - python (3): deps:            35|
[1/5] - python (3): deps:        … while evaluating derivation 'nix-shell'
[1/5] - python (3): deps:          whose name attribute is located at /nix/store/93haqkb7bl8l90vpfqgkygrd5l13gafm-source/pkgs/stdenv/generic/make-derivation.nix:336:7
[1/5] - python (3): deps:        … while evaluating attribute '__impureHostDeps' of derivation 'nix-shell'
[1/5] - python (3): deps:          at /nix/store/93haqkb7bl8l90vpfqgkygrd5l13gafm-source/pkgs/stdenv/generic/make-derivation.nix:451:7:
[1/5] - python (3): deps:           450|       __propagatedSandboxProfile = unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
[1/5] - python (3): deps:           451|       __impureHostDeps = computedImpureHostDeps ++ computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps ++ __impureHostDeps ++ stdenv.__extraImpureHostDeps ++ [
[1/5] - python (3): deps:              |       ^
[1/5] - python (3): deps:           452|         "/dev/zero"
[1/5] - python (3): deps:        (stack trace truncated; use '--show-t
[1/5] - python (3): deps: race' to show the full, detailed trace)
[1/5] - python (3): deps:        error: 'lzma' has been renamed to/replaced by 'xz'
[1/5] - python (3): deps: failed to install nix packages: execution error: process exited with status 1; log is available at /var/folders/f0/_2j81h0s4_zf6kjr5qkczmbr0000gn/T/omni-exec.20241031T182130Z.h5Gqe4
```

[It looks like `lzma` is simply an alias for `xz`](https://github.com/NixOS/nixpkgs/pull/179377), and that the alias has been removed. I run against nightly nix (at whatever my flake is at now), so I may be ahead of your normal testing.

Since `lzma` is an alias this should work on both nightly and stable nix