### PR TITLE
fix(self update): handle cases where sudo is required

### DIFF
--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -105,6 +105,13 @@ lazy_static! {
 
     #[derive(Debug)]
     static ref NOW: OffsetDateTime = OffsetDateTime::now_utc();
+
+    #[derive(Debug)]
+    static ref RUNNING_AS_SUDO: bool = std::env::var_os("SUDO_USER").is_some()
+        && match std::env::var("USER") {
+            Ok(user) => user == "root",
+            Err(_) => false,
+        };
 }
 
 /// Get the time of the current execution of omni in UTC.
@@ -114,6 +121,11 @@ lazy_static! {
 /// greater or equal to the one of the calling process.
 pub fn now() -> OffsetDateTime {
     *NOW
+}
+
+/// Indicates if the current shell is a sudo shell.
+pub fn running_as_sudo() -> bool {
+    *RUNNING_AS_SUDO
 }
 
 /// Cleanup temporary directories created by omni in the system's

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -27,6 +27,7 @@ use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::SpinnerProgressHandler;
 use crate::internal::env::current_exe;
+use crate::internal::env::running_as_sudo;
 use crate::internal::env::shell_is_interactive;
 use crate::internal::git::full_git_url_parse;
 use crate::internal::git::path_entry_config;
@@ -405,8 +406,9 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
 
     self_update();
 
-    // Nothing more to do if nothing is in the omnipath
-    if omnipath_entries.is_empty() {
+    // Nothing more to do if nothing is in the omnipath, or if we are running
+    // as sudo since we don't want the repositories to be updated in that case
+    if running_as_sudo() || omnipath_entries.is_empty() {
         return (HashSet::new(), HashSet::new());
     }
 

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -313,10 +313,10 @@ impl OmniRelease {
                 "{} version {} is available{}",
                 "omni:".light_cyan(),
                 self.version.light_blue(),
-                if !can_update {
-                    format!("; use {} to update", "sudo omni --update".light_yellow())
-                } else {
+                if config.path_repo_updates.self_update.is_false() {
                     "".to_string()
+                } else {
+                    format!("; use {} to update", "sudo omni --update".light_yellow())
                 }
             );
             progress_handler.success_with_message(msg);

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -254,6 +254,42 @@ impl OmniRelease {
             .find(|&binary| binary.os == *RELEASE_OS && binary.arch == *RELEASE_ARCH)
     }
 
+    /// Check if we have write permissions for the current exe and for the directory
+    /// of the current exe, since this is required for the self-update to work
+    fn check_write_permissions(&self) -> bool {
+        let current_exe = current_exe();
+        if !current_exe.exists() {
+            return false;
+        }
+
+        // Check first the exe itself
+        match std::fs::metadata(&current_exe) {
+            Ok(metadata) => {
+                if metadata.permissions().readonly() {
+                    return false;
+                }
+            }
+            Err(_) => return false,
+        }
+
+        // Check the directory of the exe
+        let parent = match current_exe.parent() {
+            Some(parent) => parent,
+            None => return false,
+        };
+
+        match std::fs::metadata(parent) {
+            Ok(metadata) => {
+                if metadata.permissions().readonly() {
+                    return false;
+                }
+            }
+            Err(_) => return false,
+        }
+
+        true
+    }
+
     fn check_and_update(&self) {
         let config = config(".");
 
@@ -271,12 +307,19 @@ impl OmniRelease {
             return;
         }
 
-        if config.path_repo_updates.self_update.is_false() {
-            progress_handler.success_with_message(format!(
-                "{} version {} is available",
+        let can_update = self.check_write_permissions() || *INSTALLED_WITH_BREW;
+        if config.path_repo_updates.self_update.is_false() || !can_update {
+            let msg = format!(
+                "{} version {} is available{}",
                 "omni:".light_cyan(),
                 self.version.light_blue(),
-            ));
+                if !can_update {
+                    format!("; use {} to update", "sudo omni --update".light_yellow())
+                } else {
+                    "".to_string()
+                }
+            );
+            progress_handler.success_with_message(msg);
             return;
         }
 


### PR DESCRIPTION
For cases where omni was installed in a location where sudo access is not available, this will print a message requesting `sudo` instead of failing the update.