### PR TITLE
feat(`argparser`): the `placeholders` can now allow multiple values

### DIFF
--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -208,6 +208,7 @@ impl BuiltinCommand for HookInitCommand {
                         )
                         .to_string(),
                     ),
+                    placeholders: vec!["ALIAS".to_string(), "SUBCOMMAND".to_string()],
                     num_values: Some(SyntaxOptArgNumValues::Exactly(2)),
                     arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::String)),
                     group_occurrences: true,

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -1259,7 +1259,7 @@ impl BuiltinCommand for UpCommand {
                 },
                 SyntaxOptArg {
                     names: vec!["--prompt".to_string()],
-                    placeholder: Some("PROMPT_ID".to_string()),
+                    placeholders: vec!["PROMPT_ID".to_string()],
                     desc: Some(
                         concat!(
                             "Trigger prompts for the given prompt ids, specified as arguments, as ",

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -502,7 +502,7 @@ impl PathCommandFileDetails {
         let mut description = String::new();
 
         // Parse the argument name
-        let (names, arg_type, placeholder, mut leftovers) = parse_arg_name(arg_name);
+        let (names, arg_type, placeholders, mut leftovers) = parse_arg_name(arg_name);
         let mut arg_type = arg_type.to_string();
 
         // Now parse the rest of the string
@@ -631,7 +631,7 @@ impl PathCommandFileDetails {
             dest,
             desc,
             required,
-            placeholder,
+            placeholders,
             default,
             default_missing_value,
             arg_type: SyntaxOptArgType::from_str(&arg_type).unwrap_or(SyntaxOptArgType::String),

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -1283,7 +1283,7 @@ impl SyntaxOptArg {
                     }
                 };
 
-                if repr.len() > 0 {
+                if !repr.is_empty() {
                     help_name.push(' ');
                     help_name.push_str(&repr);
                 }
@@ -1446,7 +1446,7 @@ impl SyntaxOptArg {
                         .placeholders
                         .iter()
                         .cycle()
-                        .take(max as usize)
+                        .take(max)
                         .map(|ph| ph.to_string())
                         .collect::<Vec<_>>(),
                     None => self.placeholders.clone(),

--- a/tests/fixtures/omni/help-cd.txt
+++ b/tests/fixtures/omni/help-cd.txt
@@ -4,10 +4,10 @@ Change directory to the root of the specified work directory
 If no work directory is specified, change to the git directory of the main org as specified
 by OMNI_ORG, if specified, or errors out if not specified.
 
-Usage: omni cd [OPTIONS] [workdir]
+Usage: omni cd [OPTIONS] [WORKDIR]
 
 Arguments:
-  [workdir]      The name of the work directory to change directory to; this can be in the
+  [WORKDIR]      The name of the work directory to change directory to; this can be in the
                  format <org>/<repo>, or just <repo>, in which case the work directory will be
                  searched for in all the organizations, trying to use OMNI_ORG if it is set,
                  and then trying all the other organizations alphabetically.

--- a/tests/fixtures/omni/help-clone.txt
+++ b/tests/fixtures/omni/help-clone.txt
@@ -5,13 +5,13 @@ The clone operation will be handled using the first organization that matches th
 and for which the repository exists. The repository will be cloned in a path that matches
 omni's expectations, depending on your configuration.
 
-Usage: omni clone [OPTIONS] <repository> [clone options]...
+Usage: omni clone [OPTIONS] <REPOSITORY> [CLONE_OPTIONS]...
 
 Arguments:
-  <repository>        The repository to clone; this can be in format <org>/<repo>, just
+  <REPOSITORY>        The repository to clone; this can be in format <org>/<repo>, just
                       <repo>, or the full URL. If the case where only the repo name is
                       specified, OMNI_ORG will be used to search for the repository to clone.
-  [clone options]...  Any additional options to pass to git clone.
+  [CLONE_OPTIONS]...  Any additional options to pass to git clone.
 
 Options:
   -p, --package  Clone the repository as a package (default: no)

--- a/tests/fixtures/omni/help-config-path-switch.txt
+++ b/tests/fixtures/omni/help-config-path-switch.txt
@@ -7,10 +7,10 @@ worktree.
 When switching into a mode, if the source of the requested type does not exist, the
 repository will be cloned.
 
-Usage: omni config path switch [OPTIONS] [repository]
+Usage: omni config path switch [OPTIONS] [REPOSITORY]
 
 Arguments:
-  [repository]   The name of the repository to switch the source from; this can be in the
+  [REPOSITORY]   The name of the repository to switch the source from; this can be in the
                  format <org>/<repo>, or just <repo>. If the repository is not provided, the
                  current repository will be used, or the command will fail if not in a
                  repository. If the repo is not found in the omnipath, the command will fail.

--- a/tests/fixtures/omni/help-config-path.txt
+++ b/tests/fixtures/omni/help-config-path.txt
@@ -1,11 +1,11 @@
 
 Provides config path commands
 
-Usage: omni config path <subcommand> [options]...
+Usage: omni config path <SUBCOMMAND> [OPTIONS]...
 
 Arguments:
-  <subcommand>   Subcommand to be called
-  [options]...   Options to pass to the subcommand
+  <SUBCOMMAND>   Subcommand to be called
+  [OPTIONS]...   Options to pass to the subcommand
 
 General
   switch         Switch the source of a repository in the omnipath

--- a/tests/fixtures/omni/help-config-trust.txt
+++ b/tests/fixtures/omni/help-config-trust.txt
@@ -4,10 +4,10 @@ Trust or untrust a work directory.
 If the work directory is trusted, up and work directory-provided commands will be available
 to run without asking confirmation.
 
-Usage: omni config trust [OPTIONS] [workdir]
+Usage: omni config trust [OPTIONS] [WORKDIR]
 
 Arguments:
-  [workdir]      The work directory to trust or untrust [default: current]
+  [WORKDIR]      The work directory to trust or untrust [default: current]
 
 Options:
   --check        Check the trust status of the repository instead of changing it

--- a/tests/fixtures/omni/help-config-untrust.txt
+++ b/tests/fixtures/omni/help-config-untrust.txt
@@ -4,10 +4,10 @@ Trust or untrust a work directory.
 If the work directory is trusted, up and work directory-provided commands will be available
 to run without asking confirmation.
 
-Usage: omni config untrust [OPTIONS] [workdir]
+Usage: omni config untrust [OPTIONS] [WORKDIR]
 
 Arguments:
-  [workdir]      The work directory to trust or untrust [default: current]
+  [WORKDIR]      The work directory to trust or untrust [default: current]
 
 Options:
   --check        Check the trust status of the repository instead of changing it

--- a/tests/fixtures/omni/help-config.txt
+++ b/tests/fixtures/omni/help-config.txt
@@ -1,11 +1,11 @@
 
 Provides config commands
 
-Usage: omni config <subcommand> [options]...
+Usage: omni config <SUBCOMMAND> [OPTIONS]...
 
 Arguments:
-  <subcommand>   Subcommand to be called
-  [options]...   Options to pass to the subcommand
+  <SUBCOMMAND>   Subcommand to be called
+  [OPTIONS]...   Options to pass to the subcommand
 
 General
   bootstrap       Bootstraps the configuration of omni

--- a/tests/fixtures/omni/help-help.txt
+++ b/tests/fixtures/omni/help-help.txt
@@ -3,10 +3,10 @@ Show help for omni commands
 
 If no command is given, show a list of all available commands.
 
-Usage: omni help [OPTIONS] [command]...
+Usage: omni help [OPTIONS] [COMMAND]...
 
 Arguments:
-  [command]...   The command to get help for
+  [COMMAND]...   The command to get help for
 
 Options:
   --unfold       Show all subcommands

--- a/tests/fixtures/omni/help-hook-env.txt
+++ b/tests/fixtures/omni/help-hook-env.txt
@@ -4,10 +4,10 @@ Hook used to update the dynamic environment
 The env hook is called during your shell prompt to set the dynamic environment required for
 omni up-ed repositories.
 
-Usage: omni hook env [OPTIONS] [shell]
+Usage: omni hook env [OPTIONS] [SHELL]
 
 Arguments:
-  [shell]        The shell for which to export the dynamic environment. If not provided, the
+  [SHELL]        The shell for which to export the dynamic environment. If not provided, the
                  shell will be detected from the environment. [possible values: bash, zsh,
                  fish, posix]
 

--- a/tests/fixtures/omni/help-hook-init.txt
+++ b/tests/fixtures/omni/help-hook-init.txt
@@ -11,25 +11,25 @@ The init hook supports the --alias <alias> option, which adds an alias to the om
 with autocompletion support. It also supports the --command-alias <alias> <subcommand>
 option, which adds an alias to the specified omni subcommand with autocompletion support.
 
-Usage: omni hook init [OPTIONS] [shell]
+Usage: omni hook init [OPTIONS] [SHELL]
 
 Arguments:
-  [shell]        Which shell to initialize omni for. [possible values: bash, zsh, fish]
+  [SHELL]        Which shell to initialize omni for. [possible values: bash, zsh, fish]
 
 Options:
-  --alias <ALIAS>                  Create an alias for the omni command with autocompletion
-                                   support.
-  --command-alias <COMMAND_ALIAS> <COMMAND_ALIAS>
-                                   Create an alias for the specified omni subcommand with
-                                   autocompletion support. The second argument can be any omni
-                                   subcommand, including custom subcommands.
-  --shims                          Only load the shims without setting up the dynamic
-                                   environment.
-  --keep-shims-in-path             Prevent the dynamic environment from removing the shims
-                                   directory from the PATH. This can be useful if you are used
-                                   to launch your IDE from the terminal and do not have other
-                                   means to load the shims in its environment.
-  --print-shims-path               Print the path to the shims directory and exit. This should
-                                   not be used to eval in a shell environment.
+  --alias <ALIAS>                       Create an alias for the omni command with
+                                        autocompletion support.
+  --command-alias <ALIAS> <SUBCOMMAND>  Create an alias for the specified omni subcommand with
+                                        autocompletion support. The second argument can be any
+                                        omni subcommand, including custom subcommands.
+  --shims                               Only load the shims without setting up the dynamic
+                                        environment.
+  --keep-shims-in-path                  Prevent the dynamic environment from removing the
+                                        shims directory from the PATH. This can be useful if
+                                        you are used to launch your IDE from the terminal and
+                                        do not have other means to load the shims in its
+                                        environment.
+  --print-shims-path                    Print the path to the shims directory and exit. This
+                                        should not be used to eval in a shell environment.
 
 Source: builtin

--- a/tests/fixtures/omni/help-hook.txt
+++ b/tests/fixtures/omni/help-hook.txt
@@ -1,11 +1,11 @@
 
 Call one of omni's hooks for the shell
 
-Usage: omni hook <hook> [options]...
+Usage: omni hook <HOOK> [OPTIONS]...
 
 Arguments:
-  <hook>         Which hook to call
-  [options]...   Any options to pass to the hook.
+  <HOOK>         Which hook to call
+  [OPTIONS]...   Any options to pass to the hook.
 
 General
   env            Hook used to update the dynamic environment

--- a/tests/fixtures/omni/help-scope.txt
+++ b/tests/fixtures/omni/help-scope.txt
@@ -4,14 +4,14 @@ Runs an omni command in the context of the specified repository
 This allows to run any omni command that would be available while in the repository
 directory, but without having to change directory to the repository first.
 
-Usage: omni scope [OPTIONS] <scope> <command>...
+Usage: omni scope [OPTIONS] <SCOPE> <COMMAND>...
 
 Arguments:
-  <scope>        The name of the work directory to run commands in the context of; this can be
+  <SCOPE>        The name of the work directory to run commands in the context of; this can be
                  in the format <org>/<repo>, or just <repo>, in which case the work directory
                  will be searched for in all the organizations, trying to use OMNI_ORG if it
                  is set, and then trying all the other organizations alphabetically.
-  <command>...   The omni command to run in the context of the specified repository.
+  <COMMAND>...   The omni command to run in the context of the specified repository.
 
 Options:
   -p, --include-packages  If provided, will include packages when running the command; this

--- a/tests/fixtures/omni/help-tidy.txt
+++ b/tests/fixtures/omni/help-tidy.txt
@@ -6,10 +6,10 @@ the path they should be at if they had been cloned using omni clone. This is use
 have a bunch of repositories that you have cloned manually, and you want to start using
 omni, or if you changed your mind on the repo path format you wish to use.
 
-Usage: omni tidy [OPTIONS] [up args]...
+Usage: omni tidy [OPTIONS] [UP_ARGS]...
 
 Arguments:
-  [up args]...   Arguments to pass to omni up when running with --up-all
+  [UP_ARGS]...   Arguments to pass to omni up when running with --up-all
 
 Options:
   --yes                            Do not ask for confirmation before organizing repositories

--- a/tests/test_omni_help.bats
+++ b/tests/test_omni_help.bats
@@ -247,7 +247,7 @@ commands:
           required: true
         - name: -c
           aliases: --charlie
-          placeholder: MYPLACEHOLDER
+          placeholders: MYPLACEHOLDER
           desc: parameter c
           required: true
     desc: |

--- a/website/contents/reference/01-configuration/0102-parameters/010250-commands.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-commands.md
@@ -39,7 +39,7 @@ Each `parameter` object can take the following parameters:
 | `aliases` | string (list) | list of aliases for that parameter |
 | `desc` | string | the description/help for the parameter |
 | `required` | bool | whether or not this parameter is required |
-| `placeholder` | string | the placeholder to show in the help |
+| `placeholders` | string (list) | the placeholders to show in the help for that parameter; if multiple placeholders are provided, they will be used one after the other depending on the `num_values` configuration |
 | `type` | string | the type of the parameter, can be one of `str`, `int`, `float`, `bool`, `flag`, `counter`, `enum(vals, ...)` or `array/<type>` for any of those except `flag` and `counter`. See below for more details on the types. |
 | `default` | string | the default value for the parameter |
 | `num_values` | string | the number of values that the parameter can take. This can take ranges in the format `..max` (open), `..=max` (closed), `min..`, `min..max` (half-open), `min..=max` (closed) |


### PR DESCRIPTION
This helps with a nicer help experience when using omni's argument parser, as parameters taking multiple values can use the placeholders to give more information about the expected values in the help message.