### PR TITLE
refactor(SyntaxOptArg): takes a single list of names

### DIFF
--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -241,7 +241,7 @@ impl BuiltinCommand for CdCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--locate".to_string(),
+                    names: vec!["--locate".to_string()],
                     desc: Some(
                         concat!(
                             "If provided, will only return the path to the repository instead of switching ",
@@ -255,7 +255,7 @@ impl BuiltinCommand for CdCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--[no-]include-packages".to_string(),
+                    names: vec!["--[no-]include-packages".to_string()],
                     desc: Some(
                         concat!(
                             "If provided, will include (or not include) packages when running the command; ",
@@ -268,7 +268,7 @@ impl BuiltinCommand for CdCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "repo".to_string(),
+                    names: vec!["repo".to_string()],
                     desc: Some(
                         concat!(
                             "The name of the repo to change directory to; this can be in the format <org>/<repo>, ",

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -449,7 +449,7 @@ impl BuiltinCommand for CloneCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--package".to_string(),
+                    names: vec!["--package".to_string()],
                     desc: Some(
                         "Clone the repository as a package \x1B[90m(default: no)\x1B[0m"
                             .to_string(),
@@ -458,7 +458,7 @@ impl BuiltinCommand for CloneCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "repo".to_string(),
+                    names: vec!["repo".to_string()],
                     desc: Some(
                         concat!(
                             "The repository to clone; this can be in format <org>/<repo>, ",
@@ -472,7 +472,7 @@ impl BuiltinCommand for CloneCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "options".to_string(),
+                    names: vec!["options".to_string()],
                     desc: Some("Any additional options to pass to git clone.".to_string()),
                     leftovers: true,
                     ..Default::default()

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -186,25 +186,25 @@ impl BuiltinCommand for ConfigBootstrapCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--worktree".to_string(),
+                    names: vec!["--worktree".to_string()],
                     desc: Some("Bootstrap the main worktree location".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--repo-path-format".to_string(),
+                    names: vec!["--repo-path-format".to_string()],
                     desc: Some("Bootstrap the repository path format".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--organizations".to_string(),
+                    names: vec!["--organizations".to_string()],
                     desc: Some("Bootstrap the organizations".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--shell".to_string(),
+                    names: vec!["--shell".to_string()],
                     desc: Some("Bootstrap the shell integration".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     ..Default::default()

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -174,7 +174,7 @@ impl BuiltinCommand for ConfigPathSwitchCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--<source>".to_string(),
+                    names: vec!["--<source>".to_string()],
                     desc: Some(
                         concat!(
                             "The source to use for the repository; this can be either ",
@@ -187,7 +187,7 @@ impl BuiltinCommand for ConfigPathSwitchCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "repo".to_string(),
+                    names: vec!["repo".to_string()],
                     desc: Some(
                         concat!(
                             "The name of the repository to switch the source from; this can be in the format ",

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -135,7 +135,7 @@ impl BuiltinCommand for ConfigTrustCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--check".to_string(),
+                    names: vec!["--check".to_string()],
                     desc: Some(
                         "Check the trust status of the repository instead of changing it"
                             .to_string(),
@@ -144,7 +144,7 @@ impl BuiltinCommand for ConfigTrustCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "repo".to_string(),
+                    names: vec!["repo".to_string()],
                     desc: Some(
                         concat!("The repository to trust or untrust ", "[default: current]",)
                             .to_string(),

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -527,14 +527,14 @@ impl BuiltinCommand for HelpCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--unfold".to_string(),
+                    names: vec!["--unfold".to_string()],
                     desc: Some("Show all subcommands".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     required: false,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "command".to_string(),
+                    names: vec!["command".to_string()],
                     desc: Some("The command to get help for".to_string()),
                     leftovers: true,
                     required: false,

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -36,13 +36,13 @@ impl BuiltinCommand for HookCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "hook".to_string(),
+                    names: vec!["hook".to_string()],
                     desc: Some("Which hook to call".to_string()),
                     required: true,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "options".to_string(),
+                    names: vec!["options".to_string()],
                     desc: Some("Any options to pass to the hook.".to_string()),
                     required: false,
                     leftovers: true,

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -137,7 +137,7 @@ impl BuiltinCommand for HookEnvCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--quiet".to_string(),
+                    names: vec!["--quiet".to_string()],
                     desc: Some(
                         concat!(
                             "Suppress the output of the hook showing information about the ",
@@ -149,7 +149,7 @@ impl BuiltinCommand for HookEnvCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--keep-shims".to_string(),
+                    names: vec!["--keep-shims".to_string()],
                     desc: Some(
                         concat!(
                             "Keep the shims directory in the PATH. This is useful for instance ",
@@ -161,7 +161,7 @@ impl BuiltinCommand for HookEnvCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "shell".to_string(),
+                    names: vec!["shell".to_string()],
                     desc: Some(
                         concat!(
                             "The shell for which to export the dynamic environment. ",

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -252,7 +252,7 @@ impl BuiltinCommand for HookInitCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--alias".to_string(),
+                    names: vec!["--alias".to_string()],
                     desc: Some(
                         "Create an alias for the omni command with autocompletion support."
                             .to_string(),
@@ -261,7 +261,7 @@ impl BuiltinCommand for HookInitCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--command-alias".to_string(),
+                    names: vec!["--command-alias".to_string()],
                     desc: Some(
                         concat!(
                             "Create an alias for the specified omni subcommand with autocompletion ",
@@ -275,7 +275,7 @@ impl BuiltinCommand for HookInitCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--shims".to_string(),
+                    names: vec!["--shims".to_string()],
                     desc: Some(
                         "Only load the shims without setting up the dynamic environment."
                             .to_string(),
@@ -284,7 +284,7 @@ impl BuiltinCommand for HookInitCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--keep-shims-in-path".to_string(),
+                    names: vec!["--keep-shims-in-path".to_string()],
                     desc: Some(concat!(
                         "Prevent the dynamic environment from removing the shims directory from the PATH. ",
                         "This can be useful if you are used to launch your IDE from the terminal and do ",
@@ -294,7 +294,7 @@ impl BuiltinCommand for HookInitCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--print-shims-path".to_string(),
+                    names: vec!["--print-shims-path".to_string()],
                     desc: Some(concat!(
                         "Print the path to the shims directory and exit. This should not be ",
                         "used to eval in a shell environment."
@@ -303,7 +303,7 @@ impl BuiltinCommand for HookInitCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "shell".to_string(),
+                    names: vec!["shell".to_string()],
                     desc: Some(
                         "Which shell to initialize omni for. Can be one of bash, zsh or fish."
                             .to_string(),

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -247,7 +247,7 @@ impl BuiltinCommand for ScopeCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "repo".to_string(),
+                    names: vec!["repo".to_string()],
                     desc: Some(
                         concat!(
                             "The name of the repo to run commands in the context of; this ",
@@ -262,7 +262,7 @@ impl BuiltinCommand for ScopeCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "command".to_string(),
+                    names: vec!["command".to_string()],
                     desc: Some(
                         "The omni command to run in the context of the specified repository."
                             .to_string(),
@@ -271,7 +271,7 @@ impl BuiltinCommand for ScopeCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "options".to_string(),
+                    names: vec!["options".to_string()],
                     desc: Some("Any options to pass to the omni command.".to_string()),
                     leftovers: true,
                     ..Default::default()

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -354,13 +354,13 @@ impl BuiltinCommand for StatusCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--shell-integration".to_string(),
+                    names: vec!["--shell-integration".to_string()],
                     desc: Some("Show if the shell integration is loaded or not.".to_string()),
                     arg_type: SyntaxOptArgType::Flag,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--config".to_string(),
+                    names: vec!["--config".to_string()],
                     desc: Some(
                         "Show the configuration that omni is using for the current directory. This is not shown by default."
                             .to_string(),
@@ -369,7 +369,7 @@ impl BuiltinCommand for StatusCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--config-files".to_string(),
+                    names: vec!["--config-files".to_string()],
                     desc: Some(
                         "Show the configuration files that omni is loading for the current directory."
                             .to_string(),
@@ -378,7 +378,7 @@ impl BuiltinCommand for StatusCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--worktree".to_string(),
+                    names: vec!["--worktree".to_string()],
                     desc: Some(
                         "Show the default worktree."
                             .to_string(),
@@ -387,7 +387,7 @@ impl BuiltinCommand for StatusCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--orgs".to_string(),
+                    names: vec!["--orgs".to_string()],
                     desc: Some(
                         "Show the organizations."
                             .to_string(),
@@ -396,7 +396,7 @@ impl BuiltinCommand for StatusCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--path".to_string(),
+                    names: vec!["--path".to_string()],
                     desc: Some(
                         "Show the current omnipath."
                             .to_string(),

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -295,7 +295,7 @@ impl BuiltinCommand for TidyCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--yes".to_string(),
+                    names: vec!["--yes".to_string()],
                     desc: Some(
                         "Do not ask for confirmation before organizing repositories".to_string(),
                     ),
@@ -303,7 +303,7 @@ impl BuiltinCommand for TidyCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--search-path".to_string(),
+                    names: vec!["--search-path".to_string()],
                     desc: Some(
                         concat!(
                             "Extra path to search git repositories to tidy up ",
@@ -315,7 +315,7 @@ impl BuiltinCommand for TidyCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--up-all".to_string(),
+                    names: vec!["--up-all".to_string()],
                     desc: Some(
                         concat!(
                             "Run \x1B[3momni up\x1B[0m in all the repositories ",
@@ -330,7 +330,7 @@ impl BuiltinCommand for TidyCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "up args".to_string(),
+                    names: vec!["up args".to_string()],
                     desc: Some(
                         concat!(
                             "Arguments to pass to \x1B[3momni up\x1B[0m when running ",

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -1280,7 +1280,7 @@ impl BuiltinCommand for UpCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "--no-cache".to_string(),
+                    names: vec!["--no-cache".to_string()],
                     desc: Some(
                         concat!(
                             "Whether we should disable the cache while running the command ",
@@ -1292,7 +1292,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--fail-on-upgrade".to_string(),
+                    names: vec!["--fail-on-upgrade".to_string()],
                     desc: Some(
                         concat!(
                             "If provided, will fail the operation if a resource failed to ",
@@ -1305,7 +1305,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--bootstrap".to_string(),
+                    names: vec!["--bootstrap".to_string()],
                     desc: Some(
                         concat!(
                             "Same as using \x1B[1m--update-user-config --clone-suggested\x1B[0m; if ",
@@ -1318,7 +1318,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--clone-suggested".to_string(),
+                    names: vec!["--clone-suggested".to_string()],
                     desc: Some(
                         concat!(
                             "Whether we should clone suggested repositories found in the configuration ",
@@ -1335,7 +1335,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--prompt".to_string(),
+                    names: vec!["--prompt".to_string()],
                     desc: Some(
                         concat!(
                             "Trigger prompts for the given prompt ids, specified as arguments, as ",
@@ -1347,7 +1347,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--prompt-all".to_string(),
+                    names: vec!["--prompt-all".to_string()],
                     desc: Some(
                         concat!(
                             "Trigger all prompts for the current work directory, even if they have ",
@@ -1359,7 +1359,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--trust".to_string(),
+                    names: vec!["--trust".to_string()],
                     desc: Some(
                         "Define how to trust the repository (always/yes/no) to run the command"
                             .to_string(),
@@ -1373,7 +1373,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--update-repository".to_string(),
+                    names: vec!["--update-repository".to_string()],
                     desc: Some(
                         concat!(
                             "Whether we should update the repository before running the command; ",
@@ -1386,7 +1386,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--update-user-config".to_string(),
+                    names: vec!["--update-user-config".to_string()],
                     desc: Some(
                         concat!(
                             "Whether we should handle suggestions found in the configuration of ",
@@ -1405,7 +1405,7 @@ impl BuiltinCommand for UpCommand {
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "--upgrade".to_string(),
+                    names: vec!["--upgrade".to_string()],
                     desc: Some(
                         concat!(
                             "Whether we should upgrade the resources when the currently-installed ",

--- a/src/internal/commands/void.rs
+++ b/src/internal/commands/void.rs
@@ -49,13 +49,13 @@ impl VoidCommand {
         Some(CommandSyntax {
             parameters: vec![
                 SyntaxOptArg {
-                    name: "subcommand".to_string(),
+                    names: vec!["subcommand".to_string()],
                     desc: Some("Subcommand to be called".to_string()),
                     required: true,
                     ..Default::default()
                 },
                 SyntaxOptArg {
-                    name: "options".to_string(),
+                    names: vec!["options".to_string()],
                     desc: Some("Options to pass to the subcommand".to_string()),
                     leftovers: true,
                     ..Default::default()

--- a/src/internal/config/parser/mod.rs
+++ b/src/internal/config/parser/mod.rs
@@ -16,6 +16,7 @@ mod clone;
 pub(crate) use clone::CloneConfig;
 
 mod command_definition;
+pub(crate) use command_definition::parse_arg_name;
 pub(crate) use command_definition::CommandDefinition;
 pub(crate) use command_definition::CommandSyntax;
 pub(crate) use command_definition::SyntaxGroup;


### PR DESCRIPTION
Previously, we had a separation between the primary name and aliases, and we merged the information together before extracting the expected main long name and main short name. This fixes that by merging everything into a single 'names' list, and applying the same extraction logic but avoiding the initial merging of the lists.

This also applies the splitting logic when defining a parameter from the .omni.yaml file or the metadata yaml file, allowing to use the same syntax as the `# opt` and `# arg` metadata headers.