### PR TITLE
feat(`github-release`): improvements to arch pattern matching

### DIFF
--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -263,8 +263,8 @@ impl GithubReleasesSelector {
         self
     }
 
-    // Use a tiny int for the matching, -1 means no matching, then 0+ means matching
-    // and the lowest value is the best match
+    // Use a tiny int for the matching: -1 means no matching,
+    // 0+ means matching and the lowest value is the best match
     fn asset_matches(&self, asset: &GithubReleaseAsset) -> i32 {
         if let Some((asset_type, _)) = asset.file_type() {
             if asset_type.is_binary() && !self.binary {

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -295,7 +295,7 @@ impl GithubReleasesSelector {
             return -1;
         }
 
-        return 0;
+        0
     }
 
     fn matches_glob_patterns(patterns: &str, value: &str) -> bool {

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -23,7 +23,6 @@ use crate::internal::config::up::utils::VersionMatcher;
 use crate::internal::config::up::utils::VersionParser;
 use crate::internal::env::now as omni_now;
 use crate::internal::self_updater::compatible_release_arch;
-use crate::internal::self_updater::compatible_release_arch_extended;
 use crate::internal::self_updater::compatible_release_os;
 
 const GITHUB_RELEASE_CACHE_NAME: &str = "github_release_operation";
@@ -38,22 +37,20 @@ lazy_static! {
     };
     static ref ARCH_REGEX: Regex = match Regex::new(&format!(
         r"(?i)(\b|_)({})(\b|_)",
-        compatible_release_arch().join("|")
+        compatible_release_arch().into_iter().flatten().join("|")
     )) {
         Ok(arch_re) => arch_re,
         Err(err) => panic!("failed to create architecture regex: {}", err),
     };
-    static ref ARCH_EXTENDED_REGEX: Option<Regex> = {
-        let arch_extended = compatible_release_arch_extended();
-        if arch_extended.is_empty() {
-            None
-        } else {
-            match Regex::new(&format!(r"(?i)(\b|_)({})(\b|_)", arch_extended.join("|"))) {
-                Ok(arch_re) => Some(arch_re),
+    static ref ARCH_REGEX_PER_LEVEL: Vec<Regex> = compatible_release_arch()
+        .into_iter()
+        .map(|arch| {
+            match Regex::new(&format!(r"(?i)(\b|_)({})(\b|_)", arch.join("|"))) {
+                Ok(arch_re) => arch_re,
                 Err(err) => panic!("failed to create architecture regex: {}", err),
             }
-        }
-    };
+        })
+        .collect();
     static ref SEPARATOR_MID_REGEX: Regex = match Regex::new(r"([-_]{2,})") {
         Ok(separator_re) => separator_re,
         Err(err) => panic!("failed to create separator regex: {}", err),
@@ -266,51 +263,39 @@ impl GithubReleasesSelector {
         self
     }
 
-    // Use a tiny unsigned int for the matching, 0 means no matching,
-    // 1 means matching for extended arch, and 2 means matching for regular arch
-    fn asset_matches(&self, asset: &GithubReleaseAsset) -> usize {
+    // Use a tiny int for the matching, -1 means no matching, then 0+ means matching
+    // and the lowest value is the best match
+    fn asset_matches(&self, asset: &GithubReleaseAsset) -> i32 {
         if let Some((asset_type, _)) = asset.file_type() {
             if asset_type.is_binary() && !self.binary {
-                return 0;
+                return -1;
             }
         } else {
-            return 0;
+            return -1;
         }
 
         if let Some(ref patterns) = self.asset_name {
             if !Self::matches_glob_patterns(patterns, &asset.name) {
-                return 0;
+                return -1;
             }
         }
 
         let asset_name = asset.name.to_lowercase();
 
-        if !self.skip_os_matching
-            && compatible_release_os()
-                .into_iter()
-                .all(|os| !asset_name.contains(&os))
-        {
-            return 0;
+        if !self.skip_os_matching && !OS_REGEX.is_match(&asset_name) {
+            return -1;
         }
 
-        if !self.skip_arch_matching
-            && compatible_release_arch()
-                .into_iter()
-                .all(|arch| !asset_name.contains(&arch))
-        {
-            if compatible_release_arch_extended()
-                .into_iter()
-                .any(|arch| !asset_name.contains(&arch))
-            {
-                // Extended arch matching
-                return 1;
-            } else {
-                // Arch did not match
-                return 0;
+        if !self.skip_arch_matching {
+            for (idx, arch_level_reg) in ARCH_REGEX_PER_LEVEL.iter().enumerate() {
+                if arch_level_reg.is_match(&asset_name) {
+                    return idx as i32;
+                }
             }
+            return -1;
         }
 
-        2
+        return 0;
     }
 
     fn matches_glob_patterns(patterns: &str, value: &str) -> bool {
@@ -357,17 +342,21 @@ impl GithubReleasesSelector {
 
     fn assets_with_checksums(&self, assets: &[GithubReleaseAsset]) -> Vec<GithubReleaseAsset> {
         // This will prioritize an exact-arch matching over an extended-arch matching
-        let asset_with_matching = assets
-            .iter()
-            .map(|asset| (asset, self.asset_matches(asset)));
+        let asset_with_matching = assets.iter().filter_map(|asset| {
+            let matching_level = self.asset_matches(asset);
+            if matching_level < 0 {
+                return None;
+            }
+            Some((asset, matching_level))
+        });
 
         let highest_matching_level = asset_with_matching
             .clone()
             .map(|(_, level)| level)
-            .max()
-            .unwrap_or(0);
+            .min()
+            .unwrap_or(-1);
 
-        if highest_matching_level == 0 {
+        if highest_matching_level < 0 {
             return vec![];
         }
 
@@ -660,10 +649,6 @@ impl GithubReleaseAsset {
         let name = self.name.clone();
         let name = OS_REGEX.replace_all(&name, "$1$3");
         let name = ARCH_REGEX.replace_all(&name, "$1$3");
-        let name = match *ARCH_EXTENDED_REGEX {
-            Some(ref arch_extended) => arch_extended.replace_all(&name, "$1$3"),
-            None => name,
-        };
         let name = name.replace(version, "");
         let name = SEPARATOR_MID_REGEX.replace_all(&name, "-");
         let name = SEPARATOR_END_REGEX.replace_all(&name, "");

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -2233,6 +2233,9 @@ mod tests {
                 let current_arch = compatible_release_arch()
                     .into_iter()
                     .next()
+                    .expect("no compatible arch")
+                    .into_iter()
+                    .next()
                     .expect("no compatible arch");
                 let current_os = compatible_release_os()
                     .into_iter()


### PR DESCRIPTION
This adds support for 'universal' binaries as a second-level priority when finding assets in a github release. This will match words such as `universal`, `all` or `any` in those instances.

The initial filtering of the assets also uses regex instead of simple string 'contains' checking.

Fixes https://github.com/XaF/omni/issues/779