### PR TITLE
refactor(`up`): ♻️ make environments versioned

### DIFF
--- a/src/internal/cache/handler.rs
+++ b/src/internal/cache/handler.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
@@ -11,116 +10,15 @@ use fs4::fs_std::FileExt;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::internal::cache::migration::convert_cache;
 use crate::internal::cache::CacheObject;
 use crate::internal::config::global_config;
-
-// Read the content of the cache file and parse it as structured JSON;
-// we will want to deprecate and remove that at some point, but it will
-// allow for moving from omni <=0.0.15 to any newer version that will
-// now expect a separate file per cache category
-#[derive(Debug, Serialize, Deserialize)]
-struct OldCache {
-    #[serde(default)]
-    asdf_operation: serde_json::Value,
-    #[serde(default)]
-    homebrew_operation: serde_json::Value,
-    #[serde(default)]
-    omni_path_updates: serde_json::Value,
-    #[serde(default)]
-    trusted_repositories: OldCacheTrustedRepositories,
-    #[serde(default)]
-    up_environments: serde_json::Value,
-}
-#[derive(Debug, Serialize, Deserialize, Default)]
-struct OldCacheTrustedRepositories {
-    #[serde(default)]
-    repositories: serde_json::Value,
-    #[serde(default)]
-    updated_at: serde_json::Value,
-}
-#[derive(Debug, Serialize, Deserialize)]
-struct NewCacheRepositories {
-    trusted: serde_json::Value,
-    updated_at: serde_json::Value,
-}
-
-fn convert_cache_to_dir() -> io::Result<()> {
-    let cache_path = PathBuf::from(global_config().cache.path.clone());
-
-    // If the cache path does not exist, there is nothing to do
-    if !cache_path.exists() {
-        return Ok(());
-    }
-
-    // If the cache path exists and is a directory, there is nothing to do
-    if cache_path.is_dir() {
-        return Ok(());
-    }
-
-    // If the cache path exists and is a file, we need to prepare the directory
-    let tmp_dir = env::temp_dir();
-    let tmp_dir_path = loop {
-        let tmp_dir_path = tmp_dir.join(format!("omni-cache.d-{}", uuid::Uuid::new_v4()));
-        if let Ok(()) = std::fs::create_dir_all(&tmp_dir_path) {
-            break tmp_dir_path;
-        }
-    };
-
-    // Read the contents of the cache file into a OldCache struct
-    let old_cache_file = File::open(&cache_path)?;
-    let old_cache: OldCache = serde_json::from_reader(old_cache_file)?;
-
-    // Write each cache category to a separate file in our temporary directory
-    if old_cache.asdf_operation != serde_json::Value::Null {
-        let asdf_operation_file_path = tmp_dir_path.join("asdf_operation.json");
-        let mut asdf_operation_file = File::create(asdf_operation_file_path)?;
-        asdf_operation_file
-            .write_all(serde_json::to_string(&old_cache.asdf_operation)?.as_bytes())?;
-    }
-    if old_cache.homebrew_operation != serde_json::Value::Null {
-        let homebrew_operation_file_path = tmp_dir_path.join("homebrew_operation.json");
-        let mut homebrew_operation_file = File::create(homebrew_operation_file_path)?;
-        homebrew_operation_file
-            .write_all(serde_json::to_string(&old_cache.homebrew_operation)?.as_bytes())?;
-    }
-    if old_cache.omni_path_updates != serde_json::Value::Null {
-        let omni_path_updates_file_path = tmp_dir_path.join("omnipath.json");
-        let mut omni_path_updates_file = File::create(omni_path_updates_file_path)?;
-        omni_path_updates_file
-            .write_all(serde_json::to_string(&old_cache.omni_path_updates)?.as_bytes())?;
-    }
-    if old_cache.trusted_repositories.repositories != serde_json::Value::Null {
-        let repositories_file_path = tmp_dir_path.join("repositories.json");
-        let mut repositories_file = File::create(repositories_file_path)?;
-        // Since we're changing the format, we're rewriting this into a new struct
-        let new_repositories = NewCacheRepositories {
-            trusted: old_cache.trusted_repositories.repositories,
-            updated_at: old_cache.trusted_repositories.updated_at,
-        };
-        repositories_file.write_all(serde_json::to_string(&new_repositories)?.as_bytes())?;
-    }
-    if old_cache.up_environments != serde_json::Value::Null {
-        let up_environments_file_path = tmp_dir_path.join("up_environments.json");
-        let mut up_environments_file = File::create(up_environments_file_path)?;
-        up_environments_file
-            .write_all(serde_json::to_string(&old_cache.up_environments)?.as_bytes())?;
-    }
-
-    // Rename the current cache file to a backup file, just in case
-    let backup_file_path = cache_path.with_extension("json.bak");
-    std::fs::rename(&cache_path, backup_file_path)?;
-
-    // Move the temporary directory to the cache path
-    std::fs::rename(&tmp_dir_path, &cache_path)?;
-
-    Ok(())
-}
 
 pub fn shared<C>(cache_name: &str) -> io::Result<C>
 where
     C: CacheObject + Clone + Serialize + for<'a> Deserialize<'a>,
 {
-    convert_cache_to_dir()?;
+    convert_cache()?;
 
     let cache_dir_path = PathBuf::from(global_config().cache.path.clone());
     let cache_path = cache_dir_path.join(format!("{}.json", cache_name));
@@ -139,7 +37,7 @@ where
     F1: FnOnce(&mut C) -> bool,
     F2: FnOnce(C),
 {
-    convert_cache_to_dir()?;
+    convert_cache()?;
 
     // Check if the directory of the cache file exists, otherwise create it recursively
     let cache_dir_path = PathBuf::from(global_config().cache.path.clone());

--- a/src/internal/cache/migration/convert.rs
+++ b/src/internal/cache/migration/convert.rs
@@ -1,0 +1,11 @@
+use std::io;
+
+use crate::internal::cache::migration::pre0015::convert_cache_pre_0_0_15;
+use crate::internal::cache::migration::pre0029::convert_cache_pre_0_0_29;
+
+pub fn convert_cache() -> io::Result<()> {
+    convert_cache_pre_0_0_15()?;
+    convert_cache_pre_0_0_29()?;
+
+    Ok(())
+}

--- a/src/internal/cache/migration/mod.rs
+++ b/src/internal/cache/migration/mod.rs
@@ -1,0 +1,5 @@
+mod convert;
+pub(crate) use convert::convert_cache;
+
+mod pre0015;
+mod pre0029;

--- a/src/internal/cache/migration/pre0015.rs
+++ b/src/internal/cache/migration/pre0015.rs
@@ -1,0 +1,112 @@
+use std::env;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::config::global_config;
+
+// Read the content of the cache file and parse it as structured JSON;
+// we will want to deprecate and remove that at some point, but it will
+// allow for moving from omni <=0.0.15 to any newer version that will
+// now expect a separate file per cache category
+#[derive(Debug, Serialize, Deserialize)]
+struct Pre0015Cache {
+    #[serde(default)]
+    asdf_operation: serde_json::Value,
+    #[serde(default)]
+    homebrew_operation: serde_json::Value,
+    #[serde(default)]
+    omni_path_updates: serde_json::Value,
+    #[serde(default)]
+    trusted_repositories: Pre0015CacheTrustedRepositories,
+    #[serde(default)]
+    up_environments: serde_json::Value,
+}
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Pre0015CacheTrustedRepositories {
+    #[serde(default)]
+    repositories: serde_json::Value,
+    #[serde(default)]
+    updated_at: serde_json::Value,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct Post0015CacheRepositories {
+    trusted: serde_json::Value,
+    updated_at: serde_json::Value,
+}
+
+pub fn convert_cache_pre_0_0_15() -> io::Result<()> {
+    let cache_path = PathBuf::from(global_config().cache.path.clone());
+
+    // If the cache path does not exist, there is nothing to do
+    if !cache_path.exists() {
+        return Ok(());
+    }
+
+    // If the cache path exists and is a directory, there is nothing to do
+    if cache_path.is_dir() {
+        return Ok(());
+    }
+
+    // If the cache path exists and is a file, we need to prepare the directory
+    let tmp_dir = env::temp_dir();
+    let tmp_dir_path = loop {
+        let tmp_dir_path = tmp_dir.join(format!("omni-cache.d-{}", uuid::Uuid::new_v4()));
+        if let Ok(()) = std::fs::create_dir_all(&tmp_dir_path) {
+            break tmp_dir_path;
+        }
+    };
+
+    // Read the contents of the cache file into a Pre0015Cache struct
+    let pre0015_cache_file = File::open(&cache_path)?;
+    let pre0015_cache: Pre0015Cache = serde_json::from_reader(pre0015_cache_file)?;
+
+    // Write each cache category to a separate file in our temporary directory
+    if pre0015_cache.asdf_operation != serde_json::Value::Null {
+        let asdf_operation_file_path = tmp_dir_path.join("asdf_operation.json");
+        let mut asdf_operation_file = File::create(asdf_operation_file_path)?;
+        asdf_operation_file
+            .write_all(serde_json::to_string(&pre0015_cache.asdf_operation)?.as_bytes())?;
+    }
+    if pre0015_cache.homebrew_operation != serde_json::Value::Null {
+        let homebrew_operation_file_path = tmp_dir_path.join("homebrew_operation.json");
+        let mut homebrew_operation_file = File::create(homebrew_operation_file_path)?;
+        homebrew_operation_file
+            .write_all(serde_json::to_string(&pre0015_cache.homebrew_operation)?.as_bytes())?;
+    }
+    if pre0015_cache.omni_path_updates != serde_json::Value::Null {
+        let omni_path_updates_file_path = tmp_dir_path.join("omnipath.json");
+        let mut omni_path_updates_file = File::create(omni_path_updates_file_path)?;
+        omni_path_updates_file
+            .write_all(serde_json::to_string(&pre0015_cache.omni_path_updates)?.as_bytes())?;
+    }
+    if pre0015_cache.trusted_repositories.repositories != serde_json::Value::Null {
+        let repositories_file_path = tmp_dir_path.join("repositories.json");
+        let mut repositories_file = File::create(repositories_file_path)?;
+        // Since we're changing the format, we're rewriting this into a new struct
+        let post0015_repositories = Post0015CacheRepositories {
+            trusted: pre0015_cache.trusted_repositories.repositories,
+            updated_at: pre0015_cache.trusted_repositories.updated_at,
+        };
+        repositories_file.write_all(serde_json::to_string(&post0015_repositories)?.as_bytes())?;
+    }
+    if pre0015_cache.up_environments != serde_json::Value::Null {
+        let up_environments_file_path = tmp_dir_path.join("up_environments.json");
+        let mut up_environments_file = File::create(up_environments_file_path)?;
+        up_environments_file
+            .write_all(serde_json::to_string(&pre0015_cache.up_environments)?.as_bytes())?;
+    }
+
+    // Rename the current cache file to a backup file, just in case
+    let backup_file_path = cache_path.with_extension("json.pre0015");
+    std::fs::rename(&cache_path, backup_file_path)?;
+
+    // Move the temporary directory to the cache path
+    std::fs::rename(&tmp_dir_path, &cache_path)?;
+
+    Ok(())
+}

--- a/src/internal/cache/migration/pre0029.rs
+++ b/src/internal/cache/migration/pre0029.rs
@@ -1,0 +1,300 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::cache::up_environments::UpEnvironment;
+use crate::internal::cache::AsdfOperationCache;
+use crate::internal::cache::GithubReleaseOperationCache;
+use crate::internal::cache::HomebrewOperationCache;
+use crate::internal::cache::UpEnvironmentsCache;
+use crate::internal::config::global_config;
+use crate::internal::git_env_fresh;
+use crate::internal::ORG_LOADER;
+
+// In 0.0.29, we are changing the format of the up environments cache to handle
+// versioned environments. This means that instead of having a list of workdir
+// environments, that list will target a specific version of the environment,
+// which will be stored in a separate list.
+// This allows to build a new environment without breaking the current one in
+// case of any issue, and to keep traces of previous environments and when they
+// were used. However, this requires the following changes:
+// - up_environments.json
+//     - need to generate version names for the entries and convert them to
+//       the new format, from { "env": { "repo" => env } } to
+//       { "workdir_env": { "repo" => "version" },
+//         "versioned_env": { "version" => env },
+//         "history": [ { "wd": "repo",
+//                        "sha": "head_sha",
+//                        "env": "version",
+//                        "from": "date" } ],
+// - github_release_operation.json
+//    - Replace the references to the repository by references to the versions
+// - asdf_operation.json
+//    - Replace the references to the repository by references to the versions
+// - homebrew_operation.json
+//    - Replace the references to the repository by references to the versions
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Pre0029UpEnvironmentsCache {
+    env: HashMap<String, UpEnvironment>,
+    updated_at: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Post0029UpEnvironmentsCache {
+    workdir_env: HashMap<String, String>,
+    versioned_env: HashMap<String, UpEnvironment>,
+    history: Vec<Post0029UpEnvironmentHistoryEntry>,
+    updated_at: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Post0029UpEnvironmentHistoryEntry {
+    #[serde(rename = "wd")]
+    workdir_id: String,
+    #[serde(rename = "sha")]
+    head_sha: String,
+    #[serde(rename = "env")]
+    env_version_id: String,
+    #[serde(rename = "from")]
+    used_from_date: serde_json::Value,
+}
+
+pub fn convert_cache_pre_0_0_29() -> io::Result<()> {
+    let cache_path = PathBuf::from(global_config().cache.path.clone());
+
+    // If the cache path does not exist, there is nothing to do
+    if !cache_path.exists() {
+        return Ok(());
+    }
+
+    // If the up_enviroments.json file does not exist, there is nothing to do
+    let up_environments_path = cache_path.join("up_environments.json");
+    if !up_environments_path.exists() {
+        return Ok(());
+    }
+
+    // Read the contents of the UpEnvironments cache file into a Pre0029UpEnvironmentsCache object
+    let pre0029_cache_file = File::open(&up_environments_path)?;
+    let pre0029_cache: Pre0029UpEnvironmentsCache =
+        match serde_json::from_reader(pre0029_cache_file) {
+            Ok(cache) => cache,
+            Err(err) => {
+                // If the error is that we are missing the field `env`, we can assume
+                // that the cache is already in the new format, so we can just return
+                // without doing anything
+                if err.to_string().contains("missing field `env`") {
+                    return Ok(());
+                }
+                return Err(err.into());
+            }
+        };
+
+    // Nothing to do if the cache is empty
+    if pre0029_cache.env.is_empty() {
+        return Ok(());
+    }
+
+    // Prepare a directory to dump the updated cache files
+    let tmp_dir = env::temp_dir();
+    let tmp_dir_path = loop {
+        let tmp_dir_path = tmp_dir.join(format!("omni-cache.d-{}", uuid::Uuid::new_v4()));
+        if let Ok(()) = std::fs::create_dir_all(&tmp_dir_path) {
+            break tmp_dir_path;
+        }
+    };
+
+    // First, go over the UpEnvironment to convert in the new format
+    let mut post0029_cache = Post0029UpEnvironmentsCache {
+        workdir_env: HashMap::new(),
+        versioned_env: HashMap::new(),
+        history: Vec::new(),
+        updated_at: pre0029_cache.updated_at,
+    };
+    for (wd_id, env) in pre0029_cache.env {
+        let version = UpEnvironmentsCache::generate_version_id(&wd_id);
+        post0029_cache
+            .workdir_env
+            .insert(wd_id.clone(), version.clone());
+        post0029_cache.versioned_env.insert(version.clone(), env);
+
+        // Use the workdir_id to resolve the head sha of the repository, if possible
+        // otherwise skip the entry entirely
+        let repo_path = ORG_LOADER.find_repo(&wd_id, false, false, false);
+        let repo_path = match repo_path {
+            Some(path) => path.to_string_lossy().to_string(),
+            None => continue,
+        };
+        let head_sha = match git_env_fresh(&repo_path).commit() {
+            Some(sha) => sha.to_string(),
+            None => continue,
+        };
+        post0029_cache
+            .history
+            .push(Post0029UpEnvironmentHistoryEntry {
+                workdir_id: wd_id,
+                head_sha: head_sha,
+                env_version_id: version,
+                used_from_date: post0029_cache.updated_at.clone(),
+            });
+    }
+
+    // Write the new cache to the temporary directory
+    let post0029_cache_path = tmp_dir_path.join("up_environments.json");
+    let mut post0029_cache_file = File::create(&post0029_cache_path)?;
+    post0029_cache_file.write_all(serde_json::to_string(&post0029_cache)?.as_bytes())?;
+
+    // Keep track of the files that were modified
+    let mut modified_files = vec![post0029_cache_path];
+
+    // Now we need to go over the other resources, and replace the references to the
+    // repositories by references to the versions; we can use the cache handlers to get
+    // the objects, and then we can dump the new version in the temporary directory
+
+    // First the AsdfOperationCache
+    let asdf_operation_path = cache_path.join("asdf_operation.json");
+    let asdf_operation: Option<AsdfOperationCache> = match File::open(&asdf_operation_path) {
+        Ok(file) => serde_json::from_reader(file).ok(),
+        Err(_) => None,
+    };
+    if let Some(asdf_operation) = asdf_operation {
+        // Create a copy
+        let mut asdfop = asdf_operation.clone();
+
+        // Go over the .installed objects, and modify any reference in the .required_by
+        // parameter if one of the wd_id appears there
+        let mut updated = false;
+        for install in asdfop.installed.iter_mut() {
+            let mut required_by = install.required_by.clone();
+            for wd_id in install.required_by.iter() {
+                if let Some(version) = post0029_cache.workdir_env.get(wd_id) {
+                    required_by.remove(wd_id);
+                    required_by.insert(version.clone());
+                }
+            }
+            if required_by != install.required_by {
+                install.required_by = required_by;
+                updated = true;
+            }
+        }
+
+        if updated {
+            // Write the new cache to the temporary directory
+            let asdf_operation_path = tmp_dir_path.join("asdf_operation.json");
+            let mut asdf_operation_file = File::create(&asdf_operation_path)?;
+            asdf_operation_file.write_all(serde_json::to_string(&asdfop)?.as_bytes())?;
+
+            modified_files.push(asdf_operation_path);
+        }
+    }
+
+    // The HomebrewOperationCache
+    let homebrew_operation_path = cache_path.join("homebrew_operation.json");
+    let homebrew_operation: Option<HomebrewOperationCache> =
+        match File::open(&homebrew_operation_path) {
+            Ok(file) => serde_json::from_reader(file).ok(),
+            Err(_) => None,
+        };
+    if let Some(homebrew_operation) = homebrew_operation {
+        // Create a copy
+        let mut homebrewop = homebrew_operation.clone();
+
+        // Go over the .installed and .tapped objects, and modify any reference
+        // in the .required_by parameter if one of the wd_id appears there
+        let mut updated = false;
+
+        for install in homebrewop.installed.iter_mut() {
+            let mut required_by = install.required_by.clone();
+            for wd_id in install.required_by.iter() {
+                if let Some(version) = post0029_cache.workdir_env.get(wd_id) {
+                    required_by.remove(wd_id);
+                    required_by.insert(version.clone());
+                }
+            }
+            if required_by != install.required_by {
+                install.required_by = required_by;
+                updated = true;
+            }
+        }
+
+        for tap in homebrewop.tapped.iter_mut() {
+            let mut required_by = tap.required_by.clone();
+            for wd_id in tap.required_by.iter() {
+                if let Some(version) = post0029_cache.workdir_env.get(wd_id) {
+                    required_by.remove(wd_id);
+                    required_by.insert(version.clone());
+                }
+            }
+            if required_by != tap.required_by {
+                tap.required_by = required_by;
+                updated = true;
+            }
+        }
+
+        if updated {
+            // Write the new cache to the temporary directory
+            let homebrew_operation_path = tmp_dir_path.join("homebrew_operation.json");
+            let mut homebrew_operation_file = File::create(&homebrew_operation_path)?;
+            homebrew_operation_file.write_all(serde_json::to_string(&homebrewop)?.as_bytes())?;
+
+            modified_files.push(homebrew_operation_path);
+        }
+    }
+
+    // The GithubReleaseOperationCache
+    let github_release_operation_path = cache_path.join("github_release_operation.json");
+    let github_release_operation: Option<GithubReleaseOperationCache> =
+        match File::open(&github_release_operation_path) {
+            Ok(file) => serde_json::from_reader(file).ok(),
+            Err(_) => None,
+        };
+    if let Some(github_release_operation) = github_release_operation {
+        // Create a copy
+        let mut ghrop = github_release_operation.clone();
+
+        // Go over the .installed objects, and modify any reference in the .required_by
+        // parameter if one of the wd_id appears there
+        let mut updated = false;
+        for install in ghrop.installed.iter_mut() {
+            let mut required_by = install.required_by.clone();
+            for wd_id in install.required_by.iter() {
+                if let Some(version) = post0029_cache.workdir_env.get(wd_id) {
+                    required_by.remove(wd_id);
+                    required_by.insert(version.clone());
+                }
+            }
+            if required_by != install.required_by {
+                install.required_by = required_by;
+                updated = true;
+            }
+        }
+
+        if updated {
+            // Write the new cache to the temporary directory
+            let github_release_operation_path = tmp_dir_path.join("github_release_operation.json");
+            let mut github_release_operation_file = File::create(&github_release_operation_path)?;
+            github_release_operation_file.write_all(serde_json::to_string(&ghrop)?.as_bytes())?;
+
+            modified_files.push(github_release_operation_path);
+        }
+    }
+
+    // Finally, go over the files that were modified, rename the original files and move
+    // the new files to the original location
+    for file in modified_files {
+        let original_file = cache_path.join(file.file_name().unwrap());
+        std::fs::rename(&original_file, original_file.with_extension("json.pre0029"))?;
+        std::fs::rename(file, original_file)?;
+    }
+
+    // And remove the temporary directory
+    std::fs::remove_dir_all(tmp_dir_path)?;
+
+    Ok(())
+}

--- a/src/internal/cache/migration/pre0029.rs
+++ b/src/internal/cache/migration/pre0029.rs
@@ -12,7 +12,6 @@ use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::AsdfOperationCache;
 use crate::internal::cache::GithubReleaseOperationCache;
 use crate::internal::cache::HomebrewOperationCache;
-use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config::global_config;
 use crate::internal::git_env_fresh;
 use crate::internal::ORG_LOADER;
@@ -120,7 +119,7 @@ pub fn convert_cache_pre_0_0_29() -> io::Result<()> {
     for (wd_id, env) in pre0029_cache.env {
         let uuid = uuid::Uuid::new_v4();
         let short_uuid = uuid.to_string()[..8].to_string();
-        let version = format!("{}%{}", workdir_id, short_uuid);
+        let version = format!("{}%{}", wd_id, short_uuid);
 
         post0029_cache
             .workdir_env

--- a/src/internal/cache/migration/pre0029.rs
+++ b/src/internal/cache/migration/pre0029.rs
@@ -118,7 +118,10 @@ pub fn convert_cache_pre_0_0_29() -> io::Result<()> {
         updated_at: pre0029_cache.updated_at,
     };
     for (wd_id, env) in pre0029_cache.env {
-        let version = UpEnvironmentsCache::generate_version_id(&wd_id);
+        let uuid = uuid::Uuid::new_v4();
+        let short_uuid = uuid.to_string()[..8].to_string();
+        let version = format!("{}%{}", workdir_id, short_uuid);
+
         post0029_cache
             .workdir_env
             .insert(wd_id.clone(), version.clone());

--- a/src/internal/cache/migration/pre0029.rs
+++ b/src/internal/cache/migration/pre0029.rs
@@ -139,7 +139,7 @@ pub fn convert_cache_pre_0_0_29() -> io::Result<()> {
             .history
             .push(Post0029UpEnvironmentHistoryEntry {
                 workdir_id: wd_id,
-                head_sha: head_sha,
+                head_sha,
                 env_version_id: version,
                 used_from_date: post0029_cache.updated_at.clone(),
             });

--- a/src/internal/cache/mod.rs
+++ b/src/internal/cache/mod.rs
@@ -25,6 +25,8 @@ pub(crate) use prompts::PromptsCache;
 pub(crate) mod repositories;
 pub(crate) use repositories::RepositoriesCache;
 
+mod migration;
+
 pub(crate) mod up_environments;
 pub(crate) use up_environments::UpEnvironmentsCache;
 

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -42,12 +42,6 @@ pub struct UpEnvironmentsCache {
 }
 
 impl UpEnvironmentsCache {
-    pub fn generate_version_id(workdir_id: &str) -> String {
-        let uuid = uuid::Uuid::new_v4();
-        let short_uuid = uuid.to_string()[..8].to_string();
-        format!("{}%{}", workdir_id, short_uuid)
-    }
-
     fn updated(&mut self) {
         self.updated_at = OffsetDateTime::now_utc();
     }

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -498,11 +498,9 @@ impl UpEnvironmentHistory {
         // Go over all the entries to make sure that we have only one open per work directory
         let mut workdirs_open: BTreeSet<String> = BTreeSet::new();
         for entry in self.entries.iter_mut() {
-            if entry.is_open() {
-                if !workdirs_open.insert(entry.workdir_id.clone()) {
-                    // If we already have an open entry for this workdir, close this one
-                    entry.used_until_date = Some(now);
-                }
+            if entry.is_open() && !workdirs_open.insert(entry.workdir_id.clone()) {
+                // If we already have an open entry for this workdir, close this one
+                entry.used_until_date = Some(now);
             }
         }
 

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -1,11 +1,14 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::io;
 use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
+use time::Duration;
 use time::OffsetDateTime;
 
 use crate::internal::cache::handler::exclusive;
@@ -16,188 +19,50 @@ use crate::internal::cache::utils;
 use crate::internal::cache::utils::Empty;
 use crate::internal::cache::CacheObject;
 use crate::internal::config;
+use crate::internal::config::global_config;
+use crate::internal::config::parser::EnvConfig;
 use crate::internal::config::parser::EnvOperationConfig;
 use crate::internal::config::parser::EnvOperationEnum;
 use crate::internal::config::up::utils::get_config_mod_times;
 use crate::internal::env::data_home;
+use crate::internal::env::now as omni_now;
 
 const UP_ENVIRONMENTS_CACHE_NAME: &str = "up_environments";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpEnvironmentsCache {
-    #[serde(default = "HashMap::new", skip_serializing_if = "HashMap::is_empty")]
-    pub env: HashMap<String, UpEnvironment>,
+    #[serde(default = "BTreeMap::new", skip_serializing_if = "BTreeMap::is_empty")]
+    pub workdir_env: BTreeMap<String, String>,
+    #[serde(default = "BTreeMap::new", skip_serializing_if = "BTreeMap::is_empty")]
+    pub versioned_env: BTreeMap<String, UpEnvironment>,
+    #[serde(default, skip_serializing_if = "UpEnvironmentHistory::is_empty")]
+    pub history: UpEnvironmentHistory,
     #[serde(default = "utils::origin_of_time", with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
 }
 
 impl UpEnvironmentsCache {
+    pub fn generate_version_id(workdir_id: &str) -> String {
+        let uuid = uuid::Uuid::new_v4();
+        let short_uuid = uuid.to_string()[..8].to_string();
+        format!("{}%{}", workdir_id, short_uuid)
+    }
+
     fn updated(&mut self) {
         self.updated_at = OffsetDateTime::now_utc();
     }
 
-    pub fn set_config_hash(&mut self, workdir_id: &str) -> bool {
-        let config_hash = config(".").up_hash();
-        if let Some(env) = self.env.get_mut(workdir_id) {
-            env.config_hash = config_hash.to_string();
-        } else {
-            let mut env = UpEnvironment::new();
-            env.config_hash = config_hash.to_string();
-            self.env.insert(workdir_id.to_string(), env);
-        }
-        self.updated();
-        true
-    }
-
-    pub fn set_config_modtimes(&mut self, workdir_id: &str) -> bool {
-        let config_modtimes = get_config_mod_times(".");
-        if let Some(env) = self.env.get_mut(workdir_id) {
-            env.config_modtimes = config_modtimes;
-        } else {
-            let mut env = UpEnvironment::new();
-            env.config_modtimes = config_modtimes;
-            self.env.insert(workdir_id.to_string(), env);
-        }
-        self.updated();
-        true
-    }
-
-    pub fn set_env_vars(&mut self, workdir_id: &str, env_vars: Vec<EnvOperationConfig>) -> bool {
-        if let Some(env) = self.env.get_mut(workdir_id) {
-            env.env_vars = env_vars.into_iter().map(|e| e.into()).collect();
-        } else {
-            let mut env = UpEnvironment::new();
-            env.env_vars = env_vars.into_iter().map(|e| e.into()).collect();
-            self.env.insert(workdir_id.to_string(), env);
-        }
-        self.updated();
-        true
-    }
-
-    pub fn add_env_var(&mut self, workdir_id: &str, key: &str, value: &str) -> bool {
-        self.add_env_var_operation(workdir_id, key, value, EnvOperationEnum::Set)
-    }
-
-    pub fn add_env_var_operation(
-        &mut self,
-        workdir_id: &str,
-        key: &str,
-        value: &str,
-        operation: EnvOperationEnum,
-    ) -> bool {
-        let up_env_var = UpEnvVar {
-            name: key.to_string(),
-            value: Some(value.to_string()),
-            operation,
-        };
-
-        if let Some(env) = self.env.get_mut(workdir_id) {
-            env.env_vars.push(up_env_var);
-        } else {
-            let mut env = UpEnvironment::new();
-            env.env_vars.push(up_env_var);
-            self.env.insert(workdir_id.to_string(), env);
-        }
-        self.updated();
-        true
-    }
-
-    pub fn add_path(&mut self, workdir_id: &str, path: PathBuf) -> bool {
-        if let Some(env) = self.env.get_mut(workdir_id) {
-            env.paths.retain(|p| p != &path);
-            // Prepend anything that starts with the data_home()
-            if path.starts_with(data_home()) {
-                env.paths.insert(0, path);
-            } else {
-                env.paths.push(path);
-            }
-        } else {
-            let mut env = UpEnvironment::new();
-            env.paths.push(path);
-            self.env.insert(workdir_id.to_string(), env);
-        }
-        self.updated();
-        true
-    }
-
-    pub fn add_paths(&mut self, workdir_id: &str, paths: Vec<PathBuf>) -> bool {
-        for path in paths {
-            self.add_path(workdir_id, path);
-        }
-        true
-    }
-
-    pub fn add_version(
-        &mut self,
-        workdir_id: &str,
-        tool: &str,
-        tool_real_name: Option<&str>,
-        version: &str,
-        dirs: BTreeSet<String>,
-    ) -> bool {
-        let mut dirs = dirs;
-
-        if let Some(wd_up_env) = self.env.get(workdir_id) {
-            for exists in wd_up_env.versions.iter() {
-                if exists.tool == tool && exists.version == version {
-                    dirs.remove(&exists.dir);
-                    if dirs.is_empty() {
-                        break;
-                    }
-                }
-            }
-        }
-
-        if dirs.is_empty() {
-            return false;
-        }
-
-        let wd_up_env = self.env.get_mut(workdir_id);
-        let wd_up_env = if let Some(wd_up_env) = wd_up_env {
-            wd_up_env
-        } else {
-            let env = UpEnvironment::new();
-            self.env.insert(workdir_id.to_string(), env);
-            self.env.get_mut(workdir_id).unwrap()
-        };
-
-        for dir in dirs {
-            wd_up_env
-                .versions
-                .push(UpVersion::new(tool, tool_real_name, version, &dir));
-        }
-
-        self.updated();
-        true
-    }
-
-    pub fn add_version_data_path(
-        &mut self,
-        workdir_id: &str,
-        tool: &str,
-        version: &str,
-        dir: &str,
-        data_path: &str,
-    ) -> bool {
-        if let Some(wd_up_env) = self.env.get_mut(workdir_id) {
-            for exists in wd_up_env.versions.iter_mut() {
-                if exists.tool == tool && exists.version == version && exists.dir == dir {
-                    exists.data_path = Some(data_path.to_string());
-                    self.updated();
-                    return true;
-                }
-            }
-        }
-
-        false
-    }
-
     pub fn contains(&self, workdir_id: &str) -> bool {
-        self.env.contains_key(workdir_id)
+        self.workdir_env.contains_key(workdir_id)
     }
 
     pub fn get_env(&self, workdir_id: &str) -> Option<&UpEnvironment> {
-        self.env.get(workdir_id)
+        let env_version_id = self.workdir_env.get(workdir_id)?;
+        self.get_env_version(env_version_id)
+    }
+
+    pub fn get_env_version(&self, env_version_id: &str) -> Option<&UpEnvironment> {
+        self.versioned_env.get(env_version_id)
     }
 
     pub fn clear(&mut self, workdir_id: &str) -> bool {
@@ -205,23 +70,81 @@ impl UpEnvironmentsCache {
             return false;
         }
 
-        self.env.remove(workdir_id);
-
+        self.workdir_env.remove(workdir_id);
+        self.history.close(workdir_id);
         self.updated();
         true
+    }
+
+    pub fn assign_environment(
+        &mut self,
+        workdir_id: &str,
+        head_sha: Option<String>,
+        environment: &mut UpEnvironment,
+    ) -> (bool, String) {
+        let mut new_env = true;
+        let env_hash = environment.hash_string();
+        let env_version_id = format!("{}%{}", workdir_id, env_hash);
+
+        // Check if the version already exists in the cache
+        if let Some(existing_env) = self.versioned_env.get_mut(&env_version_id) {
+            existing_env.assigning();
+            new_env = false;
+        } else {
+            environment.assigning();
+            self.versioned_env
+                .insert(env_version_id.clone(), environment.clone());
+        }
+
+        self.workdir_env
+            .insert(workdir_id.to_string(), env_version_id.clone());
+        self.history.add(workdir_id, head_sha, &env_version_id);
+
+        self.cleanup();
+        (new_env, env_version_id)
+    }
+
+    pub fn environment_ids(&self) -> BTreeSet<String> {
+        self.versioned_env.keys().cloned().collect()
+    }
+
+    pub fn cleanup(&mut self) {
+        let config = global_config().cache.environment;
+        self.history.cleanup(
+            Some(Duration::seconds(config.retention as i64)),
+            config.max_per_workdir,
+            config.max_total,
+        );
+
+        // Get all the environment IDs that are in the history or active
+        // (active should also be in the history but.. just in case)
+        let keep_env_ids: Vec<_> = self
+            .workdir_env
+            .values()
+            .chain(self.history.environment_ids().iter())
+            .cloned()
+            .collect();
+
+        // Remove any environment that is not in the history or active
+        self.versioned_env.retain(|id, _| keep_env_ids.contains(id));
+
+        // Mark as updated
+        self.updated();
     }
 }
 
 impl Empty for UpEnvironmentsCache {
     fn is_empty(&self) -> bool {
-        self.env.is_empty()
+        self.workdir_env.is_empty() && self.versioned_env.is_empty()
     }
 }
 
 impl CacheObject for UpEnvironmentsCache {
     fn new_empty() -> Self {
         Self {
-            env: HashMap::new(),
+            workdir_env: BTreeMap::new(),
+            versioned_env: BTreeMap::new(),
+            history: UpEnvironmentHistory::default(),
             updated_at: utils::origin_of_time(),
         }
     }
@@ -246,18 +169,41 @@ impl CacheObject for UpEnvironmentsCache {
     }
 }
 
+/// The environment configuration for a work directory
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpEnvironment {
+    /// The versions of the tools to be loaded in the environment
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub versions: Vec<UpVersion>,
+    /// The paths to add to the PATH environment variable
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub paths: Vec<PathBuf>,
+    /// The environment variables to set
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env_vars: Vec<UpEnvVar>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub config_modtimes: HashMap<String, u64>,
+    /// The modification times of the configuration files
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub config_modtimes: BTreeMap<String, u64>,
+    /// The hash of the configuration files
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub config_hash: String,
+    /// The time this environment was last updated
+    #[serde(
+        default = "utils::origin_of_time",
+        with = "time::serde::rfc3339",
+        skip_serializing_if = "utils::is_origin_of_time"
+    )]
+    pub last_assigned_at: OffsetDateTime,
+}
+
+impl Hash for UpEnvironment {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.versions.hash(state);
+        self.paths.hash(state);
+        self.env_vars.hash(state);
+        self.config_modtimes.hash(state);
+        self.config_hash.hash(state);
+    }
 }
 
 impl UpEnvironment {
@@ -266,9 +212,22 @@ impl UpEnvironment {
             versions: Vec::new(),
             paths: Vec::new(),
             env_vars: Vec::new(),
-            config_modtimes: HashMap::new(),
+            config_modtimes: BTreeMap::new(),
             config_hash: String::new(),
+            last_assigned_at: utils::origin_of_time(),
         }
+    }
+
+    pub fn init(mut self) -> Self {
+        self.config_hash = config(".").up_hash();
+        self.config_modtimes = get_config_mod_times(".");
+        self
+    }
+
+    pub fn hash_string(&self) -> String {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut hasher);
+        format!("{:x}", hasher.finish())
     }
 
     pub fn versions_for_dir(&self, dir: &str) -> Vec<UpVersion> {
@@ -295,9 +254,101 @@ impl UpEnvironment {
 
         versions.values().cloned().collect()
     }
+
+    pub fn assigning(&mut self) {
+        self.last_assigned_at = OffsetDateTime::now_utc();
+    }
+
+    pub fn add_env_var(&mut self, key: &str, value: &str) -> bool {
+        self.add_env_var_operation(key, value, EnvOperationEnum::Set)
+    }
+
+    pub fn add_env_var_operation(
+        &mut self,
+        key: &str,
+        value: &str,
+        operation: EnvOperationEnum,
+    ) -> bool {
+        let up_env_var = UpEnvVar {
+            name: key.to_string(),
+            value: Some(value.to_string()),
+            operation,
+        };
+
+        self.env_vars.push(up_env_var);
+
+        true
+    }
+
+    pub fn add_path(&mut self, path: PathBuf) -> bool {
+        self.paths.retain(|p| p != &path);
+
+        // Prepend anything that starts with the data_home()
+        if path.starts_with(data_home()) {
+            self.paths.insert(0, path);
+        } else {
+            self.paths.push(path);
+        }
+
+        true
+    }
+
+    pub fn add_paths(&mut self, paths: Vec<PathBuf>) -> bool {
+        for path in paths {
+            self.add_path(path);
+        }
+        true
+    }
+
+    pub fn add_version(
+        &mut self,
+        tool: &str,
+        tool_real_name: Option<&str>,
+        version: &str,
+        dirs: BTreeSet<String>,
+    ) -> bool {
+        let mut dirs = dirs;
+
+        for exists in self.versions.iter() {
+            if exists.tool == tool && exists.version == version {
+                dirs.remove(&exists.dir);
+                if dirs.is_empty() {
+                    break;
+                }
+            }
+        }
+
+        if dirs.is_empty() {
+            return false;
+        }
+
+        for dir in dirs {
+            self.versions
+                .push(UpVersion::new(tool, tool_real_name, version, &dir));
+        }
+
+        true
+    }
+
+    pub fn add_version_data_path(
+        &mut self,
+        tool: &str,
+        version: &str,
+        dir: &str,
+        data_path: &str,
+    ) -> bool {
+        for exists in self.versions.iter_mut() {
+            if exists.tool == tool && exists.version == version && exists.dir == dir {
+                exists.data_path = Some(data_path.to_string());
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash)]
 pub struct UpVersion {
     pub tool: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -321,7 +372,7 @@ impl UpVersion {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash)]
 pub struct UpEnvVar {
     #[serde(
         rename = "n",
@@ -352,6 +403,423 @@ impl From<EnvOperationConfig> for UpEnvVar {
             name: env_op.name,
             value: env_op.value,
             operation: env_op.operation,
+        }
+    }
+}
+
+impl From<EnvConfig> for Vec<UpEnvVar> {
+    fn from(env_config: EnvConfig) -> Self {
+        env_config
+            .operations
+            .into_iter()
+            .map(|operation| operation.into())
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(transparent)]
+pub struct UpEnvironmentHistory {
+    pub entries: Vec<UpEnvironmentHistoryEntry>,
+}
+
+impl Empty for UpEnvironmentHistory {
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl UpEnvironmentHistory {
+    /// Adds a new entry if needed
+    pub fn add(
+        &mut self,
+        workdir_id: &str,
+        head_sha: Option<String>,
+        env_version_id: &str,
+    ) -> bool {
+        // Check if we have an open entry for this workdir
+        if let Some(open_entry) = self
+            .entries
+            .iter_mut()
+            .rev()
+            .find(|entry| entry.workdir_id == workdir_id && entry.is_open())
+        {
+            // Check if the environment version is different, in which case
+            // we can return right away since we are already on the correct
+            // version in the history
+            if open_entry.env_version_id == env_version_id && open_entry.head_sha == head_sha {
+                return false;
+            }
+
+            // Close the current entry
+            open_entry.used_until_date = Some(omni_now());
+        }
+
+        // If we get here, we need to add the new entry, at the beginning of the list
+        // to keep the most recent entries at the top
+        self.entries.insert(
+            0,
+            UpEnvironmentHistoryEntry::new(workdir_id, head_sha, env_version_id),
+        );
+
+        // Return true to indicate that we added a new entry
+        true
+    }
+
+    /// Closes the most recent open entry for the given workdir
+    pub fn close(&mut self, workdir_id: &str) -> bool {
+        if let Some(open_entry) = self
+            .entries
+            .iter_mut()
+            .rev()
+            .find(|entry| entry.workdir_id == workdir_id && entry.is_open())
+        {
+            open_entry.used_until_date = Some(omni_now());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Cleans up history entries based on given constraints:
+    /// - Ensures only one open entry per workdir (closes duplicates)
+    /// - If max_per_workdir specified, keeps only that many entries per workdir (keeping open ones)
+    /// - Removes entries older than max_retention if specified
+    /// - Limits total entries to max_total if specified
+    /// - Sorts entries with most recent at the top (open entries first)
+    pub fn cleanup(
+        &mut self,
+        max_retention: Option<Duration>,
+        max_per_workdir: Option<usize>,
+        max_total: Option<usize>,
+    ) {
+        let now = omni_now();
+
+        // Go over all the entries to make sure that we have only one open per work directory
+        let mut workdirs_open: BTreeSet<String> = BTreeSet::new();
+        for entry in self.entries.iter_mut() {
+            if entry.is_open() {
+                if !workdirs_open.insert(entry.workdir_id.clone()) {
+                    // If we already have an open entry for this workdir, close this one
+                    entry.used_until_date = Some(now);
+                }
+            }
+        }
+
+        // Apply retention policy if specified
+        if let Some(retention) = max_retention {
+            let cutoff = now - retention;
+            self.entries.retain(|entry| {
+                entry.is_open() || entry.used_until_date.map_or(true, |date| date > cutoff)
+            });
+        }
+
+        // Sort entries with most recent at top (open entries first)
+        self.entries.sort_by(|a, b| {
+            match (a.used_until_date, b.used_until_date) {
+                (None, None) => b.used_from_date.cmp(&a.used_from_date), // Both open, compare by start date
+                (None, Some(_)) => std::cmp::Ordering::Less, // a is open, should come first
+                (Some(_), None) => std::cmp::Ordering::Greater, // b is open, should come first
+                (Some(date_a), Some(date_b)) => match date_b.cmp(&date_a) {
+                    std::cmp::Ordering::Equal => b.used_from_date.cmp(&a.used_from_date), // Same end date, use start date
+                    other => other,
+                },
+            }
+        });
+
+        // Apply max_per_workdir limit if specified
+        if let Some(max_per_workdir) = max_per_workdir {
+            let mut workdir_counts: HashMap<String, usize> = HashMap::new();
+            self.entries.retain(|entry| {
+                let count = workdir_counts.entry(entry.workdir_id.clone()).or_insert(0);
+                *count += 1;
+                entry.is_open() || *count <= max_per_workdir
+            });
+        }
+
+        // Apply max_total limit if specified
+        if let Some(max_total) = max_total {
+            if self.entries.len() > max_total {
+                // Count open entries to ensure we don't remove them
+                let open_count = self.entries.iter().filter(|e| e.is_open()).count();
+                let to_keep = max_total.max(open_count);
+
+                // Remove oldest closed entries until we reach max_total
+                self.entries.truncate(to_keep);
+            }
+        }
+    }
+
+    pub fn environment_ids(&self) -> BTreeSet<String> {
+        self.entries
+            .iter()
+            .map(|entry| entry.env_version_id.clone())
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpEnvironmentHistoryEntry {
+    #[serde(rename = "wd")]
+    pub workdir_id: String,
+    #[serde(rename = "sha", skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
+    #[serde(rename = "env")]
+    pub env_version_id: String,
+    #[serde(
+        rename = "from",
+        default = "utils::origin_of_time",
+        with = "time::serde::rfc3339"
+    )]
+    pub used_from_date: OffsetDateTime,
+    #[serde(
+        rename = "until",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "utils::optional_rfc3339"
+    )]
+    pub used_until_date: Option<OffsetDateTime>,
+}
+
+impl UpEnvironmentHistoryEntry {
+    pub fn new(workdir_id: &str, head_sha: Option<String>, env_version_id: &str) -> Self {
+        Self {
+            workdir_id: workdir_id.to_string(),
+            head_sha,
+            env_version_id: env_version_id.to_string(),
+            used_from_date: omni_now(),
+            used_until_date: None,
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.used_until_date.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod up_environment_history {
+        use super::*;
+
+        #[test]
+        fn test_add_first_entry() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            assert!(history.add("work1", "sha1", "env1"));
+            assert_eq!(history.entries.len(), 1);
+            assert!(history.entries[0].is_open());
+            assert_eq!(history.entries[0].workdir_id, "work1");
+            assert_eq!(history.entries[0].head_sha, "sha1");
+            assert_eq!(history.entries[0].env_version_id, "env1");
+        }
+
+        #[test]
+        fn test_add_same_environment() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            assert!(history.add("work1", "sha1", "env1"));
+            assert!(!history.add("work1", "sha1", "env1")); // Should return false for same environment
+            assert_eq!(history.entries.len(), 1);
+            assert!(history.entries[0].is_open());
+        }
+
+        #[test]
+        fn test_add_different_environment() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            assert!(history.add("work1", "sha1", "env1"));
+            assert!(history.add("work1", "sha2", "env2"));
+
+            assert_eq!(history.entries.len(), 2);
+            assert!(history.entries[0].is_open());
+            assert!(!history.entries[1].is_open());
+
+            assert_eq!(history.entries[0].env_version_id, "env2");
+            assert_eq!(history.entries[1].env_version_id, "env1");
+        }
+
+        #[test]
+        fn test_add_multiple_workdirs() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            assert!(history.add("work1", "sha1", "env1"));
+            assert!(history.add("work2", "sha2", "env2"));
+
+            assert_eq!(history.entries.len(), 2);
+            // Both entries should be open since they're for different workdirs
+            assert!(history.entries.iter().all(|e| e.is_open()));
+        }
+
+        #[test]
+        fn test_cleanup_single_open_per_workdir() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            // Add multiple open entries for same workdir
+            history.add("work1", "sha1", "env1");
+            // Manually add another open entry for the same workdir
+            history
+                .entries
+                .push(UpEnvironmentHistoryEntry::new("work1", "sha2", "env2"));
+
+            history.cleanup(None, None, None);
+
+            // Should only have one open entry per workdir
+            assert_eq!(history.entries.iter().filter(|e| e.is_open()).count(), 1);
+        }
+
+        #[test]
+        fn test_cleanup_max_per_workdir() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            // Add multiple entries for same workdir
+            history.add("work1", "sha1", "env1");
+            history.add("work1", "sha2", "env2");
+            history.add("work1", "sha3", "env3");
+
+            history.cleanup(None, Some(2), None);
+
+            assert_eq!(history.entries.len(), 2);
+            // Should keep the most recent entries
+            assert!(history.entries[0].env_version_id == "env3");
+        }
+
+        #[test]
+        fn test_cleanup_retention() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+            let now = omni_now();
+
+            // Add an old entry
+            let mut old_entry = UpEnvironmentHistoryEntry::new("work1", "sha1", "env1");
+            old_entry.used_from_date = now - Duration::hours(5);
+            old_entry.used_until_date = Some(now - Duration::hours(4));
+            history.entries.push(old_entry);
+
+            // Add a recent entry
+            history.add("work1", "sha2", "env2");
+
+            history.cleanup(Some(Duration::hours(3)), None, None);
+
+            assert_eq!(history.entries.len(), 1);
+            assert_eq!(history.entries[0].env_version_id, "env2");
+        }
+
+        #[test]
+        fn test_cleanup_max_total() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+
+            // Add entries for different workdirs
+            history.add("work1", "sha1.1", "env1.1");
+            history.add("work1", "sha1.2", "env1.2");
+            history.add("work2", "sha2.1", "env2.1");
+            history.add("work2", "sha2.2", "env2.2");
+            history.add("work3", "sha3.1", "env3.1");
+            history.add("work3", "sha3.2", "env3.2");
+
+            history.cleanup(None, None, Some(5));
+
+            assert_eq!(history.entries.len(), 5);
+            // Should keep open entries
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env3.2"));
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env2.2"));
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env1.2"));
+            // And should keep the most recent closed entries
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env3.1"));
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env2.1"));
+
+            // Now try to cleanup with a max of 2
+            history.cleanup(None, None, Some(2));
+
+            assert_eq!(history.entries.len(), 3);
+            // Should still keep open entries
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env3.2"));
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env2.2"));
+            assert!(history.entries.iter().any(|e| e.env_version_id == "env1.2"));
+        }
+
+        #[test]
+        fn test_cleanup_sorting() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+            let now = omni_now();
+
+            // Add entries in mixed order with same close dates
+            let mut entry1 = UpEnvironmentHistoryEntry::new("work1", "sha1", "env1");
+            entry1.used_from_date = now - Duration::hours(3);
+            entry1.used_until_date = Some(now - Duration::hours(1));
+
+            let mut entry2 = UpEnvironmentHistoryEntry::new("work1", "sha2", "env2");
+            entry2.used_from_date = now - Duration::hours(2);
+            entry2.used_until_date = Some(now - Duration::hours(1));
+
+            let entry3 = UpEnvironmentHistoryEntry::new("work2", "sha3", "env3");
+
+            history.entries.extend([entry1, entry2, entry3]);
+
+            history.cleanup(None, None, None);
+
+            // Check sorting:
+            // 1. Open entries first
+            assert!(history.entries[0].is_open());
+            // 2. For same close dates, sort by start date
+            assert!(history.entries[1].used_from_date > history.entries[2].used_from_date);
+        }
+
+        #[test]
+        fn test_multiple_constraints() {
+            let mut history = UpEnvironmentHistory {
+                entries: Vec::new(),
+            };
+            let now = omni_now();
+
+            // Add multiple entries with various dates and states
+            for i in 0..10 {
+                let mut entry = UpEnvironmentHistoryEntry::new(
+                    &format!("work{}", i % 2),
+                    &format!("sha{}", i),
+                    &format!("env{}", i),
+                );
+                if i < 4 {
+                    entry.used_from_date = now - Duration::hours(5 - i as i64);
+                    entry.used_until_date = Some(now - Duration::hours(4 - i as i64));
+                }
+                history.entries.push(entry);
+            }
+
+            // Apply multiple constraints
+            history.cleanup(
+                Some(Duration::hours(2)), // retain only last 2 hours
+                Some(2),                  // max 2 per workdir
+                Some(3),                  // max 3 total
+            );
+
+            assert!(history.entries.len() <= 3);
+            // Should keep open entries
+            assert!(history.entries.iter().any(|e| e.is_open()));
+            // Should respect retention
+            assert!(history
+                .entries
+                .iter()
+                .all(|e| e.is_open() || e.used_until_date.unwrap() > (now - Duration::hours(2))));
         }
     }
 }

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -195,11 +195,10 @@ impl CdCommand {
             return Some(format!("{}", repo_path.display()));
         }
 
-        if let Some(repo_path) = ORG_LOADER.find_repo(
-            repo,
-            self.cli_args().include_packages,
-            !self.cli_args().locate,
-        ) {
+        let only_worktree = !self.cli_args().include_packages;
+        let allow_interactive = !self.cli_args().locate;
+        if let Some(repo_path) = ORG_LOADER.find_repo(repo, only_worktree, false, allow_interactive)
+        {
             return Some(format!("{}", repo_path.display()));
         }
 

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -223,7 +223,7 @@ impl BuiltinCommand for ConfigPathSwitchCommand {
         let mut package_path = None;
 
         if let Some(repo) = self.cli_args().repository.clone() {
-            let repo_path = ORG_LOADER.find_repo(&repo, true, false);
+            let repo_path = ORG_LOADER.find_repo(&repo, true, false, false);
             if let Some(repo_path) = repo_path {
                 let git = git_env(repo_path.to_string_lossy());
                 if git.in_repo() && git.has_origin() {

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -170,7 +170,7 @@ impl BuiltinCommand for ConfigTrustCommand {
         }
 
         let path = if let Some(repo) = &self.cli_args().repository {
-            if let Some(repo_path) = ORG_LOADER.find_repo(repo, true, false) {
+            if let Some(repo_path) = ORG_LOADER.find_repo(repo, true, false, false) {
                 repo_path
             } else {
                 omni_error!(format!("repository not found: {}", repo));

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -191,7 +191,8 @@ impl ScopeCommand {
             return Ok(());
         }
 
-        if let Some(repo_path) = ORG_LOADER.find_repo(repo, include_packages, true) {
+        let only_worktree = !include_packages;
+        if let Some(repo_path) = ORG_LOADER.find_repo(repo, only_worktree, false, true) {
             if let Err(err) = std::env::set_current_dir(&repo_path) {
                 if !silent_failure {
                     omni_error!(format!(

--- a/src/internal/config/parser/cache/mod.rs
+++ b/src/internal/config/parser/cache/mod.rs
@@ -9,3 +9,6 @@ pub(crate) use github_release::GithubReleaseCacheConfig;
 
 mod homebrew;
 pub(crate) use homebrew::HomebrewCacheConfig;
+
+mod up_environment;
+pub(crate) use up_environment::UpEnvironmentCacheConfig;

--- a/src/internal/config/parser/cache/root.rs
+++ b/src/internal/config/parser/cache/root.rs
@@ -4,12 +4,14 @@ use serde::Serialize;
 use crate::internal::config::parser::cache::AsdfCacheConfig;
 use crate::internal::config::parser::cache::GithubReleaseCacheConfig;
 use crate::internal::config::parser::cache::HomebrewCacheConfig;
+use crate::internal::config::parser::cache::UpEnvironmentCacheConfig;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::cache_home;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CacheConfig {
     pub path: String,
+    pub environment: UpEnvironmentCacheConfig,
     pub asdf: AsdfCacheConfig,
     pub github_release: GithubReleaseCacheConfig,
     pub homebrew: HomebrewCacheConfig,
@@ -19,6 +21,7 @@ impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             path: cache_home(),
+            environment: UpEnvironmentCacheConfig::default(),
             asdf: AsdfCacheConfig::default(),
             github_release: GithubReleaseCacheConfig::default(),
             homebrew: HomebrewCacheConfig::default(),
@@ -38,6 +41,8 @@ impl CacheConfig {
             None => cache_home(),
         };
 
+        let environment =
+            UpEnvironmentCacheConfig::from_config_value(config_value.get("environment"));
         let asdf = AsdfCacheConfig::from_config_value(config_value.get("asdf"));
         let github_release =
             GithubReleaseCacheConfig::from_config_value(config_value.get("github_release"));
@@ -45,6 +50,7 @@ impl CacheConfig {
 
         Self {
             path,
+            environment,
             asdf,
             github_release,
             homebrew,

--- a/src/internal/config/parser/cache/up_environment.rs
+++ b/src/internal/config/parser/cache/up_environment.rs
@@ -1,0 +1,56 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::config::utils::parse_duration_or_default;
+use crate::internal::config::ConfigValue;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpEnvironmentCacheConfig {
+    pub retention: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_per_workdir: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_total: Option<usize>,
+}
+
+impl Default for UpEnvironmentCacheConfig {
+    fn default() -> Self {
+        Self {
+            retention: Self::DEFAULT_RETENTION,
+            max_per_workdir: None,
+            max_total: None,
+        }
+    }
+}
+
+impl UpEnvironmentCacheConfig {
+    const DEFAULT_RETENTION: u64 = 7776000; // 90 days
+
+    pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let retention = parse_duration_or_default(
+            config_value.get("retention").as_ref(),
+            Self::DEFAULT_RETENTION,
+        );
+
+        let max_per_workdir = config_value
+            .get("max_per_workdir")
+            .and_then(|v| v.as_unsigned_integer())
+            .map(|v| v as usize);
+
+        let max_total = config_value
+            .get("max_total")
+            .and_then(|v| v.as_unsigned_integer())
+            .map(|v| v as usize);
+
+        Self {
+            retention,
+            max_per_workdir,
+            max_total,
+        }
+    }
+}

--- a/src/internal/config/parser/env.rs
+++ b/src/internal/config/parser/env.rs
@@ -321,7 +321,7 @@ impl Serialize for EnvOperationConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, Default, Hash)]
 pub enum EnvOperationEnum {
     #[default]
     #[serde(rename = "s", alias = "set")]

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -9,6 +9,7 @@ pub struct UpCommandConfig {
     pub auto_bootstrap: bool,
     pub notify_workdir_config_updated: bool,
     pub notify_workdir_config_available: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preferred_tools: Vec<String>,
     pub upgrade: bool,
 }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
@@ -15,6 +14,7 @@ use tokio::process::Command as TokioCommand;
 use walkdir::WalkDir;
 
 use crate::internal::cache::asdf_operation::AsdfOperationUpdateCachePluginVersions;
+use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::utils as cache_utils;
 use crate::internal::cache::AsdfOperationCache;
 use crate::internal::cache::CacheObject;
@@ -35,7 +35,7 @@ use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
-use crate::internal::dynenv::update_dynamic_env_for_command;
+use crate::internal::dynenv::update_dynamic_env_for_command_from_env;
 use crate::internal::env::data_home;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
@@ -48,6 +48,8 @@ lazy_static! {
 
 type DetectVersionFunc = fn(tool_real_name: String, path: PathBuf) -> Option<String>;
 type PostInstallFunc = fn(
+    options: &UpOptions,
+    environment: &mut UpEnvironment,
     progress_handler: &dyn ProgressHandler,
     config_value: Option<ConfigValue>,
     tool: String,
@@ -392,12 +394,11 @@ impl UpConfigAsdfBase {
         }
     }
 
-    fn update_cache(&self, progress_handler: &dyn ProgressHandler) {
-        let workdir = workdir(".");
-        let wd_id = match workdir.id() {
-            Some(wd_id) => wd_id,
-            None => return,
-        };
+    fn update_cache(
+        &self,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) {
         let version = match self.version() {
             Ok(version) => version,
             Err(_err) => return,
@@ -406,29 +407,24 @@ impl UpConfigAsdfBase {
         progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = AsdfOperationCache::exclusive(|asdf_cache| {
-            asdf_cache.add_installed(&wd_id, &self.tool, &version, self.tool_real_name.as_deref())
+            asdf_cache.add_installed(&self.tool, &version, self.tool_real_name.as_deref())
         }) {
             progress_handler.progress(format!("failed to update tool cache: {}", err));
             return;
         }
 
-        if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
-            let mut dirs = self.dirs.clone();
-            if dirs.is_empty() {
-                dirs.insert("".to_string());
-            }
-
-            up_env.add_version(
-                &wd_id,
-                &self.tool,
-                self.tool_real_name.as_deref(),
-                &version,
-                dirs.clone(),
-            )
-        }) {
-            progress_handler.progress(format!("failed to update tool cache: {}", err));
-            return;
+        // Update environment
+        let mut dirs = self.dirs.clone();
+        if dirs.is_empty() {
+            dirs.insert("".to_string());
         }
+
+        environment.add_version(
+            &self.tool,
+            self.tool_real_name.as_deref(),
+            &version,
+            dirs.clone(),
+        );
 
         progress_handler.progress("updated cache".to_string());
     }
@@ -436,18 +432,39 @@ impl UpConfigAsdfBase {
     pub fn up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         if self.up_succeeded.get().is_some() {
             return Err(UpError::Exec("up operation already attempted".to_string()));
         }
 
-        let result = self.run_up(options, progress_handler);
+        let result = self.run_up(options, environment, progress_handler);
         if let Err(err) = self.up_succeeded.set(result.is_ok()) {
             omni_warning!(format!("failed to record status of up operation: {}", err));
         }
 
         result
+    }
+
+    pub fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        let version = match self.version() {
+            Ok(version) => version,
+            Err(_err) => return Err(UpError::Exec("failed to get version".to_string())),
+        };
+
+        if let Err(err) = AsdfOperationCache::exclusive(|asdf_cache| {
+            asdf_cache.add_required_by(
+                env_version_id,
+                &self.tool,
+                &version,
+                self.tool_real_name.as_deref(),
+            )
+        }) {
+            return Err(UpError::Cache(err.to_string()));
+        }
+
+        Ok(())
     }
 
     pub fn was_upped(&self) -> bool {
@@ -457,14 +474,15 @@ impl UpConfigAsdfBase {
     fn run_up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.init(format!("{} ({}):", self.name(), self.version).light_blue());
 
         // Make sure that dependencies are installed
         let subhandler = progress_handler.subhandler(&"deps: ".light_black());
-        self.deps().up(options, &subhandler)?;
-        update_dynamic_env_for_command(".");
+        self.deps().up(options, environment, &subhandler)?;
+        update_dynamic_env_for_command_from_env(".", environment);
 
         if let Err(err) = install_asdf(progress_handler) {
             progress_handler.error();
@@ -477,14 +495,14 @@ impl UpConfigAsdfBase {
         }
 
         if self.version == "auto" {
-            return self.run_up_auto(options, progress_handler);
+            return self.run_up_auto(options, environment, progress_handler);
         }
 
         match self.resolve_and_install_version(options, progress_handler) {
             Ok(installed) => {
                 let version = self.version()?;
 
-                self.update_cache(progress_handler);
+                self.update_cache(environment, progress_handler);
 
                 if !self.post_install_funcs.is_empty() {
                     let post_install_versions = vec![AsdfToolUpVersion {
@@ -499,6 +517,8 @@ impl UpConfigAsdfBase {
 
                     for func in self.post_install_funcs.iter() {
                         if let Err(err) = func(
+                            options,
+                            environment,
                             progress_handler,
                             self.config_value.clone(),
                             self.tool.clone(),
@@ -531,6 +551,7 @@ impl UpConfigAsdfBase {
     fn run_up_auto(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.progress("detecting required versions and paths".to_string());
@@ -651,7 +672,7 @@ impl UpConfigAsdfBase {
                 already_installed_versions.push(version.clone());
             }
 
-            asdf_base.update_cache(progress_handler);
+            asdf_base.update_cache(environment, progress_handler);
         }
 
         self.actual_versions
@@ -670,6 +691,8 @@ impl UpConfigAsdfBase {
 
             for func in self.post_install_funcs.iter() {
                 if let Err(err) = func(
+                    options,
+                    environment,
                     progress_handler,
                     self.config_value.clone(),
                     self.tool.clone(),
@@ -1150,36 +1173,22 @@ impl UpConfigAsdfBase {
     }
 
     pub fn cleanup(progress_handler: &dyn ProgressHandler) -> Result<Option<String>, UpError> {
-        let workdir = workdir(".");
-        let workdir_id = match workdir.id() {
-            Some(workdir_id) => workdir_id,
-            None => return Err(UpError::Exec("failed to get workdir id".to_string())),
-        };
-
-        // Get the expected installed versions of the tool from
-        // the up environment cache
-        let mut env_tools = Vec::new();
-        if let Some(env) = UpEnvironmentsCache::get().get_env(&workdir_id) {
-            env_tools.extend(env.versions.iter().cloned());
-        }
-
-        let expected_tools = env_tools
-            .iter()
-            .map(|tool| (tool.tool.clone(), tool.version.clone()))
-            .collect::<HashSet<_>>();
-
         let mut uninstalled = Vec::new();
         if let Err(err) = AsdfOperationCache::exclusive(|asdf_cache| {
             // Update the asdf versions cache
             let mut updated = false;
             let mut to_remove = Vec::new();
 
+            let environment_ids = if asdf_cache.installed.len() > 0 {
+                UpEnvironmentsCache::get().environment_ids()
+            } else {
+                BTreeSet::new()
+            };
+
             for (idx, exists) in asdf_cache.installed.iter_mut().enumerate() {
-                if exists.required_by.contains(&workdir_id)
-                    && exists.stale()
-                    && !expected_tools.contains(&(exists.tool.clone(), exists.version.clone()))
-                {
-                    exists.required_by.retain(|id| id != &workdir_id);
+                let required_by_len = exists.required_by.len();
+                exists.required_by.retain(|id| environment_ids.contains(id));
+                if exists.required_by.len() != required_by_len {
                     updated = true;
                 }
                 if exists.removable() {

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -1179,7 +1179,7 @@ impl UpConfigAsdfBase {
             let mut updated = false;
             let mut to_remove = Vec::new();
 
-            let environment_ids = if asdf_cache.installed.len() > 0 {
+            let environment_ids = if !asdf_cache.installed.is_empty() {
                 UpEnvironmentsCache::get().environment_ids()
             } else {
                 BTreeSet::new()

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -222,7 +222,7 @@ impl UpConfig {
         // as required by the `assigned_environment`
         if new_env {
             progress_handler.progress("committing environment dependencies".to_string());
-            if let Err(err) = self.commit(&options, &assigned_environment) {
+            if let Err(err) = self.commit(options, &assigned_environment) {
                 progress_handler.error_with_message(format!(
                     "failed to commit environment dependencies: {}",
                     err

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -301,7 +301,7 @@ impl UpConfigGithubReleases {
 
             let mut updated = false;
 
-            let environment_ids = if ghrelease.installed.len() > 0 {
+            let environment_ids = if !ghrelease.installed.is_empty() {
                 UpEnvironmentsCache::get().environment_ids()
             } else {
                 BTreeSet::new()

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -761,11 +761,10 @@ impl UpConfigGithubRelease {
     }
 
     pub fn was_upped(&self) -> bool {
-        match self.was_handled.get() {
-            Some(GithubReleaseHandled::Handled) => true,
-            Some(GithubReleaseHandled::Noop) => true,
-            _ => false,
-        }
+        matches!(
+            self.was_handled.get(),
+            Some(GithubReleaseHandled::Handled) | Some(GithubReleaseHandled::Noop)
+        )
     }
 
     pub fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -24,6 +24,7 @@ use once_cell::sync::Lazy;
 
 use crate::internal::cache::github_release::GithubReleaseAsset;
 use crate::internal::cache::github_release::GithubReleasesSelector;
+use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::utils as cache_utils;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::GithubReleaseOperationCache;
@@ -45,6 +46,7 @@ use crate::internal::config::ConfigValue;
 use crate::internal::env::data_home;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
+use std::collections::BTreeSet;
 
 const GITHUB_API_URL: &str = "https://api.github.com";
 
@@ -157,10 +159,11 @@ impl UpConfigGithubReleases {
     pub fn up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         if self.releases.len() == 1 {
-            return self.releases[0].up(options, progress_handler);
+            return self.releases[0].up(options, environment, progress_handler);
         }
 
         progress_handler.init("github releases:".light_blue());
@@ -183,14 +186,30 @@ impl UpConfigGithubReleases {
                 )
                 .light_yellow(),
             );
-            release.up(options, &subhandler).inspect_err(|_err| {
-                progress_handler.error();
-            })?;
+            release
+                .up(options, environment, &subhandler)
+                .inspect_err(|_err| {
+                    progress_handler.error();
+                })?;
         }
 
         progress_handler.success_with_message(self.get_up_message());
 
         Ok(())
+    }
+
+    pub fn commit(&self, options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        for release in &self.releases {
+            if release.was_upped() {
+                release.commit(options, env_version_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        self.releases.iter().any(|release| release.was_upped())
     }
 
     fn get_up_message(&self) -> String {
@@ -273,12 +292,6 @@ impl UpConfigGithubReleases {
     }
 
     pub fn cleanup(progress_handler: &UpProgressHandler) -> Result<Option<String>, UpError> {
-        let wd = workdir(".");
-        let wd_id = match wd.id() {
-            Some(wd_id) => wd_id,
-            None => return Err(UpError::Exec("failed to get workdir id".to_string())),
-        };
-
         let mut return_value: Result<(bool, usize, Vec<PathBuf>), UpError> =
             Err(UpError::Exec("cleanup_path not run".to_string()));
 
@@ -288,14 +301,23 @@ impl UpConfigGithubReleases {
 
             let mut updated = false;
 
+            let environment_ids = if ghrelease.installed.len() > 0 {
+                UpEnvironmentsCache::get().environment_ids()
+            } else {
+                BTreeSet::new()
+            };
+
             // Use 'retain' so we can cleanup the github release cache of the releases
             // that are being removed entirely
             ghrelease.installed.retain_mut(|install| {
                 // Cleanup the references to this repository for
-                // any installed github release that is not currently
-                // listed in the up configuration
-                if install.required_by.contains(&wd_id) && install.stale() {
-                    install.required_by.retain(|id| id != &wd_id);
+                // any installed github release that is not used by any
+                // of the existing environments (active or in the history)
+                let required_by_len = install.required_by.len();
+                install
+                    .required_by
+                    .retain(|id| environment_ids.contains(id));
+                if required_by_len != install.required_by.len() {
                     updated = true;
                 }
 
@@ -662,13 +684,12 @@ impl UpConfigGithubRelease {
         }
     }
 
-    fn update_cache(&self, progress_handler: &dyn ProgressHandler) {
-        let wd = workdir(".");
-        let wd_id = match wd.id() {
-            Some(wd_id) => wd_id,
-            None => return,
-        };
-
+    fn update_cache(
+        &self,
+        _options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) {
         let version = match self.actual_version.get() {
             Some(version) => version,
             None => {
@@ -680,20 +701,14 @@ impl UpConfigGithubRelease {
         progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = GithubReleaseOperationCache::exclusive(|ghrelease| {
-            ghrelease.add_installed(&wd_id, &self.repository, version)
+            ghrelease.add_installed(&self.repository, version)
         }) {
             progress_handler.progress(format!("failed to update github release cache: {}", err));
             return;
         }
 
         let release_version_path = self.release_version_path(version);
-
-        if let Err(err) =
-            UpEnvironmentsCache::exclusive(|up_env| up_env.add_path(&wd_id, release_version_path))
-        {
-            progress_handler.progress(format!("failed to update up environment cache: {}", err));
-            return;
-        }
+        environment.add_path(release_version_path);
 
         progress_handler.progress("updated cache".to_string());
     }
@@ -717,6 +732,7 @@ impl UpConfigGithubRelease {
     pub fn up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.init(self.desc().light_blue());
@@ -729,7 +745,7 @@ impl UpConfigGithubRelease {
 
         let installed = self.resolve_and_download_release(options, progress_handler)?;
 
-        self.update_cache(progress_handler);
+        self.update_cache(options, environment, progress_handler);
 
         let version = match self.actual_version.get() {
             Some(version) => version.to_string(),
@@ -740,6 +756,34 @@ impl UpConfigGithubRelease {
             false => format!("{} already installed", version).light_black(),
         };
         progress_handler.success_with_message(msg);
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        match self.was_handled.get() {
+            Some(GithubReleaseHandled::Handled) => true,
+            Some(GithubReleaseHandled::Noop) => true,
+            _ => false,
+        }
+    }
+
+    pub fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        let version = match self.actual_version.get() {
+            Some(version) => version,
+            None => {
+                return Err(UpError::Exec("version not set".to_string()));
+            }
+        };
+
+        if let Err(err) = GithubReleaseOperationCache::exclusive(|ghrelease| {
+            ghrelease.add_required_by(env_version_id, &self.repository, version)
+        }) {
+            return Err(UpError::Cache(format!(
+                "failed to update github release cache: {}",
+                err
+            )));
+        }
 
         Ok(())
     }
@@ -2337,9 +2381,10 @@ mod tests {
                     .collect::<Vec<_>>();
 
                 let options = UpOptions::default().cache_disabled();
+                let mut environment = UpEnvironment::new();
                 let progress_handler = UpProgressHandler::new(None);
 
-                let result = config.up(&options, &progress_handler);
+                let result = config.up(&options, &mut environment, &progress_handler);
 
                 assert!(if test.expected_version.is_some() {
                     result.is_ok()

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -13,10 +13,10 @@ use serde::Serialize;
 use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::utils as cache_utils;
 use crate::internal::commands::utils::abs_path;
+use crate::internal::config::up::asdf_base::PostInstallFuncArgs;
 use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::UpProgressHandler;
-use crate::internal::config::up::AsdfToolUpVersion;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpError;
 use crate::internal::config::up::UpOptions;
@@ -239,14 +239,13 @@ fn setup_individual_gopath(
     _options: &UpOptions,
     environment: &mut UpEnvironment,
     _progress_handler: &dyn ProgressHandler,
-    _config_value: Option<ConfigValue>,
-    tool: String,
-    tool_real_name: String,
-    _requested_version: String,
-    versions: Vec<AsdfToolUpVersion>,
+    args: &PostInstallFuncArgs,
 ) -> Result<(), UpError> {
-    if tool_real_name != "golang" {
-        panic!("setup_individual_gopath called with wrong tool: {}", tool);
+    if args.tool_real_name != "golang" {
+        panic!(
+            "setup_individual_gopath called with wrong tool: {}",
+            args.tool
+        );
     }
 
     // Get the data path for the work directory
@@ -263,17 +262,17 @@ fn setup_individual_gopath(
     };
 
     // Handle each version individually
-    for version in &versions {
+    for version in &args.versions {
         for dir in &version.dirs {
             let gopath_dir = data_path_dir_hash(dir);
 
             let gopath = data_path
-                .join(&tool)
+                .join(&args.tool)
                 .join(&version.version)
                 .join(&gopath_dir);
 
             environment.add_version_data_path(
-                &tool,
+                &args.tool,
                 &version.version,
                 dir,
                 &gopath.to_string_lossy(),

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -10,9 +10,8 @@ use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::utils as cache_utils;
-use crate::internal::cache::utils::CacheObject;
-use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::ProgressHandler;
@@ -126,9 +125,14 @@ impl UpConfigGolang {
     pub fn up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
-        self.asdf_base()?.up(options, progress_handler)
+        self.asdf_base()?.up(options, environment, progress_handler)
+    }
+
+    pub fn commit(&self, options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        self.asdf_base()?.commit(options, env_version_id)
     }
 
     pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
@@ -232,7 +236,9 @@ fn extract_version_from_gomod_file(
 }
 
 fn setup_individual_gopath(
-    progress_handler: &dyn ProgressHandler,
+    _options: &UpOptions,
+    environment: &mut UpEnvironment,
+    _progress_handler: &dyn ProgressHandler,
     _config_value: Option<ConfigValue>,
     tool: String,
     tool_real_name: String,
@@ -246,16 +252,6 @@ fn setup_individual_gopath(
     // Get the data path for the work directory
     let workdir = workdir(".");
 
-    let workdir_id = match workdir.id() {
-        Some(workdir_id) => workdir_id,
-        None => {
-            return Err(UpError::Exec(format!(
-                "failed to get workdir id for {}",
-                current_dir().display()
-            )));
-        }
-    };
-
     let data_path = match workdir.data_path() {
         Some(data_path) => data_path,
         None => {
@@ -268,31 +264,20 @@ fn setup_individual_gopath(
 
     // Handle each version individually
     for version in &versions {
-        if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
-            let mut any_changed = false;
-            for dir in &version.dirs {
-                let gopath_dir = data_path_dir_hash(dir);
+        for dir in &version.dirs {
+            let gopath_dir = data_path_dir_hash(dir);
 
-                let gopath = data_path
-                    .join(&tool)
-                    .join(&version.version)
-                    .join(&gopath_dir);
+            let gopath = data_path
+                .join(&tool)
+                .join(&version.version)
+                .join(&gopath_dir);
 
-                any_changed = up_env.add_version_data_path(
-                    &workdir_id,
-                    &tool,
-                    &version.version,
-                    dir,
-                    &gopath.to_string_lossy(),
-                ) || any_changed;
-            }
-            any_changed
-        }) {
-            progress_handler.progress(format!("failed to update tool cache: {}", err));
-            return Err(UpError::Cache(format!(
-                "failed to update tool cache: {}",
-                err
-            )));
+            environment.add_version_data_path(
+                &tool,
+                &version.version,
+                dir,
+                &gopath.to_string_lossy(),
+            );
         }
     }
 

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -250,11 +250,12 @@ impl UpConfigHomebrew {
             progress_handler.init("homebrew:".light_blue());
             progress_handler.progress("checking for unused homebrew dependencies".to_string());
 
-            let environment_ids = if brew_cache.installed.len() > 0 || brew_cache.tapped.len() > 0 {
-                UpEnvironmentsCache::get().environment_ids()
-            } else {
-                BTreeSet::new()
-            };
+            let environment_ids =
+                if !brew_cache.installed.is_empty() || !brew_cache.tapped.is_empty() {
+                    UpEnvironmentsCache::get().environment_ids()
+                } else {
+                    BTreeSet::new()
+                };
 
             // Cleanup the references to this repository for
             // any installed formulae or casks that is not currently
@@ -619,7 +620,7 @@ impl HomebrewTap {
     fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
         if self.was_handled() {
             if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
-                brew_cache.add_tap_required_by(&env_version_id, &self.name, self.was_handled())
+                brew_cache.add_tap_required_by(env_version_id, &self.name, self.was_handled())
             }) {
                 return Err(UpError::Cache(err.to_string()));
             }
@@ -1064,7 +1065,7 @@ impl HomebrewInstall {
         if self.was_handled() {
             if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
                 brew_cache.add_install_required_by(
-                    &env_version_id,
+                    env_version_id,
                     &self.name,
                     self.version.clone(),
                     self.is_cask(),

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::process::Command as TokioCommand;
 
+use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::utils as cache_utils;
 use crate::internal::cache::CacheObject;
 use crate::internal::cache::HomebrewInstalled;
@@ -52,6 +53,7 @@ impl UpConfigHomebrew {
     pub fn up(
         &self,
         options: &UpOptions,
+        environment: &mut UpEnvironment,
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.init("homebrew:".light_blue());
@@ -82,10 +84,31 @@ impl UpConfigHomebrew {
                 )
                 .light_yellow(),
             );
-            install.up(options, &subhandler)?;
+            install.up(options, environment, &subhandler)?;
         }
 
         progress_handler.success_with_message(self.get_up_message());
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        self.tap.iter().any(|tap| tap.was_handled())
+            || self.install.iter().any(|install| install.was_handled())
+    }
+
+    pub fn commit(&self, options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        for tap in &self.tap {
+            if tap.was_handled() {
+                tap.commit(options, env_version_id)?;
+            }
+        }
+
+        for install in &self.install {
+            if install.was_handled() {
+                install.commit(options, env_version_id)?;
+            }
+        }
 
         Ok(())
     }
@@ -218,12 +241,6 @@ impl UpConfigHomebrew {
     }
 
     pub fn cleanup(progress_handler: &UpProgressHandler) -> Result<Option<String>, UpError> {
-        let wd = workdir(".");
-        let wd_id = match wd.id() {
-            Some(wd_id) => wd_id,
-            None => return Err(UpError::Exec("failed to get workdir id".to_string())),
-        };
-
         let mut return_value: Result<Option<String>, UpError> = Ok(None);
         let mut updated = false;
         let mut to_untap = vec![];
@@ -233,28 +250,34 @@ impl UpConfigHomebrew {
             progress_handler.init("homebrew:".light_blue());
             progress_handler.progress("checking for unused homebrew dependencies".to_string());
 
+            let environment_ids = if brew_cache.installed.len() > 0 || brew_cache.tapped.len() > 0 {
+                UpEnvironmentsCache::get().environment_ids()
+            } else {
+                BTreeSet::new()
+            };
+
             // Cleanup the references to this repository for
             // any installed formulae or casks that is not currently
             // listed in the up configuration
-            for install in brew_cache
-                .installed
-                .iter_mut()
-                .filter(|install| install.required_by.contains(&wd_id) && install.stale())
-            {
-                install.required_by.retain(|id| id != &wd_id);
-                updated = true;
+            for install in brew_cache.installed.iter_mut() {
+                let required_by_len = install.required_by.len();
+                install
+                    .required_by
+                    .retain(|id| environment_ids.contains(id));
+                if required_by_len != install.required_by.len() {
+                    updated = true;
+                }
             }
 
             // Cleanup the references to this repository for
             // any tap that is not currently listed in the up
             // configuration
-            for tap in brew_cache
-                .tapped
-                .iter_mut()
-                .filter(|tap| tap.required_by.contains(&wd_id) && tap.stale())
-            {
-                tap.required_by.retain(|id| id != &wd_id);
-                updated = true;
+            for tap in brew_cache.tapped.iter_mut() {
+                let required_by_len = tap.required_by.len();
+                tap.required_by.retain(|id| environment_ids.contains(id));
+                if required_by_len != tap.required_by.len() {
+                    updated = true;
+                }
             }
 
             // Get the list of formulae and casks that are not
@@ -582,21 +605,27 @@ impl HomebrewTap {
     }
 
     fn update_cache(&self, progress_handler: &dyn ProgressHandler) {
-        let workdir = workdir(".");
-        let workdir_id = match workdir.id() {
-            Some(wd_id) => wd_id,
-            None => return,
-        };
-
         progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
-            brew_cache.add_tap(&workdir_id, &self.name, self.was_handled())
+            brew_cache.add_tap(&self.name, self.was_handled())
         }) {
             progress_handler.progress(format!("failed to update cache: {}", err));
         } else {
             progress_handler.progress("updated cache".to_string());
         }
+    }
+
+    fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        if self.was_handled() {
+            if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
+                brew_cache.add_tap_required_by(&env_version_id, &self.name, self.was_handled())
+            }) {
+                return Err(UpError::Cache(err.to_string()));
+            }
+        }
+
+        Ok(())
     }
 
     fn up(&self, options: &UpOptions, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
@@ -997,18 +1026,16 @@ impl HomebrewInstall {
         }
     }
 
-    fn update_cache(&self, options: &UpOptions, progress_handler: &dyn ProgressHandler) {
-        let workdir = workdir(".");
-        let workdir_id = match workdir.id() {
-            Some(wd_id) => wd_id,
-            None => return,
-        };
-
+    fn update_cache(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) {
         progress_handler.progress("updating cache".to_string());
 
         if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
             brew_cache.add_install(
-                &workdir_id,
                 &self.name,
                 self.version.clone(),
                 self.is_cask(),
@@ -1025,21 +1052,38 @@ impl HomebrewInstall {
         }
 
         if !bin_paths.is_empty() {
-            if let Err(err) = UpEnvironmentsCache::exclusive(|up_env| {
-                for bin_path in bin_paths {
-                    up_env.add_path(&workdir_id, bin_path);
-                }
-                true
-            }) {
-                progress_handler.progress(format!("failed to update cache: {}", err));
-                return;
+            for bin_path in bin_paths {
+                environment.add_path(bin_path);
             }
         }
 
         progress_handler.progress("updated cache".to_string());
     }
 
-    fn up(&self, options: &UpOptions, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+    fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        if self.was_handled() {
+            if let Err(err) = HomebrewOperationCache::exclusive(|brew_cache| {
+                brew_cache.add_install_required_by(
+                    &env_version_id,
+                    &self.name,
+                    self.version.clone(),
+                    self.is_cask(),
+                    self.was_handled(),
+                )
+            }) {
+                return Err(UpError::Cache(err.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn up(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
         let progress_handler = progress_handler.subhandler(
             &format!(
                 "install {}{}: ",
@@ -1057,7 +1101,7 @@ impl HomebrewInstall {
             if self.was_handled.set(HomebrewHandled::Noop).is_err() {
                 unreachable!("failed to set was_handled (install: {})", self.name);
             }
-            self.update_cache(options, &progress_handler);
+            self.update_cache(options, environment, &progress_handler);
             progress_handler.success_with_message("already installed".light_black());
             return Ok(());
         }
@@ -1072,7 +1116,7 @@ impl HomebrewInstall {
                 if self.was_handled.set(was_handled).is_err() {
                     unreachable!("failed to set was_handled (install: {})", self.name);
                 }
-                self.update_cache(options, &progress_handler);
+                self.update_cache(options, environment, &progress_handler);
                 progress_handler.success_with_message(message);
                 Ok(())
             }

--- a/src/internal/config/up/options.rs
+++ b/src/internal/config/up/options.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UpOptions<'a> {
+    pub commit_sha: Option<String>,
     pub read_cache: bool,
     pub write_cache: bool,
     pub fail_on_upgrade: bool,
@@ -14,6 +15,7 @@ pub struct UpOptions<'a> {
 impl Default for UpOptions<'_> {
     fn default() -> Self {
         Self {
+            commit_sha: None,
             read_cache: true,
             write_cache: true,
             fail_on_upgrade: false,
@@ -26,6 +28,11 @@ impl Default for UpOptions<'_> {
 impl<'a> UpOptions<'a> {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn commit_sha(mut self, commit_sha: &Option<String>) -> Self {
+        self.commit_sha = commit_sha.clone();
+        self
     }
 
     pub fn cache(mut self, read_cache: bool) -> Self {

--- a/src/internal/config/up/utils/directory.rs
+++ b/src/internal/config/up/utils/directory.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
@@ -91,8 +91,8 @@ pub fn set_writeable_recursive<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
 
 /// Return the modification time of the configuration files
 /// for the work directory at the given path.
-pub fn get_config_mod_times<T: AsRef<str>>(path: T) -> HashMap<String, u64> {
-    let mut mod_times = HashMap::new();
+pub fn get_config_mod_times<T: AsRef<str>>(path: T) -> BTreeMap<String, u64> {
+    let mut mod_times = BTreeMap::new();
 
     if let Some(wdroot) = workdir(path.as_ref()).root() {
         for config_file in WORKDIR_CONFIG_FILES {


### PR DESCRIPTION
When running `omni up`, the current environment of a repository will now only be replaced upon success. This means that any failure to `omni up` won't break the existing environment used in a repository (except for potential side-effects). This also allows to keep an history of previous environments for a configurable retention period, up to a configurable maximum entries in the history per work directory, and globally.

Closes https://github.com/XaF/omni/issues/749