### PR TITLE
`up`/`go-install`: add a way to `go install` tools easily

### DIFF
--- a/src/internal/cache/database/sql/go_install_operation_add.sql
+++ b/src/internal/cache/database/sql/go_install_operation_add.sql
@@ -1,0 +1,19 @@
+-- Add a new go-installed tool
+-- :param: ?1 import_path - the import path used with 'go install'
+-- :param: ?2 version - the version of the tool
+INSERT INTO go_installed (
+    import_path,
+    version,
+    last_required_at
+)
+VALUES (
+    ?1,
+    ?2,
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+)
+ON CONFLICT (import_path, version) DO UPDATE
+SET
+    last_required_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE
+    import_path = ?1
+    AND version = ?2;

--- a/src/internal/cache/database/sql/go_install_operation_add_required_by.sql
+++ b/src/internal/cache/database/sql/go_install_operation_add_required_by.sql
@@ -1,0 +1,15 @@
+-- Add required_by relationship for go-install tool
+-- :param: ?1 import_path - the import path used with 'go install'
+-- :param: ?2 version - the version of the tool
+-- :param: ?3 env_version_id - the id of the environment version that is requiring the tool
+INSERT INTO go_install_required_by (
+    import_path,
+    version,
+    env_version_id
+)
+VALUES (
+    ?1,
+    ?2,
+    ?3
+)
+ON CONFLICT (import_path, version, env_version_id) DO NOTHING;

--- a/src/internal/cache/database/sql/go_install_operation_add_versions.sql
+++ b/src/internal/cache/database/sql/go_install_operation_add_versions.sql
@@ -1,0 +1,19 @@
+-- Cache go versions for a given import path
+-- :param: ?1 import_path - the import path used with 'go install'
+-- :param: ?2 versions - JSON array of String
+INSERT INTO go_versions (
+    import_path,
+    versions,
+    fetched_at
+)
+VALUES (
+    ?1,
+    ?2,
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+)
+ON CONFLICT (import_path) DO UPDATE
+SET
+    versions = ?2,
+    fetched_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE
+    import_path = ?1;

--- a/src/internal/cache/database/sql/go_install_operation_cleanup.sql
+++ b/src/internal/cache/database/sql/go_install_operation_cleanup.sql
@@ -1,0 +1,13 @@
+-- Delete the go install versions that are not required by any workdir
+-- :param1: number of seconds of the grace period before a version can be removed
+DELETE FROM go_installed AS gi
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM go_install_required_by AS girb
+    WHERE girb.import_path = gi.import_path
+          AND girb.version = gi.version
+)
+AND (
+    CAST(strftime('%s', 'now') AS INTEGER) >
+    (CAST(strftime('%s', last_required_at) AS INTEGER) + ?1)
+);

--- a/src/internal/cache/database/sql/go_install_operation_get_versions.sql
+++ b/src/internal/cache/database/sql/go_install_operation_get_versions.sql
@@ -1,0 +1,9 @@
+-- Get the go versions cached for a given import path
+-- :param: ?1 import_path - the import path used with 'go install'
+SELECT
+    versions,
+    fetched_at
+FROM
+    go_versions
+WHERE
+    import_path = ?1;

--- a/src/internal/cache/database/sql/go_install_operation_list_installed.sql
+++ b/src/internal/cache/database/sql/go_install_operation_list_installed.sql
@@ -1,0 +1,6 @@
+-- List all the installed go tools
+SELECT
+    import_path,
+    version
+FROM
+    go_installed;

--- a/src/internal/cache/go_install.rs
+++ b/src/internal/cache/go_install.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use rusqlite::params;
 use rusqlite::Row;
 use serde::Deserialize;

--- a/src/internal/cache/go_install.rs
+++ b/src/internal/cache/go_install.rs
@@ -1,0 +1,142 @@
+use itertools::Itertools;
+use rusqlite::params;
+use rusqlite::Row;
+use serde::Deserialize;
+use serde::Serialize;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::internal::cache::database::FromRow;
+use crate::internal::cache::database::RowExt;
+use crate::internal::cache::CacheManager;
+use crate::internal::cache::CacheManagerError;
+use crate::internal::config::global_config;
+use crate::internal::env::now as omni_now;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GoInstallOperationCache {}
+
+impl GoInstallOperationCache {
+    pub fn get() -> Self {
+        Self {}
+    }
+
+    pub fn add_versions(
+        &self,
+        path: &str,
+        versions: &GoInstallVersions,
+    ) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/go_install_operation_add_versions.sql"),
+            params![path, serde_json::to_string(&versions.versions)?],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn get_versions(&self, path: &str) -> Option<GoInstallVersions> {
+        let db = CacheManager::get();
+        let versions: Option<GoInstallVersions> = db
+            .query_one(
+                include_str!("database/sql/go_install_operation_get_versions.sql"),
+                params![path],
+            )
+            .ok();
+        versions
+    }
+
+    pub fn add_installed(&self, path: &str, version: &str) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/go_install_operation_add.sql"),
+            params![path, version],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn add_required_by(
+        &self,
+        env_version_id: &str,
+        path: &str,
+        version: &str,
+    ) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/go_install_operation_add_required_by.sql"),
+            params![path, version, env_version_id],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn list_installed(&self) -> Result<Vec<GoInstalled>, CacheManagerError> {
+        let db = CacheManager::get();
+        let installed: Vec<GoInstalled> = db.query_as(
+            include_str!("database/sql/go_install_operation_list_installed.sql"),
+            params![],
+        )?;
+        Ok(installed)
+    }
+
+    pub fn cleanup(&self) -> Result<(), CacheManagerError> {
+        let db = CacheManager::get();
+
+        let config = global_config();
+        let grace_period = config.cache.go_install.cleanup_after;
+
+        db.execute(
+            include_str!("database/sql/go_install_operation_cleanup.sql"),
+            params![&grace_period],
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GoInstalled {
+    pub path: String,
+    pub version: String,
+}
+
+impl FromRow for GoInstalled {
+    fn from_row(row: &Row) -> Result<Self, CacheManagerError> {
+        Ok(Self {
+            path: row.get("import_path")?,
+            version: row.get("version")?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GoInstallVersions {
+    #[serde(alias = "Versions")]
+    pub versions: Vec<String>,
+    #[serde(default = "OffsetDateTime::now_utc", with = "time::serde::rfc3339")]
+    pub fetched_at: OffsetDateTime,
+}
+
+impl GoInstallVersions {
+    pub fn is_fresh(&self) -> bool {
+        self.fetched_at >= omni_now()
+    }
+
+    pub fn is_stale(&self, ttl: u64) -> bool {
+        let duration = time::Duration::seconds(ttl as i64);
+        self.fetched_at + duration < OffsetDateTime::now_utc()
+    }
+}
+
+impl FromRow for GoInstallVersions {
+    fn from_row(row: &Row) -> Result<Self, CacheManagerError> {
+        let versions_str: String = row.get("versions")?;
+        let versions: Vec<String> = serde_json::from_str(&versions_str)?;
+
+        let fetched_at_str: String = row.get("fetched_at")?;
+        let fetched_at: OffsetDateTime = OffsetDateTime::parse(&fetched_at_str, &Rfc3339)?;
+
+        Ok(Self {
+            versions,
+            fetched_at,
+        })
+    }
+}

--- a/src/internal/cache/go_install.rs
+++ b/src/internal/cache/go_install.rs
@@ -139,3 +139,326 @@ impl FromRow for GoInstallVersions {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::internal::cache::database::get_conn;
+    use crate::internal::testutils::run_with_env;
+
+    mod go_install_operation_cache {
+        use super::*;
+        use time::OffsetDateTime;
+
+        #[test]
+        fn test_add_and_get_versions() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+
+                // Create test versions
+                let versions = GoInstallVersions {
+                    versions: vec!["v1.0.0".to_string(), "v1.1.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Test adding versions
+                assert!(cache
+                    .add_versions(path, &versions)
+                    .expect("Failed to add versions"));
+
+                // Test retrieving versions
+                let retrieved = cache.get_versions(path).expect("Failed to get versions");
+                assert_eq!(retrieved.versions.len(), 2);
+                assert!(retrieved.versions.contains(&"v1.0.0".to_string()));
+                assert!(retrieved.versions.contains(&"v1.1.0".to_string()));
+
+                // Test retrieving non-existent package
+                let non_existent = cache.get_versions("non/existent");
+                assert!(non_existent.is_none());
+            });
+        }
+
+        #[test]
+        fn test_add_and_list_installed() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+                let version = "v1.0.0";
+
+                // Test adding installed version
+                assert!(cache
+                    .add_installed(path, version)
+                    .expect("Failed to add installed version"));
+
+                // Test listing installed versions
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+                assert_eq!(installed[0].path, path);
+                assert_eq!(installed[0].version, version);
+
+                // Test adding duplicate installed version
+                assert!(cache
+                    .add_installed(path, version)
+                    .expect("Failed to add duplicate installed version"));
+
+                // Verify no duplicates in list
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+            });
+        }
+
+        #[test]
+        fn test_add_required_by() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_version_id = "test-env-id";
+
+                // Add environment version first for foreign key constraint
+                let conn = get_conn();
+                conn.execute(
+                    include_str!("database/sql/up_environments_insert_env_version.sql"),
+                    params![env_version_id, "{}", "[]", "[]", "{}", "hash"],
+                )
+                .expect("Failed to add environment version");
+
+                // Try adding required_by without installed - should fail
+                let result = cache.add_required_by(env_version_id, path, version);
+                assert!(result.is_err(), "Should fail without installed version");
+
+                // Add installed version
+                cache
+                    .add_installed(path, version)
+                    .expect("Failed to add installed version");
+
+                // Now add required_by - should succeed
+                assert!(cache
+                    .add_required_by(env_version_id, path, version)
+                    .expect("Failed to add required by relationship"));
+
+                // Verify the relationship exists
+                let required_exists: bool = conn
+                    .query_row(
+                        concat!(
+                            "SELECT EXISTS(",
+                            "  SELECT 1 FROM go_install_required_by ",
+                            "  WHERE import_path = ?1 AND version = ?2 AND env_version_id = ?3",
+                            ")",
+                        ),
+                        params![path, version, env_version_id],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query required by relationship");
+                assert!(required_exists);
+            });
+        }
+
+        #[test]
+        fn test_multiple_required_by() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_version_ids = vec!["env-1", "env-2", "env-3"];
+
+                // Add installed version first
+                cache
+                    .add_installed(path, version)
+                    .expect("Failed to add installed version");
+
+                // Add environments
+                let conn = get_conn();
+                for env_id in &env_version_ids {
+                    conn.execute(
+                        include_str!("database/sql/up_environments_insert_env_version.sql"),
+                        params![env_id, "{}", "[]", "[]", "{}", "hash"],
+                    )
+                    .expect("Failed to add environment version");
+                }
+
+                // Add requirements for each environment
+                for env_id in &env_version_ids {
+                    assert!(cache
+                        .add_required_by(env_id, path, version)
+                        .expect("Failed to add requirement"));
+                }
+
+                // Verify requirements
+                for env_id in &env_version_ids {
+                    let required: bool = conn
+                        .query_row(
+                            concat!(
+                                "SELECT EXISTS(",
+                                "  SELECT 1 FROM go_install_required_by ",
+                                "  WHERE import_path = ?1 AND version = ?2 AND env_version_id = ?3",
+                                ")",
+                            ),
+                            params![path, version, env_id],
+                            |row| row.get(0),
+                        )
+                        .expect("Failed to query requirement");
+                    assert!(required, "Requirement for {} should exist", env_id);
+                }
+            });
+        }
+
+        #[test]
+        fn test_cleanup() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+
+                // Add two packages
+                let pkg1 = "github.com/test/pkg1";
+                let pkg2 = "github.com/test/pkg2";
+                let version = "v1.0.0";
+
+                // Add installations
+                cache
+                    .add_installed(pkg1, version)
+                    .expect("Failed to add pkg1 installation");
+                cache
+                    .add_installed(pkg2, version)
+                    .expect("Failed to add pkg2 installation");
+
+                let conn = get_conn();
+
+                // Set pkg1's last_required_at to old date (should be cleaned up)
+                conn.execute(
+                    concat!(
+                        "UPDATE go_installed ",
+                        "SET last_required_at = '1970-01-01T00:00:00.000Z' ",
+                        "WHERE import_path = ?1",
+                    ),
+                    params![pkg1],
+                )
+                .expect("Failed to update last_required_at for pkg1");
+
+                // Keep pkg2's last_required_at recent (should not be cleaned up)
+                conn.execute(
+                    concat!(
+                        "UPDATE go_installed ",
+                        "SET last_required_at = datetime('now') ",
+                        "WHERE import_path = ?1",
+                    ),
+                    params![pkg2],
+                )
+                .expect("Failed to update last_required_at for pkg2");
+
+                // Run cleanup
+                cache.cleanup().expect("Failed to cleanup");
+
+                // Verify pkg1 was cleaned up
+                let pkg1_exists: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM go_installed WHERE import_path = ?1)",
+                        params![pkg1],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query pkg1");
+                assert!(!pkg1_exists, "Old installation should have been cleaned up");
+
+                // Verify pkg2 still exists
+                let pkg2_exists: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM go_installed WHERE import_path = ?1)",
+                        params![pkg2],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query pkg2");
+                assert!(
+                    pkg2_exists,
+                    "Recent installation should not have been cleaned up"
+                );
+
+                // Verify through list_installed
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+                assert_eq!(installed[0].path, pkg2);
+            });
+        }
+
+        #[test]
+        fn test_update_versions() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+
+                // Create initial versions
+                let versions1 = GoInstallVersions {
+                    versions: vec!["v1.0.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Add initial versions
+                assert!(cache
+                    .add_versions(path, &versions1)
+                    .expect("Failed to add initial versions"));
+
+                // Create updated versions
+                let versions2 = GoInstallVersions {
+                    versions: vec!["v1.0.0".to_string(), "v1.1.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Update versions
+                assert!(cache
+                    .add_versions(path, &versions2)
+                    .expect("Failed to update versions"));
+
+                // Verify updated versions
+                let retrieved = cache.get_versions(path).expect("Failed to get versions");
+                assert_eq!(retrieved.versions.len(), 2);
+                assert!(retrieved.versions.contains(&"v1.1.0".to_string()));
+            });
+        }
+
+        #[test]
+        fn test_cleanup_cascade() {
+            run_with_env(&[], || {
+                let cache = GoInstallOperationCache::get();
+                let path = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_id = "test-env";
+
+                // Add environment
+                let conn = get_conn();
+                conn.execute(
+                    include_str!("database/sql/up_environments_insert_env_version.sql"),
+                    params![env_id, "{}", "[]", "[]", "{}", "hash"],
+                )
+                .expect("Failed to add environment version");
+
+                // Add installation and requirement
+                cache
+                    .add_installed(path, version)
+                    .expect("Failed to add installed version");
+                cache
+                    .add_required_by(env_id, path, version)
+                    .expect("Failed to add requirement");
+
+                // Remove environment
+                conn.execute(
+                    "DELETE FROM env_versions WHERE env_version_id = ?1",
+                    params![env_id],
+                )
+                .expect("Failed to remove environment");
+
+                // Verify that the requirement has been cleaned up
+                let requirement_exists: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM go_install_required_by WHERE import_path = ?1 AND version = ?2 AND env_version_id = ?3)",
+                        params![path, version, env_id],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query requirement");
+                assert!(
+                    !requirement_exists,
+                    "Requirement should be cleaned up via cascade"
+                );
+            });
+        }
+    }
+}

--- a/src/internal/cache/mod.rs
+++ b/src/internal/cache/mod.rs
@@ -10,6 +10,10 @@ pub(crate) use github_release::GithubReleaseOperationCache;
 pub(crate) use github_release::GithubReleaseVersion;
 pub(crate) use github_release::GithubReleases;
 
+pub(crate) mod go_install;
+pub(crate) use go_install::GoInstallOperationCache;
+pub(crate) use go_install::GoInstallVersions;
+
 pub(crate) mod homebrew_operation;
 pub(crate) use homebrew_operation::HomebrewOperationCache;
 

--- a/src/internal/cache/workdirs.rs
+++ b/src/internal/cache/workdirs.rs
@@ -53,7 +53,7 @@ impl WorkdirsCache {
         let fingerprint_matches: bool = db
             .query_one(
                 include_str!("database/sql/workdir_fingerprint_check.sql"),
-                params![workdir, fingerprint_type, fingerprint],
+                params![workdir, fingerprint_type, fingerprint.to_string()],
             )
             .unwrap_or(false);
         fingerprint_matches
@@ -74,7 +74,7 @@ impl WorkdirsCache {
         } else {
             db.execute(
                 include_str!("database/sql/workdir_fingerprint_upsert.sql"),
-                params![workdir, fingerprint_type, fingerprint],
+                params![workdir, fingerprint_type, fingerprint.to_string()],
             )?
         };
         Ok(changed > 0)

--- a/src/internal/config/parser/cache/go_install.rs
+++ b/src/internal/config/parser/cache/go_install.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::config::utils::parse_duration_or_default;
+use crate::internal::config::ConfigValue;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GoInstallCacheConfig {
+    pub versions_expire: u64,
+    pub cleanup_after: u64,
+}
+
+impl Default for GoInstallCacheConfig {
+    fn default() -> Self {
+        Self {
+            versions_expire: Self::DEFAULT_VERSIONS_EXPIRE,
+            cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
+        }
+    }
+}
+
+impl GoInstallCacheConfig {
+    const DEFAULT_VERSIONS_EXPIRE: u64 = 86400; // 1 day
+    const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
+
+    pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let versions_expire = parse_duration_or_default(
+            config_value.get("versions_expire").as_ref(),
+            Self::DEFAULT_VERSIONS_EXPIRE,
+        );
+
+        let cleanup_after = parse_duration_or_default(
+            config_value.get("cleanup_after").as_ref(),
+            Self::DEFAULT_CLEANUP_AFTER,
+        );
+
+        Self {
+            versions_expire,
+            cleanup_after,
+        }
+    }
+}

--- a/src/internal/config/parser/cache/mod.rs
+++ b/src/internal/config/parser/cache/mod.rs
@@ -7,6 +7,9 @@ pub(crate) use asdf::AsdfCacheConfig;
 mod github_release;
 pub(crate) use github_release::GithubReleaseCacheConfig;
 
+mod go_install;
+pub(crate) use go_install::GoInstallCacheConfig;
+
 mod homebrew;
 pub(crate) use homebrew::HomebrewCacheConfig;
 

--- a/src/internal/config/parser/cache/root.rs
+++ b/src/internal/config/parser/cache/root.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 use crate::internal::config::parser::cache::AsdfCacheConfig;
 use crate::internal::config::parser::cache::GithubReleaseCacheConfig;
+use crate::internal::config::parser::cache::GoInstallCacheConfig;
 use crate::internal::config::parser::cache::HomebrewCacheConfig;
 use crate::internal::config::parser::cache::UpEnvironmentCacheConfig;
 use crate::internal::config::ConfigValue;
@@ -14,6 +15,7 @@ pub struct CacheConfig {
     pub environment: UpEnvironmentCacheConfig,
     pub asdf: AsdfCacheConfig,
     pub github_release: GithubReleaseCacheConfig,
+    pub go_install: GoInstallCacheConfig,
     pub homebrew: HomebrewCacheConfig,
 }
 
@@ -24,6 +26,7 @@ impl Default for CacheConfig {
             environment: UpEnvironmentCacheConfig::default(),
             asdf: AsdfCacheConfig::default(),
             github_release: GithubReleaseCacheConfig::default(),
+            go_install: GoInstallCacheConfig::default(),
             homebrew: HomebrewCacheConfig::default(),
         }
     }
@@ -46,6 +49,7 @@ impl CacheConfig {
         let asdf = AsdfCacheConfig::from_config_value(config_value.get("asdf"));
         let github_release =
             GithubReleaseCacheConfig::from_config_value(config_value.get("github_release"));
+        let go_install = GoInstallCacheConfig::from_config_value(config_value.get("go_install"));
         let homebrew = HomebrewCacheConfig::from_config_value(config_value.get("homebrew"));
 
         Self {
@@ -53,6 +57,7 @@ impl CacheConfig {
             environment,
             asdf,
             github_release,
+            go_install,
             homebrew,
         }
     }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -912,7 +912,7 @@ impl UpConfigAsdfBase {
         Ok(version)
     }
 
-    fn version(&self) -> Result<String, UpError> {
+    pub fn version(&self) -> Result<String, UpError> {
         self.actual_version
             .get()
             .map(|version| version.to_string())

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -11,6 +11,7 @@ use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
 use crate::internal::config::up::UpConfigGithubReleases;
+use crate::internal::config::up::UpConfigGoInstalls;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigTool;
 use crate::internal::config::up::UpError;
@@ -311,6 +312,9 @@ impl UpConfig {
             cleanups.push(cleanup);
         }
         if let Some(cleanup) = UpConfigGithubReleases::cleanup(&progress_handler)? {
+            cleanups.push(cleanup);
+        }
+        if let Some(cleanup) = UpConfigGoInstalls::cleanup(&progress_handler)? {
             cleanups.push(cleanup);
         }
 

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -296,7 +296,7 @@ impl UpConfigGithubReleases {
         // Cleanup removable releases from the database
         cache.cleanup().map_err(|err| {
             progress_handler.progress(format!("failed to cleanup github releases cache: {}", err));
-            UpError::Cache(format!("failed to cleanup homebrew cache: {}", err))
+            UpError::Cache(format!("failed to cleanup github releases cache: {}", err))
         })?;
 
         // List releases that should exist
@@ -498,7 +498,7 @@ struct UpConfigGithubRelease {
     pub auth: GithubAuthConfig,
 
     #[serde(default, skip)]
-    pub actual_version: OnceCell<String>,
+    actual_version: OnceCell<String>,
 
     #[serde(default, skip)]
     was_handled: OnceCell<GithubReleaseHandled>,

--- a/src/internal/config/up/go_install.rs
+++ b/src/internal/config/up/go_install.rs
@@ -1,0 +1,1164 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use itertools::Itertools;
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use tokio::process::Command as TokioCommand;
+
+use crate::internal::cache::up_environments::UpEnvironment;
+use crate::internal::cache::utils as cache_utils;
+use crate::internal::cache::GoInstallOperationCache;
+use crate::internal::cache::GoInstallVersions;
+use crate::internal::config::config;
+use crate::internal::config::global_config;
+use crate::internal::config::up::utils::cleanup_path;
+use crate::internal::config::up::utils::get_command_output;
+use crate::internal::config::up::utils::progress_handler::ProgressHandler;
+use crate::internal::config::up::utils::run_progress;
+use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::UpProgressHandler;
+use crate::internal::config::up::utils::VersionMatcher;
+use crate::internal::config::up::utils::VersionParser;
+use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
+use crate::internal::config::ConfigValue;
+use crate::internal::env::data_home;
+use crate::internal::env::tmpdir_cleanup_prefix;
+use crate::internal::user_interface::StringColor;
+
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        fn go_install_bin_path() -> PathBuf {
+            PathBuf::from(data_home()).join("go-install")
+        }
+    } else {
+        use once_cell::sync::Lazy;
+
+        static GO_INSTALL_BIN_PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(data_home()).join("go-install"));
+
+        fn go_install_bin_path() -> PathBuf {
+            GO_INSTALL_BIN_PATH.clone()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct UpConfigGoInstalls {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<UpConfigGoInstall>,
+}
+
+impl Serialize for UpConfigGoInstalls {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.tools.len() {
+            0 => serializer.serialize_none(),
+            1 => serializer.serialize_newtype_struct("UpConfigGoInstalls", &self.tools[0]),
+            _ => serializer.collect_seq(self.tools.iter()),
+        }
+    }
+}
+
+impl UpConfigGoInstalls {
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        if let Some(_entry) = config_value.as_str_forced() {
+            return Self {
+                tools: vec![UpConfigGoInstall::from_config_value(Some(config_value))],
+            };
+        }
+
+        if let Some(array) = config_value.as_array() {
+            return Self {
+                tools: array
+                    .iter()
+                    .map(|config_value| UpConfigGoInstall::from_config_value(Some(config_value)))
+                    .collect(),
+            };
+        }
+
+        if let Some(table) = config_value.as_table() {
+            // Check if there is a 'path' key, in which case it's a single
+            // path and we can just parse it and return it
+            if table.contains_key("path") {
+                return Self {
+                    tools: vec![UpConfigGoInstall::from_config_value(Some(config_value))],
+                };
+            }
+
+            // Otherwise, we have a table of paths, where paths are
+            // the keys and the values are the configuration for the path;
+            // we want to go over them in lexico-graphical order to ensure that
+            // the order is consistent
+            let mut tools = Vec::new();
+            for path in table.keys().sorted() {
+                let value = table.get(path).expect("path config not found");
+                let path = match ConfigValue::from_str(path) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+
+                let mut path_config = if let Some(table) = value.as_table() {
+                    table.clone()
+                } else if let Some(version) = value.as_str_forced() {
+                    let mut path_config = HashMap::new();
+                    let value = match ConfigValue::from_str(&version) {
+                        Ok(value) => value,
+                        Err(_) => continue,
+                    };
+                    path_config.insert("version".to_string(), value);
+                    path_config
+                } else {
+                    HashMap::new()
+                };
+
+                path_config.insert("path".to_string(), path);
+                tools.push(UpConfigGoInstall::from_table(&path_config));
+            }
+
+            return Self { tools };
+        }
+
+        UpConfigGoInstalls::default()
+    }
+
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        if self.tools.len() == 1 {
+            return self.tools[0].up(options, environment, progress_handler);
+        }
+
+        progress_handler.init("go install:".light_blue());
+        if self.tools.is_empty() {
+            progress_handler.error_with_message("no import path".to_string());
+            return Err(UpError::Config(
+                "at least one import path required".to_string(),
+            ));
+        }
+
+        progress_handler.progress("install dependencies".to_string());
+
+        let num = self.tools.len();
+        for (idx, tool) in self.tools.iter().enumerate() {
+            let subhandler = progress_handler.subhandler(
+                &format!(
+                    "[{current:padding$}/{total:padding$}] {tool} ",
+                    current = idx + 1,
+                    total = num,
+                    padding = format!("{}", num).len(),
+                    tool = tool.desc(),
+                )
+                .light_yellow(),
+            );
+            tool.up(options, environment, &subhandler)
+                .inspect_err(|_err| {
+                    progress_handler.error();
+                })?;
+        }
+
+        progress_handler.success_with_message(self.get_up_message());
+
+        Ok(())
+    }
+
+    pub fn commit(&self, options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        for tool in &self.tools {
+            if tool.was_upped() {
+                tool.commit(options, env_version_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        self.tools.iter().any(|tool| tool.was_upped())
+    }
+
+    fn get_up_message(&self) -> String {
+        let count: HashMap<GoInstallHandled, usize> = self
+            .tools
+            .iter()
+            .map(|tool| tool.handling())
+            .fold(HashMap::new(), |mut map, item| {
+                *map.entry(item).or_insert(0) += 1;
+                map
+            });
+        let handled: Vec<String> = self
+            .tools
+            .iter()
+            .filter_map(|tool| match tool.handling() {
+                GoInstallHandled::Handled | GoInstallHandled::Noop => Some(format!(
+                    "{}@{}",
+                    tool.path,
+                    tool.actual_version
+                        .get()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                )),
+                _ => None,
+            })
+            .sorted()
+            .collect();
+
+        if handled.is_empty() {
+            return "nothing done".to_string();
+        }
+
+        let mut numbers = vec![];
+
+        if let Some(count) = count.get(&GoInstallHandled::Handled) {
+            numbers.push(format!("{} installed", count).green());
+        }
+
+        if let Some(count) = count.get(&GoInstallHandled::Noop) {
+            numbers.push(format!("{} already installed", count).light_black());
+        }
+
+        if numbers.is_empty() {
+            return "nothing done".to_string();
+        }
+
+        format!(
+            "{} {}",
+            numbers.join(", "),
+            format!("({})", handled.join(", ")).light_black().italic(),
+        )
+    }
+
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        if self.tools.len() == 1 {
+            return self.tools[0].down(progress_handler);
+        }
+
+        progress_handler.init("go install:".light_blue());
+        progress_handler.progress("updating dependencies".to_string());
+
+        let num = self.tools.len();
+        for (idx, tool) in self.tools.iter().enumerate() {
+            let subhandler = progress_handler.subhandler(
+                &format!(
+                    "[{current:padding$}/{total:padding$}] ",
+                    current = idx + 1,
+                    total = num,
+                    padding = format!("{}", num).len(),
+                )
+                .light_yellow(),
+            );
+            tool.down(&subhandler)?;
+        }
+
+        progress_handler.success_with_message("dependencies cleaned".light_green());
+
+        Ok(())
+    }
+
+    pub fn cleanup(progress_handler: &UpProgressHandler) -> Result<Option<String>, UpError> {
+        progress_handler.init("go install:".light_blue());
+        progress_handler.progress("checking for unused tools".to_string());
+
+        let cache = GoInstallOperationCache::get();
+
+        // Cleanup removable tools from the database
+        cache.cleanup().map_err(|err| {
+            let msg = format!("failed to cleanup go install cache: {}", err);
+            progress_handler.progress(msg.clone());
+            UpError::Cache(msg)
+        })?;
+
+        // List tools that should exist
+        let expected_tools = cache.list_installed().map_err(|err| {
+            let msg = format!("failed to list go-installed tools: {}", err);
+            progress_handler.progress(msg.clone());
+            UpError::Cache(msg)
+        })?;
+
+        let expected_paths = expected_tools
+            .iter()
+            .map(|install| {
+                go_install_bin_path()
+                    .join(&install.path)
+                    .join(&install.version)
+            })
+            .collect::<Vec<PathBuf>>();
+
+        let (root_removed, num_removed, removed_paths) = cleanup_path(
+            go_install_bin_path(),
+            expected_paths,
+            progress_handler,
+            true,
+        )?;
+
+        if root_removed {
+            return Ok(Some("removed all go install".to_string()));
+        }
+
+        if num_removed == 0 {
+            return Ok(None);
+        }
+
+        // We want to go over the paths that were removed to
+        // return a proper message about the go install
+        // that were removed
+        let removed_tools = removed_paths
+            .iter()
+            .filter_map(|path| {
+                // Path should starts with the bin path if it is a go-install tool
+                let rest_of_path = match path.strip_prefix(go_install_bin_path()) {
+                    Ok(rest_of_path) => rest_of_path,
+                    Err(_) => return None,
+                };
+
+                // Path should have at least 2 components after stripping the bin path
+                // (1) the import path and (2) the version
+                let parts = rest_of_path.components().collect::<Vec<_>>();
+                if parts.len() < 2 {
+                    return None;
+                }
+
+                let mut parts = parts
+                    .into_iter()
+                    .map(|part| part.as_os_str().to_string_lossy().to_string())
+                    .collect::<Vec<String>>();
+
+                let version = if parts.last().unwrap().starts_with('v') {
+                    Some(parts.pop().unwrap())
+                } else {
+                    None
+                };
+
+                let path = parts.join("/");
+
+                Some((path, version))
+            })
+            .collect::<Vec<_>>();
+
+        if removed_tools.is_empty() {
+            return Ok(Some(format!(
+                "removed {} tool{}",
+                num_removed.light_yellow(),
+                if num_removed > 1 { "s" } else { "" }
+            )));
+        }
+
+        let removed_tools = removed_tools
+            .iter()
+            .map(|(path, version)| match version {
+                Some(version) => format!("{}@{}", path.light_yellow(), version.light_yellow()),
+                None => format!("{} (all versions)", path.light_yellow(),),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Some(format!("removed {}", removed_tools.join(", "))))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum GoInstallHandled {
+    Handled,
+    Noop,
+    Unhandled,
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum GoInstallError {
+    #[error("invalid path: {0}")]
+    InvalidImportPath(String),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct UpConfigGoInstall {
+    /// The path to the path to call the `go install` command on,
+    /// e.g. `github.com/owner/path`
+    pub path: String,
+
+    /// The version of the tool to install, which will be used after the `@` in the
+    /// `go install` command, e.g. `github.com/owner/path@<version>`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Whether to install the exact version specified in the `version` field;
+    /// if `true`, there will be no check for the available versions and the
+    /// `go install` command will be called with the version specified;
+    /// if `false`, the latest version that matches the version will be installed.
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub exact: bool,
+
+    /// Whether to always upgrade the tool or use the latest matching
+    /// already installed version.
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub upgrade: bool,
+
+    /// Whether to install the pre-release version of the tool
+    /// if it is the most recent matching version
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub prerelease: bool,
+
+    /// Whether to allow versions containing build details
+    /// (e.g. 1.2.3+build)
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub build: bool,
+
+    /// In case there was an error while parsing the configuration, this field
+    /// will contain the error message
+    #[serde(default, skip)]
+    config_error: Option<String>,
+
+    #[serde(default, skip)]
+    actual_version: OnceCell<String>,
+
+    #[serde(default, skip)]
+    was_handled: OnceCell<GoInstallHandled>,
+}
+
+impl Default for UpConfigGoInstall {
+    fn default() -> Self {
+        UpConfigGoInstall {
+            path: "".to_string(),
+            version: None,
+            exact: false,
+            upgrade: false,
+            prerelease: false,
+            build: false,
+            config_error: None,
+            actual_version: OnceCell::new(),
+            was_handled: OnceCell::new(),
+        }
+    }
+}
+
+impl UpConfigGoInstall {
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => {
+                return Self {
+                    config_error: Some("no configuration provided".to_string()),
+                    ..Default::default()
+                }
+            }
+        };
+
+        if let Some(table) = config_value.as_table() {
+            Self::from_table(&table)
+        } else if let Some(path) = config_value.as_str_forced() {
+            let (path, version) = match parse_go_install_path(&path) {
+                Ok((path, version)) => (path, version),
+                Err(err) => {
+                    return Self {
+                        path: path.to_string(),
+                        config_error: Some(err.to_string()),
+                        ..Default::default()
+                    }
+                }
+            };
+
+            UpConfigGoInstall {
+                path,
+                version,
+                ..UpConfigGoInstall::default()
+            }
+        } else {
+            Self {
+                config_error: Some("no import path provided".to_string()),
+                ..Default::default()
+            }
+        }
+    }
+
+    fn from_table(table: &HashMap<String, ConfigValue>) -> Self {
+        let path = match table.get("path") {
+            Some(path) => {
+                if let Some(path) = path.as_str_forced() {
+                    path.to_string()
+                } else {
+                    return UpConfigGoInstall {
+                        config_error: Some("path must be a string".to_string()),
+                        ..Default::default()
+                    };
+                }
+            }
+            None => {
+                if table.len() == 1 {
+                    let (key, value) = table.iter().next().unwrap();
+                    if let Some(version) = value.as_str_forced() {
+                        return UpConfigGoInstall {
+                            path: key.clone(),
+                            version: Some(version.to_string()),
+                            ..UpConfigGoInstall::default()
+                        };
+                    } else if let (Some(table), Ok(path_config_value)) =
+                        (value.as_table(), ConfigValue::from_str(key))
+                    {
+                        let mut path_config = table.clone();
+                        path_config.insert("path".to_string(), path_config_value);
+                        return UpConfigGoInstall::from_table(&path_config);
+                    }
+                }
+                return UpConfigGoInstall {
+                    config_error: Some("path is required".to_string()),
+                    ..Default::default()
+                };
+            }
+        };
+
+        let (path, version) = match parse_go_install_path(&path) {
+            Ok((path, version)) => (path, version),
+            Err(err) => {
+                return UpConfigGoInstall {
+                    path,
+                    config_error: Some(err.to_string()),
+                    ..Default::default()
+                };
+            }
+        };
+
+        // If version is specified, it overrides the version in the path
+        let version = match table
+            .get("version")
+            .map(|v| v.as_str_forced())
+            .unwrap_or(None)
+        {
+            Some(version) => Some(version.to_string()),
+            None => version,
+        };
+        let exact = table
+            .get("exact")
+            .map(|v| v.as_bool_forced())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let upgrade = table
+            .get("upgrade")
+            .map(|v| v.as_bool_forced())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let prerelease = table
+            .get("prerelease")
+            .map(|v| v.as_bool())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let build = table
+            .get("build")
+            .map(|v| v.as_bool())
+            .unwrap_or(None)
+            .unwrap_or(false);
+
+        UpConfigGoInstall {
+            path,
+            version,
+            exact,
+            upgrade,
+            prerelease,
+            build,
+            ..Default::default()
+        }
+    }
+
+    fn update_cache(
+        &self,
+        _options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) {
+        let version = match self.actual_version.get() {
+            Some(version) => version,
+            None => {
+                progress_handler.error_with_message("version not set".to_string());
+                return;
+            }
+        };
+
+        progress_handler.progress("updating cache".to_string());
+
+        if let Err(err) = GoInstallOperationCache::get().add_installed(&self.path, version) {
+            progress_handler.progress(format!("failed to update github release cache: {}", err));
+            return;
+        }
+
+        let release_version_path = self.version_path(version);
+        environment.add_path(release_version_path);
+
+        progress_handler.progress("updated cache".to_string());
+    }
+
+    fn short_path(&self) -> String {
+        // Get the last, non-empty part of the path
+        self.path
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .last()
+            .unwrap_or("")
+            .to_string()
+    }
+
+    fn desc(&self) -> String {
+        if self.path.is_empty() {
+            "go install:".to_string()
+        } else if self.config_error.is_some() {
+            format!("{}:", self.path)
+        } else {
+            format!(
+                "{} ({}):",
+                self.short_path(),
+                match self.version {
+                    None => "latest".to_string(),
+                    Some(ref version) if version.is_empty() => "latest".to_string(),
+                    Some(ref version) => version.clone(),
+                }
+            )
+        }
+    }
+
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        progress_handler.init(self.desc().light_blue());
+
+        if let Some(config_error) = &self.config_error {
+            progress_handler.error_with_message(config_error.clone());
+            return Err(UpError::Config(config_error.clone()));
+        }
+
+        if self.path.is_empty() {
+            progress_handler.error_with_message("path is required".to_string());
+            return Err(UpError::Config("path is required".to_string()));
+        }
+
+        let installed = self.resolve_and_install_version(options, progress_handler)?;
+
+        self.update_cache(options, environment, progress_handler);
+
+        let version = match self.actual_version.get() {
+            Some(version) => version.to_string(),
+            None => "unknown".to_string(),
+        };
+        let msg = match installed {
+            true => format!("{} installed", version.light_yellow()),
+            false => format!("{} already installed", version).light_black(),
+        };
+        progress_handler.success_with_message(msg);
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        matches!(
+            self.was_handled.get(),
+            Some(GoInstallHandled::Handled) | Some(GoInstallHandled::Noop)
+        )
+    }
+
+    pub fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        let version = match self.actual_version.get() {
+            Some(version) => version,
+            None => {
+                return Err(UpError::Exec("version not set".to_string()));
+            }
+        };
+
+        if let Err(err) =
+            GoInstallOperationCache::get().add_required_by(env_version_id, &self.path, version)
+        {
+            return Err(UpError::Cache(format!(
+                "failed to update go install cache: {}",
+                err
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn down(&self, _progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        Ok(())
+    }
+
+    fn handling(&self) -> GoInstallHandled {
+        match self.was_handled.get() {
+            Some(handled) => handled.clone(),
+            None => GoInstallHandled::Unhandled,
+        }
+    }
+
+    fn upgrade_tool(&self, options: &UpOptions) -> bool {
+        self.upgrade || options.upgrade || config(".").up_command.upgrade
+    }
+
+    fn resolve_and_install_version(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<bool, UpError> {
+        if self.exact {
+            let version = self.version.clone().unwrap_or("latest".to_string());
+            if version == "latest" {
+                progress_handler.error_with_message("exact version cannot be 'latest'".to_string());
+                return Err(UpError::Config(
+                    "exact version cannot be 'latest'".to_string(),
+                ));
+            }
+
+            match self.install_version(options, &version, progress_handler) {
+                Ok(installed) => return self.handle_installed(&version, Ok(installed)),
+                Err(err) => {
+                    progress_handler.error_with_message(err.message());
+                    return Err(err);
+                }
+            }
+        }
+
+        let mut version = "".to_string();
+        let mut install_version = Err(UpError::Exec("did not even try".to_string()));
+        let mut versions = None;
+
+        // If the options do not include upgrade, then we can try using
+        // an already-installed version if any matches the requirements
+        if !self.upgrade_tool(options) {
+            let resolve_str = match self.version.as_ref() {
+                Some(version) if version != "latest" => version.to_string(),
+                _ => {
+                    let list_versions = self.list_versions(options, progress_handler)?;
+                    versions = Some(list_versions.clone());
+                    let latest = self.latest_version(&list_versions)?;
+                    progress_handler.progress(
+                        format!("considering installed versions matching {}", latest).light_black(),
+                    );
+                    latest
+                }
+            };
+
+            let installed_versions = self.list_installed_versions(progress_handler)?;
+            match self.resolve_version_from_str(&resolve_str, &installed_versions) {
+                Ok(installed_version) => {
+                    progress_handler.progress(format!(
+                        "found matching installed version {}",
+                        installed_version.light_yellow(),
+                    ));
+
+                    version = installed_version;
+                    install_version = Ok(false);
+                }
+                Err(_err) => {
+                    progress_handler.progress("no matching version installed".to_string());
+                }
+            }
+        }
+
+        if version.is_empty() {
+            let versions = match versions {
+                Some(versions) => versions,
+                None => self.list_versions(options, progress_handler)?,
+            };
+            version = match self.resolve_version(&versions.versions) {
+                Ok(version) => version,
+                Err(err) => {
+                    // If the versions are not fresh of now, and we failed to
+                    // resolve the version to install, we should try to refresh the
+                    // versions list and try again
+                    if options.read_cache && !versions.is_fresh() {
+                        progress_handler.progress("no matching version found in cache".to_string());
+
+                        let versions = self.list_versions(
+                            &UpOptions {
+                                read_cache: false,
+                                ..options.clone()
+                            },
+                            progress_handler,
+                        )?;
+
+                        self.resolve_version(&versions.versions)
+                            .inspect_err(|err| {
+                                progress_handler.error_with_message(err.message());
+                            })?
+                    } else {
+                        progress_handler.error_with_message(err.message());
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Try installing the version found
+            install_version = self.install_version(options, &version, progress_handler);
+            if install_version.is_err() && !options.fail_on_upgrade {
+                // If we get here and there is an issue downloading the version,
+                // list all installed versions and check if one of those could
+                // fit the requirement, in which case we can fallback to it
+                let installed_versions = self.list_installed_versions(progress_handler)?;
+                match self.resolve_version(&installed_versions) {
+                    Ok(installed_version) => {
+                        progress_handler.progress(format!(
+                            "falling back to {}@{}",
+                            self.path,
+                            installed_version.light_yellow(),
+                        ));
+
+                        version = installed_version;
+                        install_version = Ok(false);
+                    }
+                    Err(_err) => {}
+                }
+            }
+        }
+
+        self.handle_installed(&version, install_version)
+    }
+
+    fn handle_installed(
+        &self,
+        version: &str,
+        installed: Result<bool, UpError>,
+    ) -> Result<bool, UpError> {
+        if let Ok(installed) = &installed {
+            self.actual_version.set(version.to_string()).map_err(|_| {
+                let errmsg = "failed to set actual version".to_string();
+                UpError::Exec(errmsg)
+            })?;
+
+            if self
+                .was_handled
+                .set(if *installed {
+                    GoInstallHandled::Handled
+                } else {
+                    GoInstallHandled::Noop
+                })
+                .is_err()
+            {
+                unreachable!("failed to set was_handled");
+            }
+        }
+
+        installed
+    }
+
+    fn list_versions(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<GoInstallVersions, UpError> {
+        let cache = GoInstallOperationCache::get();
+        let cached_versions = if options.read_cache {
+            if let Some(versions) = cache.get_versions(&self.path) {
+                let versions = versions.clone();
+                let config = global_config();
+                let expire = config.cache.go_install.versions_expire;
+                if !versions.is_stale(expire) {
+                    progress_handler.progress("using cached version list".light_black());
+                    return Ok(versions);
+                }
+                Some(versions)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        progress_handler.progress("refreshing versions list".to_string());
+        match self.list_versions_from_go(progress_handler) {
+            Ok(versions) => {
+                if options.write_cache {
+                    progress_handler.progress("updating cache with version list".to_string());
+                    if let Err(err) = cache.add_versions(&self.path, &versions) {
+                        progress_handler.progress(format!("failed to update cache: {}", err));
+                    }
+                }
+
+                Ok(versions)
+            }
+            Err(err) => {
+                if let Some(cached_versions) = cached_versions {
+                    progress_handler.progress(format!(
+                        "{}; {}",
+                        format!("error refreshing version list: {}", err).red(),
+                        "using cached data".light_black()
+                    ));
+                    Ok(cached_versions)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    fn list_versions_from_go(
+        &self,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<GoInstallVersions, UpError> {
+        // We need to:
+        // - Resolve the path to use for the request, which is the path
+        //   without the last particle, or before any cmd/ particle, and
+        //   without any trailing slashes
+        // - Call `go list -m -versions -json <path>`
+        // - Parse the output into a list of versions, the only key that's
+        //   interesting for us in the `Versions` field which is a list of
+        //   strings
+
+        let mut package_path = Some(Path::new(&self.path));
+        while let Some(current_path) = package_path {
+            let mut go_list_cmd = TokioCommand::new("go");
+            go_list_cmd.arg("list");
+            go_list_cmd.arg("-m");
+            go_list_cmd.arg("-versions");
+            go_list_cmd.arg("-json");
+            go_list_cmd.arg(current_path);
+            go_list_cmd.stdout(std::process::Stdio::piped());
+            go_list_cmd.stderr(std::process::Stdio::piped());
+
+            match get_command_output(&mut go_list_cmd, RunConfig::new().with_askpass()) {
+                Err(err) => {
+                    let msg = format!("go list failed: {}", err);
+                    progress_handler.error_with_message(msg.clone());
+                    return Err(UpError::Exec(msg));
+                }
+                Ok(output) if !output.status.success() => {}
+                Ok(output) => {
+                    let output = String::from_utf8(output.stdout).unwrap().trim().to_string();
+                    if let Ok(versions) = serde_json::from_str::<GoInstallVersions>(&output) {
+                        return Ok(versions);
+                    }
+                }
+            }
+
+            package_path = current_path.parent();
+        }
+
+        let errmsg = format!("unable to get versions for module {}", self.path);
+        progress_handler.error_with_message(errmsg.clone());
+        Err(UpError::Exec(errmsg))
+    }
+
+    fn latest_version(&self, versions: &GoInstallVersions) -> Result<String, UpError> {
+        let latest = self.resolve_version_from_str("latest", &versions.versions)?;
+        Ok(VersionParser::parse(&latest)
+            .expect("failed to parse version string")
+            .major()
+            .to_string())
+    }
+
+    fn resolve_version(&self, versions: &[String]) -> Result<String, UpError> {
+        let match_version = self.version.clone().unwrap_or_else(|| "latest".to_string());
+        self.resolve_version_from_str(&match_version, versions)
+    }
+
+    fn resolve_version_from_str(
+        &self,
+        match_version: &str,
+        versions: &[String],
+    ) -> Result<String, UpError> {
+        let mut matcher = VersionMatcher::new(match_version);
+        matcher.prerelease(self.prerelease);
+        matcher.build(self.build);
+        matcher.prefix(true);
+
+        let version = versions
+            .iter()
+            .filter_map(|version| VersionParser::parse(version))
+            .sorted()
+            .rev()
+            .find(|version| matcher.matches(&version.to_string()))
+            .ok_or_else(|| {
+                UpError::Exec(format!(
+                    "no matching version found for {}@{}",
+                    self.path, match_version,
+                ))
+            })?;
+
+        Ok(version.to_string())
+    }
+
+    fn list_installed_versions(
+        &self,
+        _progress_handler: &dyn ProgressHandler,
+    ) -> Result<Vec<String>, UpError> {
+        let version_path = go_install_bin_path().join(&self.path);
+
+        if !version_path.exists() {
+            return Ok(vec![]);
+        }
+
+        let installed_versions = std::fs::read_dir(&version_path)
+            .map_err(|err| {
+                let errmsg = format!("failed to read directory: {}", err);
+                UpError::Exec(errmsg)
+            })?
+            .filter_map(|entry| {
+                entry.ok().and_then(|entry| {
+                    if entry.file_type().ok()?.is_dir() {
+                        entry.file_name().into_string().ok()
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        Ok(installed_versions)
+    }
+
+    fn install_version(
+        &self,
+        options: &UpOptions,
+        version: &str,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<bool, UpError> {
+        let install_path = self.version_path(version);
+
+        if options.read_cache && install_path.exists() && install_path.is_dir() {
+            progress_handler
+                .progress(format!("installed {}@{} (cached)", self.path, version).light_black());
+
+            return Ok(false);
+        }
+
+        // Make a temporary directory to download the release
+        let tmp_dir = tempfile::Builder::new()
+            .prefix(&tmpdir_cleanup_prefix("go-install"))
+            .tempdir()
+            .map_err(|err| {
+                progress_handler.error_with_message(format!("failed to create temp dir: {}", err));
+                UpError::Exec(format!("failed to create temp dir: {}", err))
+            })?;
+        let tmp_bin_path = tmp_dir.path().join("bin");
+
+        let mut go_install_cmd = TokioCommand::new("go");
+        go_install_cmd.arg("install");
+        go_install_cmd.arg("-v");
+        go_install_cmd.arg(format!("{}@{}", self.path, version));
+
+        // Override GO environment variables to ensure that the
+        // installation is done in the temporary directory
+        go_install_cmd.env("GOPATH", tmp_dir.path());
+        go_install_cmd.env("GOBIN", &tmp_bin_path);
+
+        go_install_cmd.stdout(std::process::Stdio::piped());
+        go_install_cmd.stderr(std::process::Stdio::piped());
+
+        run_progress(
+            &mut go_install_cmd,
+            Some(progress_handler),
+            RunConfig::default().with_askpass(),
+        )?;
+
+        if !tmp_bin_path.exists() {
+            let msg = "failed to install (bin directory empty)".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        // Move the installed version to the correct path
+        std::fs::create_dir_all(&install_path).map_err(|err| {
+            progress_handler.error_with_message(format!("failed to create dir: {}", err));
+            UpError::Exec(format!("failed to create dir: {}", err))
+        })?;
+
+        // Move the tmp_bin_path to the install_path/<bin> directory
+        std::fs::rename(&tmp_bin_path, install_path.join("bin")).map_err(|err| {
+            progress_handler.error_with_message(format!("failed to move bin: {}", err));
+            UpError::Exec(format!("failed to move bin: {}", err))
+        })?;
+
+        Ok(true)
+    }
+
+    fn version_path(&self, version: &str) -> PathBuf {
+        go_install_bin_path().join(&self.path).join(version)
+    }
+}
+
+/// Validates a version string for go install
+fn validate_go_install_version(version: &str) -> Result<(), GoInstallError> {
+    if version.chars().any(|c| {
+        c.is_whitespace()
+            || c.is_control()
+            || !c.is_ascii()
+            || c == '@'
+            || c == '<'
+            || c == '>'
+            || c == '['
+            || c == ']'
+            || c == '{'
+            || c == '}'
+            || c == ':'
+            || c == ';'
+            || c == ','
+    }) {
+        return Err(GoInstallError::InvalidImportPath(
+            "version contains invalid characters".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Cleans and validates a go install path
+fn validate_go_install_path(path: &str) -> Result<String, GoInstallError> {
+    if path.is_empty() {
+        return Err(GoInstallError::InvalidImportPath(
+            "empty import path".to_string(),
+        ));
+    }
+
+    // Remove protocol if present
+    let path = path.trim();
+    let path = if let Some(idx) = path.find("://") {
+        &path[idx + 3..]
+    } else {
+        path
+    };
+
+    // Split into segments and clean
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|s| !s.is_empty()) // Remove empty segments
+        .collect();
+
+    if segments.is_empty() {
+        return Err(GoInstallError::InvalidImportPath(
+            "empty path after cleaning".to_string(),
+        ));
+    }
+
+    // Join segments back together
+    Ok(segments.join("/"))
+}
+
+/// Main function that parses and validates a complete go install string
+fn parse_go_install_path<T>(input: T) -> Result<(String, Option<String>), GoInstallError>
+where
+    T: AsRef<str>,
+{
+    let input = input.as_ref();
+    let parts: Vec<&str> = input.split('@').collect();
+    if parts.len() > 2 {
+        return Err(GoInstallError::InvalidImportPath(
+            "multiple @ symbols found".to_string(),
+        ));
+    }
+
+    let cleaned_path = validate_go_install_path(parts[0])?;
+
+    let version = if parts.len() == 2 {
+        validate_go_install_version(parts[1])?;
+        Some(parts[1].to_string())
+    } else {
+        None
+    };
+
+    Ok((cleaned_path, version))
+}

--- a/src/internal/config/up/golang.rs
+++ b/src/internal/config/up/golang.rs
@@ -66,7 +66,26 @@ impl Serialize for UpConfigGolang {
     }
 }
 
+impl Default for UpConfigGolang {
+    fn default() -> Self {
+        Self {
+            version: None,
+            version_file: None,
+            upgrade: false,
+            asdf_base: OnceCell::new(),
+            dirs: BTreeSet::new(),
+        }
+    }
+}
+
 impl UpConfigGolang {
+    pub fn new_any_version() -> Self {
+        Self {
+            version: Some("*".to_string()),
+            ..Default::default()
+        }
+    }
+
     pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
         let mut version = None;
         let mut version_file = None;
@@ -166,6 +185,10 @@ impl UpConfigGolang {
 
             Ok(asdf_base)
         })
+    }
+
+    pub fn version(&self) -> Result<String, UpError> {
+        self.asdf_base()?.version()
     }
 
     fn extract_version_from_gomod(&self) -> Result<Option<String>, UpError> {

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -19,6 +19,9 @@ pub(crate) use github_release::UpConfigGithubReleases;
 pub(crate) mod golang;
 pub(crate) use golang::UpConfigGolang;
 
+pub(crate) mod go_install;
+pub(crate) use go_install::UpConfigGoInstalls;
+
 pub(crate) mod nix;
 pub(crate) use nix::UpConfigNix;
 

--- a/src/internal/config/up/tool.rs
+++ b/src/internal/config/up/tool.rs
@@ -15,6 +15,7 @@ use crate::internal::config::up::UpConfigAsdfBaseParams;
 use crate::internal::config::up::UpConfigBundler;
 use crate::internal::config::up::UpConfigCustom;
 use crate::internal::config::up::UpConfigGithubReleases;
+use crate::internal::config::up::UpConfigGoInstalls;
 use crate::internal::config::up::UpConfigGolang;
 use crate::internal::config::up::UpConfigHomebrew;
 use crate::internal::config::up::UpConfigNix;
@@ -62,6 +63,10 @@ pub enum UpConfigTool {
 
     /// Go represents the golang tool.
     Go(UpConfigGolang),
+
+    /// GoInstall represents a tool that can be installed from
+    /// a call to `go install`.
+    GoInstall(UpConfigGoInstalls),
 
     /// Homebrew represents the homebrew tool.
     Homebrew(UpConfigHomebrew),
@@ -114,6 +119,9 @@ impl Serialize for UpConfigTool {
                 create_hashmap("github-release", config).serialize(serializer)
             }
             UpConfigTool::Go(config) => create_hashmap("go", config).serialize(serializer),
+            UpConfigTool::GoInstall(config) => {
+                create_hashmap("go-install", config).serialize(serializer)
+            }
             UpConfigTool::Homebrew(config) => {
                 create_hashmap("homebrew", config).serialize(serializer)
             }
@@ -169,6 +177,9 @@ impl UpConfigTool {
             "go" | "golang" => Some(UpConfigTool::Go(UpConfigGolang::from_config_value(
                 config_value,
             ))),
+            "go-install" | "goinstall" => Some(UpConfigTool::GoInstall(
+                UpConfigGoInstalls::from_config_value(config_value),
+            )),
             "homebrew" | "brew" => Some(UpConfigTool::Homebrew(
                 UpConfigHomebrew::from_config_value(config_value),
             )),
@@ -230,6 +241,7 @@ impl UpConfigTool {
                 config.up(options, environment, progress_handler)
             }
             UpConfigTool::Go(config) => config.up(options, environment, progress_handler),
+            UpConfigTool::GoInstall(config) => config.up(options, environment, progress_handler),
             UpConfigTool::Homebrew(config) => config.up(options, environment, progress_handler),
             UpConfigTool::Nix(config) => config.up(options, environment, progress_handler),
             UpConfigTool::Nodejs(config) => config.up(options, environment, progress_handler),
@@ -280,6 +292,11 @@ impl UpConfigTool {
                     config.commit(options, env_version_id)?;
                 }
             }
+            UpConfigTool::GoInstall(config) => {
+                if config.was_upped() {
+                    config.commit(options, env_version_id)?;
+                }
+            }
             UpConfigTool::Homebrew(config) => {
                 if config.was_upped() {
                     config.commit(options, env_version_id)?;
@@ -315,6 +332,7 @@ impl UpConfigTool {
             UpConfigTool::Custom(config) => config.down(progress_handler),
             UpConfigTool::GithubRelease(config) => config.down(progress_handler),
             UpConfigTool::Go(config) => config.down(progress_handler),
+            UpConfigTool::GoInstall(config) => config.down(progress_handler),
             UpConfigTool::Homebrew(config) => config.down(progress_handler),
             UpConfigTool::Nix(config) => config.down(progress_handler),
             UpConfigTool::Nodejs(config) => config.down(progress_handler),
@@ -351,6 +369,7 @@ impl UpConfigTool {
             UpConfigTool::Custom(config) => config.was_upped(),
             // UpConfigTool::GithubRelease(config) => config.was_upped(),
             UpConfigTool::Go(config) => config.was_upped(),
+            UpConfigTool::GoInstall(config) => config.was_upped(),
             // UpConfigTool::Homebrew(config) => config.was_upped(),
             UpConfigTool::Nix(config) => config.was_upped(),
             UpConfigTool::Nodejs(config) => config.asdf_base.was_upped(),
@@ -380,6 +399,7 @@ impl UpConfigTool {
             UpConfigTool::Custom(config) => config.data_paths(),
             // UpConfigTool::GithubRelease(config) => config.data_paths(),
             UpConfigTool::Go(config) => config.data_paths(),
+            // UpConfigTool::GoInstall(config) => config.data_paths(),
             // UpConfigTool::Homebrew(config) => config.data_paths(),
             UpConfigTool::Nix(config) => config.data_paths(),
             UpConfigTool::Nodejs(config) => config.asdf_base.data_paths(),
@@ -399,6 +419,7 @@ impl UpConfigTool {
             UpConfigTool::Custom(_) => "custom".into(),
             UpConfigTool::GithubRelease(_) => "github-release".into(),
             UpConfigTool::Go(_) => "go".into(),
+            UpConfigTool::GoInstall(_) => "go-install".into(),
             UpConfigTool::Homebrew(_) => "homebrew".into(),
             UpConfigTool::Nix(_) => "nix".into(),
             UpConfigTool::Nodejs(_) => "nodejs".into(),


### PR DESCRIPTION
This introduces a new `go-install` operation for `up`, which installs a tool using `go install`. This supports finding available versions through `go list`, or using exactly the specified version without lookup. This also takes care of loading a `go` version to call the `go` commands on.

Closes https://github.com/XaF/omni/issues/714