### PR TITLE
fix(self update): trim homebrew prefix from binary

### DIFF
--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -82,8 +82,9 @@ lazy_static! {
         if let Ok(output) = output {
             if output.status.success() {
                 if let Ok(prefix) = String::from_utf8(output.stdout) {
+                    let prefix = prefix.trim();
                     if !prefix.is_empty() {
-                        return Some(prefix);
+                        return Some(prefix.to_string());
                     }
                 }
             }


### PR DESCRIPTION
This was causing issues when the `HOMEBREW_PREFIX` environment variable is not set, since the `brew --prefix` output ends with a line return. Trimming solves the problem.