### PR TITLE
feat(`custom`): add support for adding environment variables

### DIFF
--- a/.github/workflows/build-and-test-target.yaml
+++ b/.github/workflows/build-and-test-target.yaml
@@ -287,4 +287,4 @@ jobs:
           OMNI_TEST_BIN: ./omni
           PROJECT_DIR: ${{ github.workspace }}
         run: |
-          "${HOME}/.local/bin/bats" --no-tempdir-cleanup --jobs 8 tests/
+          "${HOME}/.local/bin/bats" --verbose-run --no-tempdir-cleanup --jobs 8 tests/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,10 +738,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -746,8 +783,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1675,6 +1714,7 @@ dependencies = [
  "duct",
  "flate2",
  "fs4",
+ "futures",
  "gethostname",
  "git-url-parse",
  "git2",
@@ -1690,6 +1730,7 @@ dependencies = [
  "machine-uid",
  "md-5",
  "mockito",
+ "nix",
  "node-semver",
  "normalize-path",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ctrlc = { version = "3.4.5", features = ["termination"] }
 duct = "0.13.6"
 flate2 = "1.0.34"
 fs4 = "0.11.1"
+futures = "0.3.31"
 gethostname = "0.5.0"
 git-url-parse = "0.4.5"
 git2 = { version = "0.19.0", features = ["vendored-libgit2"] }
@@ -47,6 +48,7 @@ lazy_static = "1.4.0"
 libz-sys = { version = "1.1.19", features = ["static"] }
 machine-uid = "0.5.2"
 md-5 = "0.10.6"
+nix = "0.29.0"
 node-semver = "2.1.0"
 normalize-path = "0.2.1"
 num-bigint = "0.4.6"

--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -274,6 +274,11 @@ impl UpEnvironment {
         true
     }
 
+    pub fn add_raw_env_vars(&mut self, env_vars: Vec<UpEnvVar>) -> bool {
+        self.env_vars.extend(env_vars);
+        true
+    }
+
     pub fn add_path(&mut self, path: PathBuf) -> bool {
         self.paths.retain(|p| p != &path);
 

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -296,7 +296,7 @@ where
 
                 env_operations.push(UpEnvVar {
                     name: var.to_string(),
-                    operation: operation.clone(),
+                    operation: *operation,
                     value: Some(value.to_string()),
                 });
 
@@ -325,9 +325,9 @@ where
                 };
 
             // Remove quotes around the delimiter if any, but just one set of quotes
-            let delimiter = if delimiter.starts_with('\'') && delimiter.ends_with('\'') {
-                &delimiter[1..delimiter.len() - 1]
-            } else if delimiter.starts_with('"') && delimiter.ends_with('"') {
+            let delimiter = if (delimiter.starts_with('\'') && delimiter.ends_with('\''))
+                || (delimiter.starts_with('"') && delimiter.ends_with('"'))
+            {
                 &delimiter[1..delimiter.len() - 1]
             } else {
                 delimiter
@@ -344,10 +344,10 @@ where
             // Now read the value until the delimiter is encountered
             let mut value = String::new();
             let mut ended = false;
-            while let Some(line) = lines.next() {
+            for line in lines.by_ref() {
                 let line = line.as_ref();
                 let line = if remove_all_indent {
-                    line.trim_start_matches(|c| c == ' ' || c == '\t')
+                    line.trim_start_matches([' ', '\t'])
                 } else {
                     line
                 };
@@ -357,7 +357,7 @@ where
                     break;
                 }
 
-                value.push_str(&line);
+                value.push_str(line);
                 value.push('\n');
             }
 

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -2,11 +2,16 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::process::Command as TokioCommand;
 
+use crate::internal::cache::up_environments::UpEnvVar;
+use crate::internal::cache::up_environments::UpEnvironment;
+use crate::internal::config::parser::EnvOperationEnum;
 use crate::internal::config::up::utils::run_progress;
+use crate::internal::config::up::utils::FifoHandler;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
 use crate::internal::config::ConfigValue;
 use crate::internal::user_interface::StringColor;
 
@@ -66,7 +71,12 @@ impl UpConfigCustom {
         self.dir.as_ref().map(|dir| dir.to_string())
     }
 
-    pub fn up(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+    pub fn up(
+        &self,
+        _options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
         let name = if let Some(name) = &self.name {
             name.to_string()
         } else {
@@ -84,7 +94,7 @@ impl UpConfigCustom {
             return Ok(());
         }
 
-        if let Err(err) = self.meet(progress_handler) {
+        if let Err(err) = self.meet(environment, progress_handler) {
             progress_handler.error_with_message(format!("{}", err).light_red());
             return Err(UpError::StepFailed(name, progress_handler.step()));
         }
@@ -143,13 +153,21 @@ impl UpConfigCustom {
         }
     }
 
-    fn meet(&self, progress_handler: &dyn ProgressHandler) -> Result<(), UpError> {
+    fn meet(
+        &self,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<(), UpError> {
         if !self.meet.is_empty() {
             progress_handler.progress("running (meet) command".to_string());
+
+            let mut fifo_handler =
+                FifoHandler::new().map_err(|err| UpError::Exec(format!("{}", err)))?;
 
             let mut command = TokioCommand::new("bash");
             command.arg("-c");
             command.arg(&self.meet);
+            command.env("OMNI_ENV", fifo_handler.path());
             command.stdout(std::process::Stdio::piped());
             command.stderr(std::process::Stdio::piped());
 
@@ -158,6 +176,15 @@ impl UpConfigCustom {
                 Some(progress_handler),
                 RunConfig::default().with_askpass(),
             )?;
+
+            // Close the fifo handler
+            fifo_handler.close();
+
+            // Parse the contents of the environment file
+            let env_vars = parse_env_file_lines(fifo_handler.lines().into_iter())?;
+
+            // Add the environment operations to the environment
+            environment.add_raw_env_vars(env_vars);
         }
 
         Ok(())
@@ -178,4 +205,264 @@ impl UpConfigCustom {
 
         Ok(())
     }
+}
+
+/// Parse an environment file lines in the format supported by omni, and return a list of
+/// environment operations to be performed, which will be added to the dynamic
+/// environment of the work directory.
+///
+/// The file format supports the following:
+/// - `unset VAR1 VAR2...`: Unset the specified environment variables
+/// - `VAR1=VALUE1`: Set the specified environment variable to the specified value
+/// - `VAR1>=VALUE1`: Append the specified value to the specified environment variable
+/// - `VAR1<=VALUE1`: Prepend the specified value to the specified environment variable
+/// - `VAR1>>=VALUE1`: Append the specified value to the specified environment variable,
+///                    working on the assumption that the variable is a path-type variable
+///                    (e.g. PATH, LD_LIBRARY_PATH, etc.) separated by colons (':')
+/// - `VAR1<<=VALUE1`: Append the specified value to the specified environment variable,
+///                    working on the assumption that the variable is a path-type variable
+///                    (e.g. PATH, LD_LIBRARY_PATH, etc.) separated by colons (':')
+/// - `VAR1-=VALUE1`: Remove the specified value from the specified environment variable,
+///                   working on the assumption that the variable is a path-type variable
+///                   (e.g. PATH, LD_LIBRARY_PATH, etc.) separated by colons (':')
+/// - `VAR1<<EOF`: Set a multi-line value for the specified environment variable, with the
+///                value being read from the following lines until an `EOF` is encountered
+///                (can be any delimiter value instead of `EOF`)
+///
+/// Any `export` prefix is simply removed.
+/// Any line starting with a `#` is considered a comment and ignored.
+/// Any unexpected line format will result in an error.
+fn parse_env_file_lines<I, T>(mut lines: I) -> Result<Vec<UpEnvVar>, UpError>
+where
+    I: Iterator<Item = T>,
+    T: AsRef<str>,
+{
+    // Prepare the output vector
+    let mut env_operations = Vec::new();
+
+    'outer: while let Some(line) = lines.next() {
+        let line = line.as_ref().trim();
+
+        // Skip empty lines and comments
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Handle unsetting variables through 'unset VAR1 VAR2...'
+        if let Some(vars) = line.strip_prefix("unset ") {
+            let vars = vars.split_whitespace();
+
+            // Validate that all the values are valid environment variables
+            for var in vars {
+                if !is_valid_env_name(var) {
+                    return Err(UpError::Exec(format!(
+                        "invalid environment variable name: '{}', in 'unset' operation",
+                        var
+                    )));
+                }
+
+                env_operations.push(UpEnvVar {
+                    name: var.to_string(),
+                    operation: EnvOperationEnum::Set,
+                    value: None,
+                });
+            }
+
+            continue;
+        }
+
+        // Remove the `export ` prefix if any
+        let line = match line.strip_prefix("export ") {
+            Some(line) => line,
+            None => line,
+        };
+
+        // Handle the different operations
+        for (operation_str, operation) in &[
+            (">>=", EnvOperationEnum::Append),
+            ("<<=", EnvOperationEnum::Prepend),
+            ("-=", EnvOperationEnum::Remove),
+            (">=", EnvOperationEnum::Prefix),
+            ("<=", EnvOperationEnum::Suffix),
+            ("=", EnvOperationEnum::Set),
+        ] {
+            if let Some((var, value)) = line.split_once(operation_str) {
+                if !is_valid_env_name(var) {
+                    return Err(UpError::Exec(format!(
+                        "invalid environment variable name: '{}', in '{}' operation",
+                        var, operation_str
+                    )));
+                }
+
+                env_operations.push(UpEnvVar {
+                    name: var.to_string(),
+                    operation: operation.clone(),
+                    value: Some(value.to_string()),
+                });
+
+                continue 'outer;
+            }
+        }
+
+        // Handle the multi-line 'heredoc' operation
+        if let Some((var, delimiter)) = line.split_once("<<") {
+            if !is_valid_env_name(var) {
+                return Err(UpError::Exec(format!(
+                    "invalid environment variable name: '{}', in '<<' operation",
+                    var
+                )));
+            }
+
+            // Check if the heredoc is an indented heredoc
+            let delimiter = delimiter.trim();
+            let (delimiter, remove_all_indent, remove_min_indent) =
+                if let Some(delimiter) = delimiter.strip_prefix('-') {
+                    (delimiter.trim(), true, false)
+                } else if let Some(delimiter) = delimiter.strip_prefix('~') {
+                    (delimiter.trim(), false, true)
+                } else {
+                    (delimiter, false, false)
+                };
+
+            // Remove quotes around the delimiter if any, but just one set of quotes
+            let delimiter = if delimiter.starts_with('\'') && delimiter.ends_with('\'') {
+                &delimiter[1..delimiter.len() - 1]
+            } else if delimiter.starts_with('"') && delimiter.ends_with('"') {
+                &delimiter[1..delimiter.len() - 1]
+            } else {
+                delimiter
+            };
+
+            // Validate the delimiter
+            if !is_valid_delimiter(delimiter) {
+                return Err(UpError::Exec(format!(
+                    "invalid delimiter: '{}', in '<<' operation",
+                    delimiter
+                )));
+            }
+
+            // Now read the value until the delimiter is encountered
+            let mut value = String::new();
+            let mut ended = false;
+            while let Some(line) = lines.next() {
+                let line = line.as_ref();
+                let line = if remove_all_indent {
+                    line.trim_start_matches(|c| c == ' ' || c == '\t')
+                } else {
+                    line
+                };
+
+                if line == delimiter {
+                    ended = true;
+                    break;
+                }
+
+                value.push_str(&line);
+                value.push('\n');
+            }
+
+            if !ended {
+                return Err(UpError::Exec(format!(
+                    "expected delimiter '{}' to end '<<' operation",
+                    delimiter
+                )));
+            }
+
+            // Remove the minimum indentation if requested
+            if remove_min_indent {
+                // Find the minimum indentation; if that minimum in N, it requires
+                // N characters at the beginning of each line to be either all spaces
+                // or all tabs for the whole value
+                let mut min_indent = 0;
+                let mut indent_type = None;
+                for line in value.lines() {
+                    // Skip empty lines
+                    if line.is_empty() {
+                        continue;
+                    }
+
+                    // Check the indentation type
+                    let current_indent_type = line.chars().next().unwrap();
+
+                    if current_indent_type != ' ' && current_indent_type != '\t' {
+                        min_indent = 0;
+                        break;
+                    }
+
+                    match indent_type {
+                        Some(indent_type) => {
+                            if current_indent_type != indent_type {
+                                min_indent = 0;
+                                break;
+                            }
+                        }
+                        None => {
+                            indent_type = Some(current_indent_type);
+                        }
+                    }
+
+                    // Now count the indentation
+                    let indent = line
+                        .chars()
+                        .take_while(|c| *c == current_indent_type)
+                        .count();
+
+                    if indent < min_indent || min_indent == 0 {
+                        min_indent = indent;
+                    }
+                }
+
+                // Now modify all the lines to remove the minimum indentation
+                let mut new_value = String::new();
+                for line in value.lines() {
+                    if line.len() >= min_indent {
+                        new_value.push_str(&line[min_indent..]);
+                    }
+                    new_value.push('\n');
+                }
+                value = new_value;
+            }
+
+            // Remove the last newline character
+            if value.ends_with('\n') {
+                value.pop();
+            }
+
+            env_operations.push(UpEnvVar {
+                name: var.to_string(),
+                operation: EnvOperationEnum::Set,
+                value: Some(value),
+            });
+
+            continue;
+        }
+
+        // If no operation was found, return an error
+        return Err(UpError::Exec(format!(
+            "invalid environment operation: '{}'",
+            line
+        )));
+    }
+
+    Ok(env_operations)
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+
+    let first_char = name.chars().next().unwrap();
+    if !first_char.is_ascii_alphabetic() && first_char != '_' {
+        return false;
+    }
+
+    name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn is_valid_delimiter(delimiter: &str) -> bool {
+    !delimiter.is_empty()
+        && delimiter
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -466,3 +466,254 @@ fn is_valid_delimiter(delimiter: &str) -> bool {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_env_names() {
+        assert!(is_valid_env_name("PATH"));
+        assert!(is_valid_env_name("_PATH"));
+        assert!(is_valid_env_name("MY_VAR_1"));
+        assert!(!is_valid_env_name(""));
+        assert!(!is_valid_env_name("1VAR"));
+        assert!(!is_valid_env_name("MY-VAR"));
+        assert!(!is_valid_env_name("MY VAR"));
+    }
+
+    #[test]
+    fn test_valid_delimiters() {
+        assert!(is_valid_delimiter("EOF"));
+        assert!(is_valid_delimiter("END"));
+        assert!(is_valid_delimiter("DONE"));
+        assert!(is_valid_delimiter("123"));
+        assert!(is_valid_delimiter("MY_DELIMITER"));
+        assert!(!is_valid_delimiter(""));
+        assert!(!is_valid_delimiter("END HERE"));
+        assert!(!is_valid_delimiter("END\n"));
+    }
+
+    mod parse_env_file_lines {
+        use super::*;
+
+        #[test]
+        fn test_basic_env_operations() {
+            let input = vec![
+                "export PATH=/usr/bin",
+                "LANG=en_US.UTF-8",
+                "unset TEMP OLD_PATH",
+                "# This is a comment",
+                "",
+                "JAVA_HOME=/opt/java",
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 5);
+
+            assert_eq!(result[0].name, "PATH");
+            assert_eq!(result[0].operation, EnvOperationEnum::Set);
+            assert_eq!(result[0].value, Some("/usr/bin".to_string()));
+
+            assert_eq!(result[1].name, "LANG");
+            assert_eq!(result[1].operation, EnvOperationEnum::Set);
+            assert_eq!(result[1].value, Some("en_US.UTF-8".to_string()));
+
+            assert_eq!(result[2].name, "TEMP");
+            assert_eq!(result[2].operation, EnvOperationEnum::Set);
+            assert_eq!(result[2].value, None);
+
+            assert_eq!(result[3].name, "OLD_PATH");
+            assert_eq!(result[3].operation, EnvOperationEnum::Set);
+            assert_eq!(result[3].value, None);
+
+            assert_eq!(result[4].name, "JAVA_HOME");
+            assert_eq!(result[4].operation, EnvOperationEnum::Set);
+            assert_eq!(result[4].value, Some("/opt/java".to_string()));
+        }
+
+        #[test]
+        fn test_advanced_operations() {
+            let input = vec![
+                "PATH>>=/new/bin",        // Append
+                "LD_LIBRARY_PATH<<=/lib", // Prepend
+                "PATH-=/old/bin",         // Remove
+                "PREFIX>=value",          // Prefix
+                "SUFFIX<=value",          // Suffix
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 5);
+
+            assert_eq!(result[0].name, "PATH");
+            assert_eq!(result[0].operation, EnvOperationEnum::Append);
+            assert_eq!(result[0].value, Some("/new/bin".to_string()));
+
+            assert_eq!(result[1].name, "LD_LIBRARY_PATH");
+            assert_eq!(result[1].operation, EnvOperationEnum::Prepend);
+            assert_eq!(result[1].value, Some("/lib".to_string()));
+
+            assert_eq!(result[2].name, "PATH");
+            assert_eq!(result[2].operation, EnvOperationEnum::Remove);
+            assert_eq!(result[2].value, Some("/old/bin".to_string()));
+
+            assert_eq!(result[3].name, "PREFIX");
+            assert_eq!(result[3].operation, EnvOperationEnum::Prefix);
+            assert_eq!(result[3].value, Some("value".to_string()));
+
+            assert_eq!(result[4].name, "SUFFIX");
+            assert_eq!(result[4].operation, EnvOperationEnum::Suffix);
+            assert_eq!(result[4].value, Some("value".to_string()));
+        }
+
+        #[test]
+        fn test_heredoc() {
+            let input = vec![
+                "MULTILINE<<EOF",
+                "line 1",
+                "line 2",
+                "line 3",
+                "EOF",
+                "NEXT_VAR=value",
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].name, "MULTILINE");
+            assert_eq!(result[0].operation, EnvOperationEnum::Set);
+            assert_eq!(result[0].value, Some("line 1\nline 2\nline 3".to_string()));
+
+            assert_eq!(result[1].name, "NEXT_VAR");
+            assert_eq!(result[1].operation, EnvOperationEnum::Set);
+            assert_eq!(result[1].value, Some("value".to_string()));
+        }
+
+        #[test]
+        fn test_heredoc_indentation() {
+            let input = vec![
+                "NORMAL<<-EOF",
+                "    line 1",
+                "      line 2",
+                "    line 3",
+                "EOF",
+                "MINIMAL<<~EOF",
+                "    line 1",
+                "      line 2",
+                "    line 3",
+                "EOF",
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 2);
+
+            // Test normal heredoc with -
+            assert_eq!(result[0].name, "NORMAL");
+            assert_eq!(result[0].operation, EnvOperationEnum::Set);
+            assert_eq!(result[0].value, Some("line 1\nline 2\nline 3".to_string()));
+
+            // Test minimal indentation heredoc with ~
+            assert_eq!(result[1].name, "MINIMAL");
+            assert_eq!(result[1].operation, EnvOperationEnum::Set);
+            assert_eq!(
+                result[1].value,
+                Some("line 1\n  line 2\nline 3".to_string())
+            );
+        }
+
+        #[test]
+        fn test_invalid_operations() {
+            // Invalid environment variable name
+            let input = vec!["1INVALID=value"];
+            assert!(parse_env_file_lines(input.into_iter()).is_err());
+
+            // Invalid operation
+            let input = vec!["VAR+=value"];
+            assert!(parse_env_file_lines(input.into_iter()).is_err());
+
+            // Missing heredoc terminator
+            let input = vec!["VAR<<EOF", "content"];
+            assert!(parse_env_file_lines(input.into_iter()).is_err());
+
+            // Invalid heredoc delimiter
+            let input = vec!["VAR<<EOF HERE", "content", "EOF HERE"];
+            assert!(parse_env_file_lines(input.into_iter()).is_err());
+
+            // Invalid unset syntax
+            let input = vec!["unset 1INVALID"];
+            assert!(parse_env_file_lines(input.into_iter()).is_err());
+        }
+
+        #[test]
+        fn test_quoted_heredoc_delimiter() {
+            let input = vec![
+                "VAR<<'EOF'",
+                "content",
+                "EOF",
+                "VAR2<<\"END\"",
+                "more content",
+                "END",
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].value, Some("content".to_string()));
+            assert_eq!(result[1].value, Some("more content".to_string()));
+        }
+
+        #[test]
+        fn test_mixed_operations() {
+            let input = vec![
+                "# Setting up environment",
+                "JAVA_HOME=/opt/java",
+                "PATH>>=$JAVA_HOME/bin",
+                "unset OLD_JAVA_HOME TEMP_PATH",
+                "CONFIG<<EOF",
+                "key1=value1",
+                "key2=value2",
+                "EOF",
+                "DEBUG>=true",
+            ];
+
+            let result = parse_env_file_lines(input.into_iter()).unwrap();
+
+            assert_eq!(result.len(), 6);
+
+            // Verify JAVA_HOME
+            assert_eq!(result[0].name, "JAVA_HOME");
+            assert_eq!(result[0].operation, EnvOperationEnum::Set);
+            assert_eq!(result[0].value, Some("/opt/java".to_string()));
+
+            // Verify PATH
+            assert_eq!(result[1].name, "PATH");
+            assert_eq!(result[1].operation, EnvOperationEnum::Append);
+            assert_eq!(result[1].value, Some("$JAVA_HOME/bin".to_string()));
+
+            // Verify unset operations
+            assert_eq!(result[2].name, "OLD_JAVA_HOME");
+            assert_eq!(result[2].operation, EnvOperationEnum::Set);
+            assert_eq!(result[2].value, None);
+
+            assert_eq!(result[3].name, "TEMP_PATH");
+            assert_eq!(result[3].operation, EnvOperationEnum::Set);
+            assert_eq!(result[3].value, None);
+
+            // Verify heredoc
+            assert_eq!(result[4].name, "CONFIG");
+            assert_eq!(result[4].operation, EnvOperationEnum::Set);
+            assert_eq!(
+                result[4].value,
+                Some("key1=value1\nkey2=value2".to_string())
+            );
+
+            // Verify prefix operation
+            assert_eq!(result[5].name, "DEBUG");
+            assert_eq!(result[5].operation, EnvOperationEnum::Prefix);
+            assert_eq!(result[5].value, Some("true".to_string()));
+        }
+    }
+}

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -715,7 +715,7 @@ mod tests {
 
             // Verify prefix operation
             assert_eq!(result[5].name, "DEBUG");
-            assert_eq!(result[5].operation, EnvOperationEnum::Prefix);
+            assert_eq!(result[5].operation, EnvOperationEnum::Suffix);
             assert_eq!(result[5].value, Some("true".to_string()));
         }
     }

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -225,7 +225,7 @@ impl UpConfigTool {
             UpConfigTool::Asdf(config) => config.up(options, environment, progress_handler),
             UpConfigTool::Bash(config) => config.up(options, environment, progress_handler),
             UpConfigTool::Bundler(config) => config.up(options, environment, progress_handler),
-            UpConfigTool::Custom(config) => config.up(progress_handler),
+            UpConfigTool::Custom(config) => config.up(options, environment, progress_handler),
             UpConfigTool::GithubRelease(config) => {
                 config.up(options, environment, progress_handler)
             }

--- a/src/internal/config/up/utils/askpass.rs
+++ b/src/internal/config/up/utils/askpass.rs
@@ -170,20 +170,13 @@ impl Listener for AskPassListener {
                         // Create the handler function with the correct type
                         let handler: EventHandlerFn = Box::new(move || {
                             Box::pin(async move {
-                                if let Err(err) = AskPassListener::handle_request(&mut stream).await
-                                {
-                                    return Err(err);
-                                }
+                                AskPassListener::handle_request(&mut stream).await?;
                                 Ok(())
                             })
                         });
                         return (handler, true);
                     }
-                    Err(err) => {
-                        let handler: EventHandlerFn =
-                            Box::new(move || Box::pin(async move { Err(err.to_string()) }));
-                        return (handler, false);
-                    }
+                    Err(_err) => {}
                 }
             }
         })
@@ -305,10 +298,7 @@ impl AskPassListener {
 
         // Create the listener
         match UnixListener::bind(&socket_path) {
-            Ok(listener) => Ok(Some(Self {
-                listener: listener,
-                tmp_dir: tmp_dir,
-            })),
+            Ok(listener) => Ok(Some(Self { listener, tmp_dir })),
             Err(err) => Err(UpError::Exec(
                 format!("failed to bind to socket: {:?}", err).to_string(),
             )),

--- a/src/internal/config/up/utils/askpass.rs
+++ b/src/internal/config/up/utils/askpass.rs
@@ -1,9 +1,12 @@
 use std::fs::set_permissions;
 use std::fs::Permissions;
+use std::mem;
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::pin::Pin;
 
+use futures::Future;
 use serde::Deserialize;
 use serde::Serialize;
 use shell_escape::escape;
@@ -13,7 +16,6 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
-use tokio::net::unix::SocketAddr;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
 use tokio::process::Command as TokioCommand;
@@ -21,7 +23,8 @@ use tokio::process::Command as TokioCommand;
 use crate::internal::config::global_config;
 use crate::internal::config::template::render_askpass_template;
 use crate::internal::config::up::utils::force_remove_dir_all;
-use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::EventHandlerFn;
+use crate::internal::config::up::utils::Listener;
 use crate::internal::config::up::UpError;
 use crate::internal::env::current_exe;
 use crate::internal::env::shell_is_interactive;
@@ -124,10 +127,10 @@ impl AskPassRequest {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AskPassListener {
-    listener: Option<UnixListener>,
-    tmp_dir: Option<TempDir>,
+    listener: UnixListener,
+    tmp_dir: TempDir,
 }
 
 impl Drop for AskPassListener {
@@ -135,10 +138,70 @@ impl Drop for AskPassListener {
         if let Err(_err) = tokio::runtime::Handle::try_current() {
             if let Ok(rt) = tokio::runtime::Runtime::new() {
                 rt.block_on(async {
-                    let _ = self.close().await;
+                    let _ = self.stop().await;
                 });
             }
         }
+    }
+}
+
+impl Listener for AskPassListener {
+    fn set_process_env(&self, process: &mut TokioCommand) -> Result<(), String> {
+        let needs_askpass = Self::needs_askpass();
+        for tool in &needs_askpass {
+            let askpass_path = Self::askpass_path(&self.tmp_dir, tool);
+            let askpass_path = askpass_path.to_string_lossy().to_string();
+            process.env(format!("{}_ASKPASS", tool.to_uppercase()), &askpass_path);
+        }
+
+        process.env("SSH_ASKPASS_REQUIRE", "force");
+        process.env_remove("DISPLAY");
+
+        Ok(())
+    }
+
+    fn next(&mut self) -> Pin<Box<dyn Future<Output = (EventHandlerFn, bool)> + Send + '_>> {
+        // Create a stream copy that we can move into the future
+        Box::pin(async move {
+            // Accept a connection from the socket
+            loop {
+                match self.listener.accept().await {
+                    Ok((mut stream, _addr)) => {
+                        // Create the handler function with the correct type
+                        let handler: EventHandlerFn = Box::new(move || {
+                            Box::pin(async move {
+                                if let Err(err) = AskPassListener::handle_request(&mut stream).await
+                                {
+                                    return Err(err);
+                                }
+                                Ok(())
+                            })
+                        });
+                        return (handler, true);
+                    }
+                    Err(err) => {
+                        let handler: EventHandlerFn =
+                            Box::new(move || Box::pin(async move { Err(err.to_string()) }));
+                        return (handler, false);
+                    }
+                }
+            }
+        })
+    }
+
+    fn stop(&mut self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+        Box::pin(async move {
+            // Take ownership of the tmp_dir and handle cleanup
+            let tmp_dir = mem::replace(&mut self.tmp_dir, TempDir::new().unwrap());
+            let tmp_dir_path = tmp_dir.path().to_path_buf();
+            if let Err(_err) = tmp_dir.close() {
+                if let Err(err) = force_remove_dir_all(tmp_dir_path) {
+                    return Err(err.to_string());
+                }
+            }
+
+            Ok(())
+        })
     }
 }
 
@@ -166,19 +229,15 @@ impl AskPassListener {
             .join(format!("{}-askpass.sh", tool.to_lowercase()))
     }
 
-    pub async fn new(command: &str, run_config: &RunConfig) -> Result<Self, UpError> {
-        if !run_config.askpass() {
-            return Ok(Self::default());
-        }
-
+    pub async fn new(command: &str) -> Result<Option<Self>, UpError> {
         let config = global_config();
         if !config.askpass.enabled {
-            return Ok(Self::default());
+            return Ok(None);
         }
 
         let needs_askpass = Self::needs_askpass();
         if needs_askpass.is_empty() {
-            return Ok(Self::default());
+            return Ok(None);
         }
 
         // Create a temporary directory
@@ -246,38 +305,13 @@ impl AskPassListener {
 
         // Create the listener
         match UnixListener::bind(&socket_path) {
-            Ok(listener) => Ok(Self {
-                listener: Some(listener),
-                tmp_dir: Some(tmp_dir),
-            }),
+            Ok(listener) => Ok(Some(Self {
+                listener: listener,
+                tmp_dir: tmp_dir,
+            })),
             Err(err) => Err(UpError::Exec(
                 format!("failed to bind to socket: {:?}", err).to_string(),
             )),
-        }
-    }
-
-    pub async fn accept(&mut self) -> Option<Result<(UnixStream, SocketAddr), String>> {
-        if let Some(listener) = &mut self.listener {
-            match listener.accept().await {
-                Ok((stream, addr)) => Some(Ok((stream, addr))),
-                Err(err) => Some(Err(err.to_string())),
-            }
-        } else {
-            None
-        }
-    }
-
-    pub async fn set_process_env(&self, process: &mut TokioCommand) {
-        if let Some(tmp_dir) = &self.tmp_dir {
-            let needs_askpass = Self::needs_askpass();
-            for tool in &needs_askpass {
-                let askpass_path = Self::askpass_path(tmp_dir, tool);
-                let askpass_path = askpass_path.to_string_lossy().to_string();
-                process.env(format!("{}_ASKPASS", tool.to_uppercase()), &askpass_path);
-            }
-
-            process.env("SSH_ASKPASS_REQUIRE", "force");
-            process.env_remove("DISPLAY");
         }
     }
 
@@ -343,23 +377,6 @@ impl AskPassListener {
             Ok(_) => {}
             Err(err) => {
                 return Err(format!("failed to write to socket: {:?}", err));
-            }
-        }
-
-        Ok(())
-    }
-
-    pub async fn close(&mut self) -> Result<(), String> {
-        if let Some(listener) = self.listener.take() {
-            drop(listener);
-        }
-
-        if let Some(tmp_dir) = self.tmp_dir.take() {
-            let tmp_dir_path = tmp_dir.path().to_path_buf();
-            if let Err(_err) = tmp_dir.close() {
-                if let Err(err) = force_remove_dir_all(tmp_dir_path) {
-                    return Err(err.to_string());
-                }
             }
         }
 

--- a/src/internal/config/up/utils/fifo_handler.rs
+++ b/src/internal/config/up/utils/fifo_handler.rs
@@ -187,14 +187,13 @@ impl FifoReader {
         let mut buffer = String::new();
 
         loop {
-            if stop_signal.load(Ordering::Relaxed) {
-                break;
-            }
-
             buffer.clear();
             match reader.read_line(&mut buffer) {
                 Ok(0) => {
-                    // EOF reached, try again
+                    // EOF reached, try again unless we received the stop signal
+                    if stop_signal.load(Ordering::Relaxed) {
+                        break;
+                    }
                 }
                 Ok(_) => {
                     if let Err(e) = sender.send(buffer.to_string()) {

--- a/src/internal/config/up/utils/fifo_handler.rs
+++ b/src/internal/config/up/utils/fifo_handler.rs
@@ -1,13 +1,17 @@
 use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::thread;
 
 use nix::sys::stat::Mode;
@@ -66,14 +70,17 @@ impl Drop for TempFifo {
     }
 }
 
-pub struct FifoHandler {
-    path: String,
-    fifo: Option<TempFifo>,
-    storage: Arc<Mutex<Vec<String>>>,
-    stop_signal: Sender<()>,
+pub struct FifoReader {
+    fifo_path: PathBuf,
+    _temp_fifo: Option<TempFifo>,
+    stop_signal: Arc<AtomicBool>,
+    reader_handle: Option<thread::JoinHandle<std::io::Result<()>>>,
+    receiver: Receiver<String>,
+    lines: Vec<String>,
 }
 
-impl FifoHandler {
+impl FifoReader {
+    /// Create a new FifoReader with a temporary FIFO.
     pub fn new() -> std::io::Result<Self> {
         let fifo = TempFifo::new()?;
 
@@ -91,93 +98,183 @@ impl FifoHandler {
     // Self::build(path.to_string_lossy().to_string(), None)
     // }
 
-    fn build(path: String, fifo: Option<TempFifo>) -> std::io::Result<Self> {
-        // Shared storage for FIFO contents
-        let storage = Arc::new(Mutex::new(Vec::new()));
+    /// Create a new FifoReader with the given FIFO path.
+    fn build<P: AsRef<Path>>(fifo_path: P, temp_fifo: Option<TempFifo>) -> std::io::Result<Self> {
+        let fifo_path = fifo_path.as_ref().to_path_buf();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = mpsc::channel();
 
-        // Channel to signal fifo thread readiness
-        let (ready_signal_transmitter, ready_signal_receiver) = mpsc::channel();
-
-        // Channel to signal thread termination
-        let (stop_signal_transmitter, stop_signal_receiver) = mpsc::channel();
-
-        // Clone the storage for the thread
-        let storage_clone = Arc::clone(&storage);
-
-        // Spawn a background thread to read from the FIFO
-        let fifo_path = path.clone();
-        let _thread_handle = thread::spawn(move || {
-            // Signal that the thread is ready
-            let _ = ready_signal_transmitter.send(());
-
-            loop {
-                // Check for stop signal
-                if stop_signal_receiver.try_recv().is_ok() {
-                    break;
-                }
-
-                let fifo = match File::open(&fifo_path) {
-                    Ok(fifo) => fifo,
-                    Err(_err) => {
-                        return;
-                    }
-                };
-                let reader = BufReader::new(fifo);
-
-                for line in reader.lines() {
-                    // Store the line in shared storage
-                    match line {
-                        Ok(line) => {
-                            let mut storage = storage_clone.lock().unwrap();
-                            storage.push(line);
-                        }
-                        Err(_err) => {
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-
-        // Wait for the thread to be ready
-        let _ = ready_signal_receiver.recv();
+        let reader_handle = Some(Self::spawn_reader(
+            fifo_path.clone(),
+            stop_signal.clone(),
+            sender,
+        ));
 
         Ok(Self {
-            path,
-            fifo,
-            storage,
-            stop_signal: stop_signal_transmitter,
+            fifo_path,
+            _temp_fifo: temp_fifo,
+            stop_signal,
+            reader_handle,
+            receiver,
+            lines: Vec::new(),
         })
     }
 
     /// Returns the path to the FIFO.
-    pub fn path(&self) -> &str {
-        &self.path
+    pub fn path(&self) -> &Path {
+        &self.fifo_path
     }
 
-    /// Returns the accumulated contents from the FIFO.
-    pub fn lines(&self) -> Vec<String> {
-        let storage = self.storage.lock().unwrap();
-        storage.clone()
+    /// Open the FIFO for reading.
+    fn open_fifo_in(path: &Path) -> std::io::Result<File> {
+        OpenOptions::new().read(true).open(path)
     }
 
-    /// Closes the FIFO handler and terminates the background thread.
-    pub fn close(&mut self) {
-        // Send the stop signal
-        let _ = self.stop_signal.send(());
+    /// Open the FIFO for writing.
+    fn open_fifo_out(path: &Path) -> std::io::Result<File> {
+        OpenOptions::new()
+            .custom_flags(nix::libc::O_NONBLOCK)
+            .write(true)
+            .open(path)
+    }
 
-        // Remove the FIFO file on best effort
-        if let Some(fifo) = self.fifo.take() {
-            drop(fifo);
-        } else {
-            let _ = std::fs::remove_file(&self.path);
+    /// Spawn a reader thread that reads from the FIFO until it is closed.
+    fn spawn_reader(
+        fifo_path: PathBuf,
+        stop_signal: Arc<AtomicBool>,
+        sender: Sender<String>,
+    ) -> thread::JoinHandle<std::io::Result<()>> {
+        thread::spawn(move || {
+            while !stop_signal.load(Ordering::Relaxed) {
+                match Self::read_fifo_until_closed(&fifo_path, &stop_signal, &sender) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// Check if the error is recoverable and the operation can be retried.
+    fn is_recoverable_error(e: &std::io::Error) -> bool {
+        use std::io::ErrorKind::*;
+        matches!(
+            e.kind(),
+            NotFound
+                | PermissionDenied
+                | ConnectionReset
+                | ConnectionAborted
+                | BrokenPipe
+                | WouldBlock
+        )
+    }
+
+    /// Read from the FIFO until it is closed.
+    fn read_fifo_until_closed(
+        fifo_path: &Path,
+        stop_signal: &AtomicBool,
+        sender: &Sender<String>,
+    ) -> std::io::Result<()> {
+        let file = match Self::open_fifo_in(fifo_path) {
+            Ok(f) => f,
+            Err(e) if Self::is_recoverable_error(&e) => return Ok(()), // Allow retry
+            Err(e) => return Err(e),
+        };
+
+        let mut reader = BufReader::new(file);
+        let mut buffer = String::new();
+
+        loop {
+            if stop_signal.load(Ordering::Relaxed) {
+                break;
+            }
+
+            buffer.clear();
+            match reader.read_line(&mut buffer) {
+                Ok(0) => {
+                    // EOF reached, try again
+                }
+                Ok(_) => {
+                    if let Err(e) = sender.send(buffer.to_string()) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("Failed to send data: {}", e),
+                        ));
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No data available right now, try again
+                }
+                Err(e) if Self::is_recoverable_error(&e) => return Ok(()), // Allow retry
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Flush any pending messages from the FIFO.
+    fn flush(&mut self) {
+        while let Ok(msg) = self.receiver.try_recv() {
+            // Remove one \n from the end of the message if any
+            let msg = if msg.ends_with('\n') {
+                msg[..msg.len() - 1].to_string()
+            } else {
+                msg
+            };
+
+            self.lines.push(msg);
         }
     }
+
+    /// Stop the reader thread and return all the lines collected so far.
+    pub fn stop(&mut self) -> std::io::Result<Vec<String>> {
+        // Send the stop signal to the reader thread
+        self.stop_signal.store(true, Ordering::Relaxed);
+
+        // Collect all buffered messages
+        self.flush();
+
+        // Wait for the reader thread to finish and check for any errors
+        if let Some(handle) = self.reader_handle.take() {
+            // Since we are doing blocking I/O in the reader thread, we need to
+            // open the FIFO for writing to make sure it gets unblocked.
+            // This open is unblocking, and we do not mind if there is an error.
+            let _ = Self::open_fifo_out(&self.fifo_path);
+
+            // Now we can join the reader thread
+            handle.join().map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::Other, "Reader thread panicked")
+            })??;
+        }
+
+        // Collect any final messages that might have been sent while joining
+        self.flush();
+
+        // Return the collected messages
+        Ok(self.lines.clone())
+    }
+
+    // /// Try to read any available messages from the FIFO and return all the lines
+    // /// collected so far.
+    // pub fn try_read(&mut self) -> Vec<String> {
+    // if self.stop_signal.load(Ordering::Relaxed) {
+    // self.flush();
+    // }
+    // self.lines.clone()
+    // }
+
+    // /// Returns the accumulated contents from the FIFO.
+    // pub fn lines(&self) -> Vec<String> {
+    // self.lines.clone()
+    // }
 }
 
-impl Drop for FifoHandler {
+impl Drop for FifoReader {
     /// Ensure proper cleanup on drop.
     fn drop(&mut self) {
-        self.close();
+        self.stop().ok();
     }
 }

--- a/src/internal/config/up/utils/fifo_handler.rs
+++ b/src/internal/config/up/utils/fifo_handler.rs
@@ -1,0 +1,183 @@
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread;
+
+use nix::sys::stat::Mode;
+use nix::unistd::mkfifo;
+use tempfile::TempDir;
+
+use crate::internal::env::tmpdir_cleanup_prefix;
+
+#[derive(Debug)]
+struct TempFifo {
+    path: PathBuf,
+    _temp_dir: TempDir, // Keeps cleanup guard
+}
+
+impl TempFifo {
+    pub fn new() -> std::io::Result<Self> {
+        // Create temporary directory with restricted permissions
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&tmpdir_cleanup_prefix("env"))
+            .rand_bytes(12)
+            .tempdir()?;
+
+        // Set directory permissions to 700 (rwx------)
+        std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o700))?;
+
+        // Create FIFO inside the temp directory
+        let path = temp_dir.path().join("env.fifo");
+
+        // Create FIFO with restrictive permissions (0600)
+        match mkfifo(&path, Mode::S_IRUSR | Mode::S_IWUSR) {
+            Ok(_) => Ok(Self {
+                path,
+                _temp_dir: temp_dir,
+            }),
+            Err(err) => {
+                // Convert nix error to io::Error
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to create FIFO: {}", err),
+                ))
+            }
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+// Implement Drop to ensure cleanup even if tempdir's drop somehow fails
+impl Drop for TempFifo {
+    fn drop(&mut self) {
+        // We try to remove the FIFO explicitly, but don't worry if it fails
+        // as the tempdir deletion will clean it up anyway
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+pub struct FifoHandler {
+    path: String,
+    fifo: Option<TempFifo>,
+    storage: Arc<Mutex<Vec<String>>>,
+    stop_signal: Sender<()>,
+}
+
+impl FifoHandler {
+    pub fn new() -> std::io::Result<Self> {
+        let fifo = TempFifo::new()?;
+
+        Self::build(fifo.path().to_string_lossy().to_string(), Some(fifo))
+    }
+
+    // pub fn with_path(path: impl AsRef<Path>) -> std::io::Result<Self> {
+    // let path = path.as_ref();
+
+    // // Create the FIFO if it doesn't exist
+    // if !path.exists() {
+    // mkfifo(path, Mode::S_IRWXU)?;
+    // }
+
+    // Self::build(path.to_string_lossy().to_string(), None)
+    // }
+
+    fn build(path: String, fifo: Option<TempFifo>) -> std::io::Result<Self> {
+        // Shared storage for FIFO contents
+        let storage = Arc::new(Mutex::new(Vec::new()));
+
+        // Channel to signal fifo thread readiness
+        let (ready_signal_transmitter, ready_signal_receiver) = mpsc::channel();
+
+        // Channel to signal thread termination
+        let (stop_signal_transmitter, stop_signal_receiver) = mpsc::channel();
+
+        // Clone the storage for the thread
+        let storage_clone = Arc::clone(&storage);
+
+        // Spawn a background thread to read from the FIFO
+        let fifo_path = path.clone();
+        let _thread_handle = thread::spawn(move || {
+            // Signal that the thread is ready
+            let _ = ready_signal_transmitter.send(());
+
+            loop {
+                // Check for stop signal
+                if stop_signal_receiver.try_recv().is_ok() {
+                    break;
+                }
+
+                let fifo = match File::open(&fifo_path) {
+                    Ok(fifo) => fifo,
+                    Err(_err) => {
+                        return;
+                    }
+                };
+                let reader = BufReader::new(fifo);
+
+                for line in reader.lines() {
+                    // Store the line in shared storage
+                    match line {
+                        Ok(line) => {
+                            let mut storage = storage_clone.lock().unwrap();
+                            storage.push(line);
+                        }
+                        Err(_err) => {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        // Wait for the thread to be ready
+        let _ = ready_signal_receiver.recv();
+
+        Ok(Self {
+            path,
+            fifo,
+            storage,
+            stop_signal: stop_signal_transmitter,
+        })
+    }
+
+    /// Returns the path to the FIFO.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the accumulated contents from the FIFO.
+    pub fn lines(&self) -> Vec<String> {
+        let storage = self.storage.lock().unwrap();
+        storage.clone()
+    }
+
+    /// Closes the FIFO handler and terminates the background thread.
+    pub fn close(&mut self) {
+        // Send the stop signal
+        let _ = self.stop_signal.send(());
+
+        // Remove the FIFO file on best effort
+        if let Some(fifo) = self.fifo.take() {
+            drop(fifo);
+        } else {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl Drop for FifoHandler {
+    /// Ensure proper cleanup on drop.
+    fn drop(&mut self) {
+        self.close();
+    }
+}

--- a/src/internal/config/up/utils/listener_manager.rs
+++ b/src/internal/config/up/utils/listener_manager.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::future::select_all;
+use tokio::process::Command as TokioCommand;
+use tokio::sync::Mutex;
+
+pub type EventHandlerFn =
+    Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> + Send>;
+
+pub trait Listener: Send + Sync {
+    fn set_process_env(&self, process: &mut TokioCommand) -> Result<(), String>;
+    fn next(&mut self) -> Pin<Box<dyn Future<Output = (EventHandlerFn, bool)> + Send + '_>>;
+    fn stop(&mut self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>>;
+}
+
+type ListenerActiveFuture = Pin<Box<dyn Future<Output = (EventHandlerFn, bool)> + Send>>;
+
+#[derive(Default)]
+pub struct ListenerManager {
+    listeners: Vec<Arc<Mutex<Box<dyn Listener>>>>,
+    active_futures: HashMap<usize, ListenerActiveFuture>,
+    started: bool,
+}
+
+impl Clone for ListenerManager {
+    fn clone(&self) -> Self {
+        Self {
+            listeners: self.listeners.clone(),
+            active_futures: HashMap::new(),
+            started: false,
+        }
+    }
+}
+
+impl std::fmt::Debug for ListenerManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "ListenerManager {{ started: {}, listeners: {:?} }}",
+            self.started,
+            self.listeners.len()
+        )
+    }
+}
+
+impl ListenerManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_listener(&mut self, listener: Box<dyn Listener>) {
+        let index = self.listeners.len();
+        let listener = Arc::new(Mutex::new(listener));
+
+        // Start the future immediately if we add a listener after start()
+        if self.started {
+            let listener_clone = listener.clone();
+            let future = Box::pin(async move {
+                let mut lock = listener_clone.lock().await;
+                lock.next().await
+            });
+            self.active_futures.insert(index, future);
+        }
+
+        self.listeners.push(listener);
+    }
+
+    pub async fn set_process_env(&self, process: &mut TokioCommand) -> Result<(), String> {
+        for listener in &self.listeners {
+            let lock = listener.lock().await;
+            lock.set_process_env(process)?;
+        }
+        Ok(())
+    }
+
+    pub fn start(&mut self) {
+        for (index, listener) in self.listeners.iter().enumerate() {
+            let listener_clone = listener.clone();
+            let future = Box::pin(async move {
+                let mut lock = listener_clone.lock().await;
+                lock.next().await
+            });
+            self.active_futures.insert(index, future);
+        }
+        self.started = true;
+    }
+
+    pub async fn next(&mut self) -> Option<(EventHandlerFn, bool)> {
+        // If no futures are active, return None
+        if !self.started || self.active_futures.is_empty() {
+            return None;
+        }
+
+        let futures: Vec<_> = self
+            .active_futures
+            .iter_mut()
+            .map(|(&idx, fut)| (idx, fut.as_mut()))
+            .collect();
+
+        let indices: Vec<_> = futures.iter().map(|(idx, _)| *idx).collect();
+        let futures: Vec<_> = futures.into_iter().map(|(_, fut)| fut).collect();
+
+        let ((handler, interactive), index, _remaining) = select_all(futures).await;
+        let listener_index = indices[index];
+
+        // Remove the completed future
+        self.active_futures.remove(&listener_index);
+
+        // Immediately start a new future for this listener
+        let listener = self.listeners[listener_index].clone();
+        let future = Box::pin(async move {
+            let mut lock = listener.lock().await;
+            lock.next().await
+        });
+        self.active_futures.insert(listener_index, future);
+
+        Some((handler, interactive))
+    }
+
+    pub async fn stop(&mut self) -> Result<(), String> {
+        self.active_futures.clear();
+        self.started = false;
+
+        // Call stop on all the listeners, and wait for all the stop
+        // futures to complete before returning Ok(()) if all are Ok(())
+        // or Err(e) if any are Err(e)
+        let results = self
+            .listeners
+            .iter()
+            .map(|listener| {
+                let listener_clone = listener.clone();
+                async move {
+                    let mut lock = listener_clone.lock().await;
+                    lock.stop().await
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let results = futures::future::join_all(results).await;
+
+        if results.iter().all(|r| r.is_ok()) {
+            Ok(())
+        } else {
+            Err("Error stopping listeners".to_string())
+        }
+    }
+}

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use listener_manager::Listener;
 pub(crate) use listener_manager::ListenerManager;
 
 mod fifo_handler;
-pub(crate) use fifo_handler::FifoHandler;
+pub(crate) use fifo_handler::FifoReader;
 
 pub(crate) mod print_progress_handler;
 pub(crate) use print_progress_handler::PrintProgressHandler;

--- a/src/internal/config/up/utils/mod.rs
+++ b/src/internal/config/up/utils/mod.rs
@@ -8,6 +8,14 @@ pub(crate) use directory::data_path_dir_hash;
 pub(crate) use directory::force_remove_dir_all;
 pub(crate) use directory::get_config_mod_times;
 
+mod listener_manager;
+pub(crate) use listener_manager::EventHandlerFn;
+pub(crate) use listener_manager::Listener;
+pub(crate) use listener_manager::ListenerManager;
+
+mod fifo_handler;
+pub(crate) use fifo_handler::FifoHandler;
+
 pub(crate) mod print_progress_handler;
 pub(crate) use print_progress_handler::PrintProgressHandler;
 

--- a/src/internal/config/up/utils/run_config.rs
+++ b/src/internal/config/up/utils/run_config.rs
@@ -1,4 +1,8 @@
+use tokio::process::Command as TokioCommand;
 use tokio::time::Duration;
+
+use crate::internal::config::up::utils::AskPassListener;
+use crate::internal::config::up::utils::ListenerManager;
 
 #[derive(Debug, Clone)]
 pub struct RunConfig {
@@ -37,11 +41,46 @@ impl RunConfig {
         self.clone()
     }
 
-    pub fn askpass(&self) -> bool {
-        self.askpass
-    }
-
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
+
+    pub async fn listener_manager_for_command(
+        &self,
+        process_command: &mut TokioCommand,
+    ) -> Result<ListenerManager, String> {
+        let mut listener_manager = ListenerManager::new();
+        let command_string = &command_str(process_command);
+
+        if self.askpass {
+            match AskPassListener::new(command_string).await {
+                Ok(Some(listener)) => {
+                    listener_manager.add_listener(Box::new(listener));
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(err.to_string());
+                }
+            }
+        }
+
+        listener_manager.set_process_env(process_command).await?;
+
+        Ok(listener_manager)
+    }
+}
+
+/// Convert a `TokioCommand` to a string
+fn command_str(command: &TokioCommand) -> String {
+    let command = command.as_std();
+    let mut command_arr = vec![];
+    command_arr.push(command.get_program().to_string_lossy().to_string());
+    for arg in command.get_args() {
+        let mut arg = arg.to_string_lossy().to_string();
+        if arg.contains(' ') {
+            arg = format!("\"{}\"", arg.replace('"', "\\\""));
+        }
+        command_arr.push(arg);
+    }
+    command_arr.join(" ")
 }

--- a/tests/helpers/utils.bash
+++ b/tests/helpers/utils.bash
@@ -6,6 +6,10 @@ omni_setup() {
   # echo "$BATS_FILE_TMPDIR" # Shared with the whole file
   # echo "$BATS_TEST_TMPDIR" # Only available to the current test
   # echo "$BATS_TEST_FILENAME" # The current test file
+  if [ -z "$BATS_TEST_TMPDIR" ]; then
+    echo "BATS_TEST_TMPDIR is not set" >&2
+    return 1
+  fi
 
   # Get the git directory
   local git_dir="$(git rev-parse --show-toplevel 2>/dev/null)"

--- a/tests/helpers/utils.bash
+++ b/tests/helpers/utils.bash
@@ -43,7 +43,7 @@ omni_setup() {
     # Build the omni binary
     if [[ "$NEEDS_BUILD" == true ]]; then
       echo "Building omni binary in ${git_dir}" >&2
-      (cd "${git_dir}" && cargo build) >&2 || echo "ERROR building omni" >&2
+      (cd "${git_dir}" && cargo build) >&2 || { echo "ERROR building omni" >&2; return 1; }
     fi
 
     # # If the binary still does not exist, error out

--- a/tests/test_omni_up_custom.bats
+++ b/tests/test_omni_up_custom.bats
@@ -145,7 +145,102 @@ EOF
   [ "$ENV_VAR2" = "VALUE2" ]
 }
 
-custom_operation_multiline() {
+custom_operation_multiline_single_arrow() {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "SIMPLE<<DELIM" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+        echo "NOINDENT<<-DELIM" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+        echo "NOINDENT_INDENTEDDELIM<<-DELIM" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo " DELIM" > "$OMNI_ENV"
+
+        echo "MININDENT<<~DELIM" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+        echo "WITHSPACES<< DELIM " > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+        echo "WITHSQUOTES<<'DELIM'" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+        echo "WITHDQUOTES<<\"DELIM\"" > "$OMNI_ENV"
+        echo "  line1" > "$OMNI_ENV"
+        echo "    line2" > "$OMNI_ENV"
+        echo "  line3" > "$OMNI_ENV"
+        echo "DELIM" > "$OMNI_ENV"
+
+EOF
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "SIMPLE: BEGIN"
+  echo "$SIMPLE"
+  echo "SIMPLE: END"
+  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "NOINDENT: BEGIN"
+  echo "$NOINDENT"
+  echo "NOINDENT: END"
+  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ]
+
+  echo "NOINDENT_INDENTEDDELIM: BEGIN"
+  echo "$NOINDENT_INDENTEDDELIM"
+  echo "NOINDENT_INDENTEDDELIM: END"
+  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ]
+
+  echo "MININDENT: BEGIN"
+  echo "$MININDENT"
+  echo "MININDENT: END"
+  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ]
+
+  echo "WITHSPACES: BEGIN"
+  echo "$WITHSPACES"
+  echo "WITHSPACES: END"
+  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "WITHSQUOTES: BEGIN"
+  echo "$WITHSQUOTES"
+  echo "WITHSQUOTES: END"
+  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "WITHDQUOTES: BEGIN"
+  echo "$WITHDQUOTES"
+  echo "WITHDQUOTES: END"
+  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+}
+
+custom_operation_multiline_double_arrow() {
   cat > .omni.yaml <<'EOF'
 up:
   - custom:
@@ -241,28 +336,53 @@ EOF
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
-@test "omni up custom operation should allow to set a multiline environment variables (1/5)" {
-  custom_operation_multiline
+@test "omni up custom operation should allow to set a multiline environment variables using > (1/5)" {
+  custom_operation_multiline_single_arrow
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
-@test "omni up custom operation should allow to set a multiline environment variables (2/5)" {
-  custom_operation_multiline
+@test "omni up custom operation should allow to set a multiline environment variables using > (2/5)" {
+  custom_operation_multiline_single_arrow
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
-@test "omni up custom operation should allow to set a multiline environment variables (3/5)" {
-  custom_operation_multiline
+@test "omni up custom operation should allow to set a multiline environment variables using > (3/5)" {
+  custom_operation_multiline_single_arrow
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
-@test "omni up custom operation should allow to set a multiline environment variables (4/5)" {
-  custom_operation_multiline
+@test "omni up custom operation should allow to set a multiline environment variables using > (4/5)" {
+  custom_operation_multiline_single_arrow
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
-@test "omni up custom operation should allow to set a multiline environment variables (5/5)" {
-  custom_operation_multiline
+@test "omni up custom operation should allow to set a multiline environment variables using > (5/5)" {
+  custom_operation_multiline_single_arrow
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables using >> (1/5)" {
+  custom_operation_multiline_double_arrow
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables using >> (2/5)" {
+  custom_operation_multiline_double_arrow
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables using >> (3/5)" {
+  custom_operation_multiline_double_arrow
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables using >> (4/5)" {
+  custom_operation_multiline_double_arrow
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables using >> (5/5)" {
+  custom_operation_multiline_double_arrow
 }
 
 # bats test_tags=omni:up,omni:up:custom

--- a/tests/test_omni_up_custom.bats
+++ b/tests/test_omni_up_custom.bats
@@ -136,7 +136,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -198,46 +200,72 @@ EOF
   run omni up --trust 3>&-
   echo "STATUS: $status"
   echo "OUTPUT: $output"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || {
+    echo "command failed, expected success"
+    return 1
+  }
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "SIMPLE: BEGIN"
   echo "$SIMPLE"
   echo "SIMPLE: END"
-  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "SIMPLE does not match"
+    return 1
+  }
 
   echo "NOINDENT: BEGIN"
   echo "$NOINDENT"
   echo "NOINDENT: END"
-  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ]
+  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ] || {
+    echo "NOINDENT does not match"
+    return 1
+  }
 
   echo "NOINDENT_INDENTEDDELIM: BEGIN"
   echo "$NOINDENT_INDENTEDDELIM"
   echo "NOINDENT_INDENTEDDELIM: END"
-  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ]
+  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ] || {
+    echo "NOINDENT_INDENTEDDELIM does not match"
+    return 1
+  }
 
   echo "MININDENT: BEGIN"
   echo "$MININDENT"
   echo "MININDENT: END"
-  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ]
+  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ] || {
+    echo "MININDENT does not match"
+    return 1
+  }
 
   echo "WITHSPACES: BEGIN"
   echo "$WITHSPACES"
   echo "WITHSPACES: END"
-  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHSPACES does not match"
+    return 1
+  }
 
   echo "WITHSQUOTES: BEGIN"
   echo "$WITHSQUOTES"
   echo "WITHSQUOTES: END"
-  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHSQUOTES does not match"
+    return 1
+  }
 
   echo "WITHDQUOTES: BEGIN"
   echo "$WITHDQUOTES"
   echo "WITHDQUOTES: END"
-  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHDQUOTES does not match"
+    return 1
+  }
 }
 
 custom_operation_multiline_double_arrow() {
@@ -293,46 +321,72 @@ EOF
   run omni up --trust 3>&-
   echo "STATUS: $status"
   echo "OUTPUT: $output"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 0 ] || {
+    echo "command failed, expected success"
+    return 1
+  }
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "SIMPLE: BEGIN"
   echo "$SIMPLE"
   echo "SIMPLE: END"
-  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "SIMPLE does not match"
+    return 1
+  }
 
   echo "NOINDENT: BEGIN"
   echo "$NOINDENT"
   echo "NOINDENT: END"
-  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ]
+  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ] || {
+    echo "NOINDENT does not match"
+    return 1
+  }
 
   echo "NOINDENT_INDENTEDDELIM: BEGIN"
   echo "$NOINDENT_INDENTEDDELIM"
   echo "NOINDENT_INDENTEDDELIM: END"
-  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ]
+  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ] || {
+    echo "NOINDENT_INDENTEDDELIM does not match"
+    return 1
+  }
 
   echo "MININDENT: BEGIN"
   echo "$MININDENT"
   echo "MININDENT: END"
-  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ]
+  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ] || {
+    echo "MININDENT does not match"
+    return 1
+  }
 
   echo "WITHSPACES: BEGIN"
   echo "$WITHSPACES"
   echo "WITHSPACES: END"
-  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHSPACES does not match"
+    return 1
+  }
 
   echo "WITHSQUOTES: BEGIN"
   echo "$WITHSQUOTES"
   echo "WITHSQUOTES: END"
-  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHSQUOTES does not match"
+    return 1
+  }
 
   echo "WITHDQUOTES: BEGIN"
   echo "$WITHDQUOTES"
   echo "WITHDQUOTES: END"
-  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ] || {
+    echo "WITHDQUOTES does not match"
+    return 1
+  }
 }
 
 # bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
@@ -411,7 +465,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -442,7 +498,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -473,7 +531,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -502,7 +562,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -533,7 +595,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -579,7 +643,9 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  eval "$(omni hook env --quiet)"
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  eval "$(omni hook env --quiet | tee /dev/stderr)"
+  echo "DYNAMIC ENVIRONMENT -- END"
 
   # Check the variable
   echo "BEGIN_ENV_VAR: $BEGIN_ENV_VAR"

--- a/tests/test_omni_up_custom.bats
+++ b/tests/test_omni_up_custom.bats
@@ -19,6 +19,16 @@ teardown() {
   check_commands
 }
 
+reload_dynenv() {
+  expected_env="$(omni hook env --quiet)"
+
+  echo "DYNAMIC ENVIRONMENT -- BEGIN"
+  echo "$expected_env"
+  echo "DYNAMIC ENVIRONMENT -- END"
+
+  eval "$(echo "$expected_env")"
+}
+
 # bats test_tags=omni:up,omni:up:custom
 @test "omni up custom operation" {
   cat > .omni.yaml <<EOF
@@ -136,9 +146,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -206,9 +214,7 @@ EOF
   }
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "SIMPLE: BEGIN"
@@ -327,9 +333,7 @@ EOF
   }
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "SIMPLE: BEGIN"
@@ -465,9 +469,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -498,9 +500,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -531,9 +531,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -562,9 +560,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -595,9 +591,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "ENV_VAR: $ENV_VAR"
@@ -643,9 +637,7 @@ EOF
   [ "$status" -eq 0 ]
 
   # Load the dynamic environment
-  echo "DYNAMIC ENVIRONMENT -- BEGIN"
-  eval "$(omni hook env --quiet | tee /dev/stderr)"
-  echo "DYNAMIC ENVIRONMENT -- END"
+  reload_dynenv
 
   # Check the variable
   echo "BEGIN_ENV_VAR: $BEGIN_ENV_VAR"

--- a/tests/test_omni_up_custom.bats
+++ b/tests/test_omni_up_custom.bats
@@ -1,0 +1,484 @@
+#!/usr/bin/env bats
+
+load 'helpers/utils'
+
+setup() {
+  # Setup the environment for the test; this should override $HOME too
+  omni_setup 3>&-
+
+  setup_omni_config 3>&-
+
+  # Add one repository
+  setup_git_dir "git/github.com/test1org/test1repo" "git@github.com:test1org/test1repo.git"
+
+  # Change directory to the repository
+  cd "git/github.com/test1org/test1repo"
+}
+
+teardown() {
+  check_commands
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation" {
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: "customcmd run"
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+  add_command customcmd run
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation fails if command fails" {
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: "customcmd run"
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+  add_command customcmd run exit=1
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom only executes first command if failing" {
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        set -e
+        customcmd run
+        customcmd should-not-run
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+  add_command customcmd run exit=1
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should not run if 'met' condition is true" {
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      met?: "customcmd met?"
+      meet: "customcmd should-not-run"
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+  add_command customcmd met?
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should run if 'met' condition is false" {
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      met?: "customcmd met?"
+      meet: "customcmd run"
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+  add_command customcmd met? exit=1
+  add_command customcmd run
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to set environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "ENV_VAR=VALUE" >> "$OMNI_ENV"
+        echo "ENV_VAR2=VALUE2" >> "$OMNI_ENV"
+EOF
+
+  [ -z "$ENV_VAR" ]
+  export ENV_VAR2="otherval"
+  [ "$ENV_VAR2" = "otherval" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ "$ENV_VAR" = "VALUE" ]
+  echo "ENV_VAR2: $ENV_VAR2"
+  [ "$ENV_VAR2" = "VALUE2" ]
+}
+
+custom_operation_multiline() {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "SIMPLE<<DELIM" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+        echo "NOINDENT<<-DELIM" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+        echo "NOINDENT_INDENTEDDELIM<<-DELIM" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo " DELIM" >> "$OMNI_ENV"
+
+        echo "MININDENT<<~DELIM" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+        echo "WITHSPACES<< DELIM " >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+        echo "WITHSQUOTES<<'DELIM'" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+        echo "WITHDQUOTES<<\"DELIM\"" >> "$OMNI_ENV"
+        echo "  line1" >> "$OMNI_ENV"
+        echo "    line2" >> "$OMNI_ENV"
+        echo "  line3" >> "$OMNI_ENV"
+        echo "DELIM" >> "$OMNI_ENV"
+
+EOF
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "SIMPLE: BEGIN"
+  echo "$SIMPLE"
+  echo "SIMPLE: END"
+  [ "$SIMPLE" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "NOINDENT: BEGIN"
+  echo "$NOINDENT"
+  echo "NOINDENT: END"
+  [ "$NOINDENT" = "$(echo -e "line1\nline2\nline3")" ]
+
+  echo "NOINDENT_INDENTEDDELIM: BEGIN"
+  echo "$NOINDENT_INDENTEDDELIM"
+  echo "NOINDENT_INDENTEDDELIM: END"
+  [ "$NOINDENT_INDENTEDDELIM" = "$(echo -e "line1\nline2\nline3")" ]
+
+  echo "MININDENT: BEGIN"
+  echo "$MININDENT"
+  echo "MININDENT: END"
+  [ "$MININDENT" = "$(echo -e "line1\n  line2\nline3")" ]
+
+  echo "WITHSPACES: BEGIN"
+  echo "$WITHSPACES"
+  echo "WITHSPACES: END"
+  [ "$WITHSPACES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "WITHSQUOTES: BEGIN"
+  echo "$WITHSQUOTES"
+  echo "WITHSQUOTES: END"
+  [ "$WITHSQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+
+  echo "WITHDQUOTES: BEGIN"
+  echo "$WITHDQUOTES"
+  echo "WITHDQUOTES: END"
+  [ "$WITHDQUOTES" = "$(echo -e "  line1\n    line2\n  line3")" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables (1/5)" {
+  custom_operation_multiline
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables (2/5)" {
+  custom_operation_multiline
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables (3/5)" {
+  custom_operation_multiline
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables (4/5)" {
+  custom_operation_multiline
+}
+
+# bats test_tags=omni:up,omni:up:custom,omni:up:custom:multiline
+@test "omni up custom operation should allow to set a multiline environment variables (5/5)" {
+  custom_operation_multiline
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to unset environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        set -e
+        # Make sure that the variable is set
+        [ -n "$ENV_VAR" ]
+        # Unset the variable
+        echo "unset ENV_VAR" >> "$OMNI_ENV"
+        echo "unset ENV_VAR2" >> "$OMNI_ENV"
+EOF
+
+  export ENV_VAR="VALUE"
+  [ "$ENV_VAR" = "VALUE" ]
+  unset ENV_VAR2
+  [ -z "$ENV_VAR2" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ -z "$ENV_VAR" ]
+  echo "ENV_VAR2: $ENV_VAR2"
+  [ -z "$ENV_VAR2" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to prefix environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "ENV_VAR<=PRE" >> "$OMNI_ENV"
+        echo "ENV_VAR2<=PRE2" >> "$OMNI_ENV"
+EOF
+
+  export ENV_VAR="VALUE"
+  [ "$ENV_VAR" = "VALUE" ]
+  unset ENV_VAR2
+  [ -z "$ENV_VAR2" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ "$ENV_VAR" = "PREVALUE" ]
+  echo "ENV_VAR2: $ENV_VAR"
+  [ "$ENV_VAR2" = "PRE2" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to suffix environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "ENV_VAR>=POST" >> "$OMNI_ENV"
+        echo "ENV_VAR2>=POST2" >> "$OMNI_ENV"
+EOF
+
+  export ENV_VAR="VALUE"
+  [ "$ENV_VAR" = "VALUE" ]
+  unset ENV_VAR2
+  [ -z "$ENV_VAR2" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ "$ENV_VAR" = "VALUEPOST" ]
+  echo "ENV_VAR2: $ENV_VAR"
+  [ "$ENV_VAR2" = "POST2" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to append to a path-like environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "ENV_VAR>>=newval" >> "$OMNI_ENV"
+        echo "ENV_VAR2>>=newval2" >> "$OMNI_ENV"
+EOF
+
+  export ENV_VAR="val1:val2"
+  [ "$ENV_VAR" = "val1:val2" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ "$ENV_VAR" = "val1:val2:newval" ]
+  echo "ENV_VAR2: $ENV_VAR2"
+  [ "$ENV_VAR2" = "newval2" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to prepend to a path-like environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "ENV_VAR<<=newval" >> "$OMNI_ENV"
+        echo "ENV_VAR2<<=newval2" >> "$OMNI_ENV"
+EOF
+
+  export ENV_VAR="val1:val2"
+  [ "$ENV_VAR" = "val1:val2" ]
+  unset ENV_VAR2
+  [ -z "$ENV_VAR2" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "ENV_VAR: $ENV_VAR"
+  [ "$ENV_VAR" = "newval:val1:val2" ]
+  echo "ENV_VAR2: $ENV_VAR2"
+  [ "$ENV_VAR2" = "newval2" ]
+}
+
+# bats test_tags=omni:up,omni:up:custom
+@test "omni up custom operation should allow to remove from a path-like environment variables" {
+  cat > .omni.yaml <<'EOF'
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: |
+        echo "BEGIN_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "MID_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "END_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "ONLY_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "NOVAL_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "EMPTY_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "UNSET_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "MULTI_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "MULTI_REPEAT_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "MULTI_REPEAT_ENV_VAR-=oldval" >> "$OMNI_ENV"
+        echo "MULTI_REPEAT_ENV_VAR-=oldval" >> "$OMNI_ENV"
+EOF
+
+  export BEGIN_ENV_VAR="oldval:val1:val2"
+  export MID_ENV_VAR="val1:oldval:val2"
+  export END_ENV_VAR="val1:val2:oldval"
+  export ONLY_ENV_VAR="oldval"
+  export NOVAL_ENV_VAR="val1:val2"
+  export EMPTY_ENV_VAR=""
+  export MULTI_ENV_VAR="oldval:val1:oldval:val2:oldval"
+  export MULTI_REPEAT_ENV_VAR="oldval:val1:oldval:val2:oldval"
+  unset UNSET_ENV_VAR
+  [ -z "$UNSET_ENV_VAR" ]
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+
+  # Load the dynamic environment
+  eval "$(omni hook env --quiet)"
+
+  # Check the variable
+  echo "BEGIN_ENV_VAR: $BEGIN_ENV_VAR"
+  [ "$BEGIN_ENV_VAR" = "val1:val2" ]
+  echo "MID_ENV_VAR: $MID_ENV_VAR"
+  [ "$MID_ENV_VAR" = "val1:val2" ]
+  echo "END_ENV_VAR: $END_ENV_VAR"
+  [ "$END_ENV_VAR" = "val1:val2" ]
+  echo "ONLY_ENV_VAR: $ONLY_ENV_VAR"
+  [ -z "$ONLY_ENV_VAR" ]
+  echo "NOVAL_ENV_VAR: $NOVAL_ENV_VAR"
+  [ "$NOVAL_ENV_VAR" = "val1:val2" ]
+  echo "EMPTY_ENV_VAR: $EMPTY_ENV_VAR"
+  [ -z "$EMPTY_ENV_VAR" ]
+  echo "UNSET_ENV_VAR: $UNSET_ENV_VAR"
+  [ -z "$UNSET_ENV_VAR" ]
+  echo "MULTI_ENV_VAR: $MULTI_ENV_VAR"
+  [ "$MULTI_ENV_VAR" = "val1:oldval:val2:oldval" ]
+  echo "MULTI_REPEAT_ENV_VAR: $MULTI_REPEAT_ENV_VAR"
+  [ "$MULTI_REPEAT_ENV_VAR" = "val1:val2" ]
+}
+

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-custom.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-custom.md
@@ -22,6 +22,31 @@ The following parameters can be used:
 | `unmeet` | multiline string | the command to run to 'unmeet' the requirement during tear down |
 | `dir` | path | Relative path to the directory the custom operation needs to be run from. The dynamic environment of that directory will be loaded before any of the executions for the operation. Defaults to the work dir root. |
 
+## The `$OMNI_ENV` environment variable
+
+When running the `meet` step of a `custom` operation, the `$OMNI_ENV` environment variable is set to the path of a file that can be used to manipulate the dynamic environment being built for the work directory. When writing to this file, specific patterns must be followed to ensure the dynamic environment is correctly built.
+
+| Pattern | Description |
+|---------|-------------|
+| `VAR=value` | Sets the environment variable `VAR` to `value` |
+| `unset VAR` | Unsets the environment variable `VAR` |
+| `VAR<<EOF` | Starts a multiline value for the environment variable `VAR`. The value will be read until `EOF` is found on a line by itself. |
+| `VAR<<-EOF` | Same as `VAR<<EOF`, but all leading tabs and spaces will be removed from the multiline value. |
+| `VAR<<~EOF` | Same as `VAR<<EOF`, but the minimum indentation of the multiline value will be removed from all lines. |
+| `VAR<<=value` | Prepends `value` to the path-like environment variable `VAR`; i.e. `VAR` will be set to `value:$VAR`. |
+| `VAR>>=value` | Appends `value` to the path-like environment variable `VAR`; i.e. `VAR` will be set to `$VAR:value`. |
+| `VAR-=value` | Removes `value` from the path-like environment variable `VAR`; i.e. if `VAR` is set to `otherval:value:someval`, `VAR` will be set to `otherval:someval`. |
+| `VAR<=value` | Adds `value` as a prefix to `VAR`; i.e. if `VAR` is set to `someval`, `VAR` will be set to `valuesomeval`. |
+| `VAR>=value` | Adds `value` as a suffix to `VAR`; i.e. if `VAR` is set to `someval`, `VAR` will be set to `somevalvalue`. |
+
+:::tip
+
+It is recommended to prefer the advanced patterns (e.g. `>>=`, `<<=`, `-=`, `>=`, `<=`) as the environment variable manipulation will happen when the dynamic environment is loaded for the work directory, making those changes relative to the current environment being changed.
+
+When using the `VAR=value` pattern, the value of `VAR` will be set to `value` regardless of the current value of `VAR`. If using `echo PATH=$PATH:/some/path >"$OMNI_ENV`", the value of `$PATH` will be calculated at the time of `omni up` and the resulting value will be fixed no matter future changes in the environment of the user.
+
+:::
+
 ## Examples
 
 ```yaml
@@ -51,4 +76,40 @@ up:
       met?: test -f /tmp/did_greet
       meet: touch /tmp/did_greet && echo "hello"
       unmeet: rm /tmp/did_greet && echo "goodbye"
+
+  # Set the environment variable `HELLO` to `world`
+  - custom:
+      name: Setting HELLO
+      meet: echo "HELLO=world" >"$OMNI_ENV"
+
+  # Set a multiline environment variable
+  - custom:
+      name: Setting multiline
+      meet: |
+        echo "MULTILINE<<-EOF" >"$OMNI_ENV"
+        echo "  line1" >"$OMNI_ENV"
+        echo "  line2" >"$OMNI_ENV"
+        echo "EOF" >"$OMNI_ENV"
+
+  # Set a path-like environment variable
+  - custom:
+      name: Setting PATH
+      meet: |
+        # Append to the PATH environment variable
+        echo "PATH>>=/some/path" >"$OMNI_ENV"
+        # Prepend to the PATH environment variable
+        echo "PATH<=/some/other/path" >"$OMNI_ENV"
+        # Remove from the PATH environment variable
+        echo "PATH-=/some/older/path" >"$OMNI_ENV"
+
+  # Do other environment variable manipulations
+  - custom:
+      name: Other environment variable manipulations
+      meet: |
+        # Add a prefix to the MYVAR environment variable
+        echo "MYVAR<=prefix" >"$OMNI_ENV"
+        # Add a suffix to the MYVAR environment variable
+        echo "MYVAR>=suffix" >"$OMNI_ENV"
+        # Unset the HELLO environment variable
+        echo "unset HELLO" >"$OMNI_ENV"
 ```


### PR DESCRIPTION
The `custom` operations of `omni up` now allow for adding environment variables in the dynamic environment through the special `$OMNI_ENV` environment variable provided during the `custom` operations.

This variable works similarly to `$GITHUB_ENV` in GitHub actions for instance. It supports the basic environment setting format:
- `unset VAR` to unset a variable
- `VAR=value` to set a variable to the value `value`
- `VAR<<EOF` followed by any number of lines, followed by a delimiter (like `EOF`) to set a multiline environment variable using heredoc formatting (`VAR<<-EOF` also works to remove all indentation, and `VAR<<~EOF` to remove the minimum indentation)

It does also support extended operations. These are safer to use for the dynamic environment provided by omni, as they are applied relative to the environment at the time of applying the dynamic environment, vs. being set as absolute values at the time of `omni up`.

The extended operations are the following:
- `VAR<<=value` to prepend a value to a path-like environment variable
- `VAR>>=value` to append a value to a path-like environment variable
- `VAR-=value` to remove a value from a path-like environment variable
- `VAR>=value` to add a suffix to an environment variable
- `VAR<=value` to add a prefix to an environment variable

Closes https://github.com/XaF/omni/issues/700