### PR TITLE
fix(cleanup): correctly delete symlinks

### DIFF
--- a/src/internal/config/up/utils/directory.rs
+++ b/src/internal/config/up/utils/directory.rs
@@ -216,7 +216,7 @@ pub fn cleanup_path(
 
         progress_handler.progress(format!("removing {}", path.display()));
 
-        if path.is_file() {
+        if path.is_symlink() || path.is_file() {
             if let Err(error) = std::fs::remove_file(path) {
                 return Err(UpError::Exec(format!(
                     "failed to remove {}: {}",


### PR DESCRIPTION
`cleanup_path` would throw an error when attempting to clean up symlinks to the nix store.

It shouldn't, so let's clean them up!