### PR TITLE
fix(env): path environment variables work for packages

### DIFF
--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -214,7 +214,7 @@ impl TidyCommand {
 
             let location = match path_entry.package {
                 Some(ref package) => format!("{}:{}", "package".underline(), package.light_cyan()),
-                None => path_entry.as_string().light_cyan(),
+                None => path_entry.to_string().light_cyan(),
             };
 
             omni_info!(format!(

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -691,7 +691,7 @@ impl UpCommand {
 
             let location = match path_entry.package {
                 Some(ref package) => format!("{}:{}", "package".underline(), package.light_cyan()),
-                None => path_entry.as_string().light_cyan(),
+                None => path_entry.to_string().light_cyan(),
             };
 
             omni_info!(format!(

--- a/src/internal/commands/path.rs
+++ b/src/internal/commands/path.rs
@@ -38,8 +38,8 @@ fn omnipath_from_config(config: &OmniConfig) -> Vec<String> {
     let mut omnipath_seen = HashSet::new();
 
     for path in &config.path.prepend {
-        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
-            omnipath.push(path.as_string());
+        if path.is_valid() && omnipath_seen.insert(path.to_string()) {
+            omnipath.push(path.to_string());
         }
     }
 
@@ -50,8 +50,8 @@ fn omnipath_from_config(config: &OmniConfig) -> Vec<String> {
     }
 
     for path in &config.path.append {
-        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
-            omnipath.push(path.as_string());
+        if path.is_valid() && omnipath_seen.insert(path.to_string()) {
+            omnipath.push(path.to_string());
         }
     }
 
@@ -63,7 +63,7 @@ fn omnipath_entries_from_config(config: &OmniConfig) -> Vec<PathEntryConfig> {
     let mut omnipath_seen = HashSet::new();
 
     for path in &config.path.prepend {
-        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+        if path.is_valid() && omnipath_seen.insert(path.to_string()) {
             omnipath.push(path.to_owned());
         }
     }
@@ -78,7 +78,7 @@ fn omnipath_entries_from_config(config: &OmniConfig) -> Vec<PathEntryConfig> {
     }
 
     for path in &config.path.append {
-        if path.is_valid() && omnipath_seen.insert(path.as_string()) {
+        if path.is_valid() && omnipath_seen.insert(path.to_string()) {
             omnipath.push(path.to_owned());
         }
     }

--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -156,9 +156,15 @@ impl EnvOperationConfig {
                 // before returning it. We can use the value ConfigSource
                 // to determine the current scope.
                 if value_type == "path" {
-                    match config_value.get_source() {
-                        ConfigSource::File(path) => {
-                            let parent_path = PathBuf::from(path)
+                    let source_path = match config_value.get_source() {
+                        ConfigSource::File(path) => Some(path.to_string()),
+                        ConfigSource::Package(path_entry) => Some(path_entry.to_string()),
+                        _ => None,
+                    };
+
+                    match source_path {
+                        Some(source_path) => {
+                            let parent_path = PathBuf::from(source_path)
                                 .parent()
                                 .expect("config file path has no parent")
                                 .to_string_lossy()
@@ -169,8 +175,7 @@ impl EnvOperationConfig {
                                     .to_string(),
                             )
                         }
-                        // Unsupported source type for the "path" value type
-                        _ => Some(value.to_string()),
+                        None => Some(value.to_string()),
                     }
                 } else {
                     Some(value.to_string())

--- a/src/internal/config/parser/path.rs
+++ b/src/internal/config/parser/path.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -53,6 +54,12 @@ pub struct PathEntryConfig {
     pub package: Option<String>,
     #[serde(skip)]
     pub full_path: String,
+}
+
+impl fmt::Display for PathEntryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.full_path)
+    }
 }
 
 impl PathEntryConfig {
@@ -143,10 +150,6 @@ impl PathEntryConfig {
 
     pub fn is_valid(&self) -> bool {
         !self.full_path.is_empty() && self.full_path.starts_with('/')
-    }
-
-    pub fn as_string(&self) -> String {
-        self.full_path.clone()
     }
 
     pub fn starts_with(&self, path_entry: &PathEntryConfig) -> bool {

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -417,7 +417,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
     if config.path_repo_updates.pre_auth {
         let mut auth_hosts = HashMap::new();
         for path_entry in &omnipath_entries {
-            let git_env = git_env(path_entry.as_string());
+            let git_env = git_env(path_entry.to_string());
             let repo_id = match git_env.id() {
                 Some(repo_id) => repo_id,
                 None => continue,
@@ -481,7 +481,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
         let mut seen = HashSet::new();
 
         for path_entry in omnipath_entries {
-            let path = path_entry.as_string();
+            let path = path_entry.to_string();
 
             let git_env = git_env(&path).clone();
             let repo_id = match git_env.id() {
@@ -589,7 +589,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
                     Some(ref package) => {
                         format!("{}:{}", "package".underline(), package.light_cyan(),)
                     }
-                    None => path_entry.as_string().light_cyan(),
+                    None => path_entry.to_string().light_cyan(),
                 };
 
                 omni_info!(format!(


### PR DESCRIPTION
Packages were not processing path environment variables properly. This change fixes that by extracting the package path to handle the environment variable properly.