### PR TITLE
feat(`up`): ✨ add `cargo-install` operation

### DIFF
--- a/src/internal/cache/cargo_install.rs
+++ b/src/internal/cache/cargo_install.rs
@@ -1,0 +1,484 @@
+use rusqlite::params;
+use rusqlite::Row;
+use serde::Deserialize;
+use serde::Serialize;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::internal::cache::database::FromRow;
+use crate::internal::cache::database::RowExt;
+use crate::internal::cache::CacheManager;
+use crate::internal::cache::CacheManagerError;
+use crate::internal::config::global_config;
+use crate::internal::env::now as omni_now;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CargoInstallOperationCache {}
+
+impl CargoInstallOperationCache {
+    pub fn get() -> Self {
+        Self {}
+    }
+
+    pub fn add_versions(
+        &self,
+        crate_name: &str,
+        versions: &CargoInstallVersions,
+    ) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/cargo_install_operation_add_versions.sql"),
+            params![crate_name, serde_json::to_string(&versions.versions)?],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn get_versions(&self, crate_name: &str) -> Option<CargoInstallVersions> {
+        let db = CacheManager::get();
+        let versions: Option<CargoInstallVersions> = db
+            .query_one(
+                include_str!("database/sql/cargo_install_operation_get_versions.sql"),
+                params![crate_name],
+            )
+            .ok();
+        versions
+    }
+
+    pub fn add_installed(
+        &self,
+        crate_name: &str,
+        version: &str,
+    ) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/cargo_install_operation_add.sql"),
+            params![crate_name, version],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn add_required_by(
+        &self,
+        env_version_id: &str,
+        crate_name: &str,
+        version: &str,
+    ) -> Result<bool, CacheManagerError> {
+        let db = CacheManager::get();
+        let inserted = db.execute(
+            include_str!("database/sql/cargo_install_operation_add_required_by.sql"),
+            params![crate_name, version, env_version_id],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    pub fn list_installed(&self) -> Result<Vec<CargoInstalled>, CacheManagerError> {
+        let db = CacheManager::get();
+        let installed: Vec<CargoInstalled> = db.query_as(
+            include_str!("database/sql/cargo_install_operation_list_installed.sql"),
+            params![],
+        )?;
+        Ok(installed)
+    }
+
+    pub fn cleanup(&self) -> Result<(), CacheManagerError> {
+        let db = CacheManager::get();
+
+        let config = global_config();
+        let grace_period = config.cache.cargo_install.cleanup_after;
+
+        db.execute(
+            include_str!("database/sql/cargo_install_operation_cleanup.sql"),
+            params![&grace_period],
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CargoInstalled {
+    pub crate_name: String,
+    pub version: String,
+}
+
+impl FromRow for CargoInstalled {
+    fn from_row(row: &Row) -> Result<Self, CacheManagerError> {
+        Ok(Self {
+            crate_name: row.get("crate")?,
+            version: row.get("version")?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CargoInstallVersions {
+    #[serde(alias = "Versions")]
+    pub versions: Vec<String>,
+    #[serde(default = "OffsetDateTime::now_utc", with = "time::serde::rfc3339")]
+    pub fetched_at: OffsetDateTime,
+}
+
+impl CargoInstallVersions {
+    pub fn new(versions: Vec<String>) -> Self {
+        Self {
+            versions,
+            fetched_at: omni_now(),
+        }
+    }
+
+    pub fn is_fresh(&self) -> bool {
+        self.fetched_at >= omni_now()
+    }
+
+    pub fn is_stale(&self, ttl: u64) -> bool {
+        let duration = time::Duration::seconds(ttl as i64);
+        self.fetched_at + duration < OffsetDateTime::now_utc()
+    }
+}
+
+impl FromRow for CargoInstallVersions {
+    fn from_row(row: &Row) -> Result<Self, CacheManagerError> {
+        let versions_str: String = row.get("versions")?;
+        let versions: Vec<String> = serde_json::from_str(&versions_str)?;
+
+        let fetched_at_str: String = row.get("fetched_at")?;
+        let fetched_at: OffsetDateTime = OffsetDateTime::parse(&fetched_at_str, &Rfc3339)?;
+
+        Ok(Self {
+            versions,
+            fetched_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::internal::cache::database::get_conn;
+    use crate::internal::testutils::run_with_env;
+
+    mod cargo_install_operation_cache {
+        use super::*;
+        use time::OffsetDateTime;
+
+        #[test]
+        fn test_add_and_get_versions() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+
+                // Create test versions
+                let versions = CargoInstallVersions {
+                    versions: vec!["v1.0.0".to_string(), "v1.1.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Test adding versions
+                assert!(cache
+                    .add_versions(crate_name, &versions)
+                    .expect("Failed to add versions"));
+
+                // Test retrieving versions
+                let retrieved = cache
+                    .get_versions(crate_name)
+                    .expect("Failed to get versions");
+                assert_eq!(retrieved.versions.len(), 2);
+                assert!(retrieved.versions.contains(&"v1.0.0".to_string()));
+                assert!(retrieved.versions.contains(&"v1.1.0".to_string()));
+
+                // Test retrieving non-existent package
+                let non_existent = cache.get_versions("non/existent");
+                assert!(non_existent.is_none());
+            });
+        }
+
+        #[test]
+        fn test_add_and_list_installed() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+                let version = "v1.0.0";
+
+                // Test adding installed version
+                assert!(cache
+                    .add_installed(crate_name, version)
+                    .expect("Failed to add installed version"));
+
+                // Test listing installed versions
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+                assert_eq!(installed[0].crate_name, crate_name);
+                assert_eq!(installed[0].version, version);
+
+                // Test adding duplicate installed version
+                assert!(cache
+                    .add_installed(crate_name, version)
+                    .expect("Failed to add duplicate installed version"));
+
+                // Verify no duplicates in list
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+            });
+        }
+
+        #[test]
+        fn test_add_required_by() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_version_id = "test-env-id";
+
+                // Add environment version first for foreign key constraint
+                let conn = get_conn();
+                conn.execute(
+                    include_str!("database/sql/up_environments_insert_env_version.sql"),
+                    params![env_version_id, "{}", "[]", "[]", "{}", "hash"],
+                )
+                .expect("Failed to add environment version");
+
+                // Try adding required_by without installed - should fail
+                let result = cache.add_required_by(env_version_id, crate_name, version);
+                assert!(result.is_err(), "Should fail without installed version");
+
+                // Add installed version
+                cache
+                    .add_installed(crate_name, version)
+                    .expect("Failed to add installed version");
+
+                // Now add required_by - should succeed
+                assert!(cache
+                    .add_required_by(env_version_id, crate_name, version)
+                    .expect("Failed to add required by relationship"));
+
+                // Verify the relationship exists
+                let required_exists: bool = conn
+                    .query_row(
+                        concat!(
+                            "SELECT EXISTS(",
+                            "  SELECT 1 FROM cargo_install_required_by ",
+                            "  WHERE crate = ?1 AND version = ?2 AND env_version_id = ?3",
+                            ")",
+                        ),
+                        params![crate_name, version, env_version_id],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query required by relationship");
+                assert!(required_exists);
+            });
+        }
+
+        #[test]
+        fn test_multiple_required_by() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_version_ids = vec!["env-1", "env-2", "env-3"];
+
+                // Add installed version first
+                cache
+                    .add_installed(crate_name, version)
+                    .expect("Failed to add installed version");
+
+                // Add environments
+                let conn = get_conn();
+                for env_id in &env_version_ids {
+                    conn.execute(
+                        include_str!("database/sql/up_environments_insert_env_version.sql"),
+                        params![env_id, "{}", "[]", "[]", "{}", "hash"],
+                    )
+                    .expect("Failed to add environment version");
+                }
+
+                // Add requirements for each environment
+                for env_id in &env_version_ids {
+                    assert!(cache
+                        .add_required_by(env_id, crate_name, version)
+                        .expect("Failed to add requirement"));
+                }
+
+                // Verify requirements
+                for env_id in &env_version_ids {
+                    let required: bool = conn
+                        .query_row(
+                            concat!(
+                                "SELECT EXISTS(",
+                                "  SELECT 1 FROM cargo_install_required_by ",
+                                "  WHERE crate = ?1 AND version = ?2 AND env_version_id = ?3",
+                                ")",
+                            ),
+                            params![crate_name, version, env_id],
+                            |row| row.get(0),
+                        )
+                        .expect("Failed to query requirement");
+                    assert!(required, "Requirement for {} should exist", env_id);
+                }
+            });
+        }
+
+        #[test]
+        fn test_cleanup() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+
+                // Add two packages
+                let pkg1 = "github.com/test/pkg1";
+                let pkg2 = "github.com/test/pkg2";
+                let version = "v1.0.0";
+
+                // Add installations
+                cache
+                    .add_installed(pkg1, version)
+                    .expect("Failed to add pkg1 installation");
+                cache
+                    .add_installed(pkg2, version)
+                    .expect("Failed to add pkg2 installation");
+
+                let conn = get_conn();
+
+                // Set pkg1's last_required_at to old date (should be cleaned up)
+                conn.execute(
+                    concat!(
+                        "UPDATE cargo_installed ",
+                        "SET last_required_at = '1970-01-01T00:00:00.000Z' ",
+                        "WHERE crate = ?1",
+                    ),
+                    params![pkg1],
+                )
+                .expect("Failed to update last_required_at for pkg1");
+
+                // Keep pkg2's last_required_at recent (should not be cleaned up)
+                conn.execute(
+                    concat!(
+                        "UPDATE cargo_installed ",
+                        "SET last_required_at = datetime('now') ",
+                        "WHERE crate = ?1",
+                    ),
+                    params![pkg2],
+                )
+                .expect("Failed to update last_required_at for pkg2");
+
+                // Run cleanup
+                cache.cleanup().expect("Failed to cleanup");
+
+                // Verify pkg1 was cleaned up
+                let pkg1_exists: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM cargo_installed WHERE crate = ?1)",
+                        params![pkg1],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query pkg1");
+                assert!(!pkg1_exists, "Old installation should have been cleaned up");
+
+                // Verify pkg2 still exists
+                let pkg2_exists: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM cargo_installed WHERE crate = ?1)",
+                        params![pkg2],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query pkg2");
+                assert!(
+                    pkg2_exists,
+                    "Recent installation should not have been cleaned up"
+                );
+
+                // Verify through list_installed
+                let installed = cache.list_installed().expect("Failed to list installed");
+                assert_eq!(installed.len(), 1);
+                assert_eq!(installed[0].crate_name, pkg2);
+            });
+        }
+
+        #[test]
+        fn test_update_versions() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+
+                // Create initial versions
+                let versions1 = CargoInstallVersions {
+                    versions: vec!["v1.0.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Add initial versions
+                assert!(cache
+                    .add_versions(crate_name, &versions1)
+                    .expect("Failed to add initial versions"));
+
+                // Create updated versions
+                let versions2 = CargoInstallVersions {
+                    versions: vec!["v1.0.0".to_string(), "v1.1.0".to_string()],
+                    fetched_at: OffsetDateTime::now_utc(),
+                };
+
+                // Update versions
+                assert!(cache
+                    .add_versions(crate_name, &versions2)
+                    .expect("Failed to update versions"));
+
+                // Verify updated versions
+                let retrieved = cache
+                    .get_versions(crate_name)
+                    .expect("Failed to get versions");
+                assert_eq!(retrieved.versions.len(), 2);
+                assert!(retrieved.versions.contains(&"v1.1.0".to_string()));
+            });
+        }
+
+        #[test]
+        fn test_cleanup_cascade() {
+            run_with_env(&[], || {
+                let cache = CargoInstallOperationCache::get();
+                let crate_name = "github.com/test/pkg";
+                let version = "v1.0.0";
+                let env_id = "test-env";
+
+                // Add environment
+                let conn = get_conn();
+                conn.execute(
+                    include_str!("database/sql/up_environments_insert_env_version.sql"),
+                    params![env_id, "{}", "[]", "[]", "{}", "hash"],
+                )
+                .expect("Failed to add environment version");
+
+                // Add installation and requirement
+                cache
+                    .add_installed(crate_name, version)
+                    .expect("Failed to add installed version");
+                cache
+                    .add_required_by(env_id, crate_name, version)
+                    .expect("Failed to add requirement");
+
+                // Remove environment
+                conn.execute(
+                    "DELETE FROM env_versions WHERE env_version_id = ?1",
+                    params![env_id],
+                )
+                .expect("Failed to remove environment");
+
+                // Verify that the requirement has been cleaned up
+                let requirement_exists: bool = conn
+                    .query_row(
+                        concat!(
+                            "SELECT EXISTS(",
+                            "  SELECT 1 FROM cargo_install_required_by ",
+                            "  WHERE crate = ?1 AND version = ?2 AND env_version_id = ?3",
+                            ")",
+                        ),
+                        params![crate_name, version, env_id],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to query requirement");
+                assert!(
+                    !requirement_exists,
+                    "Requirement should be cleaned up via cascade"
+                );
+            });
+        }
+    }
+}

--- a/src/internal/cache/database/sql/cargo_install_operation_add.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_add.sql
@@ -1,0 +1,19 @@
+-- Add a new cargo-installed tool
+-- :param: ?1 crate - the crate used with 'cargo install'
+-- :param: ?2 version - the version of the tool
+INSERT INTO cargo_installed (
+    crate,
+    version,
+    last_required_at
+)
+VALUES (
+    ?1,
+    ?2,
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+)
+ON CONFLICT (crate, version) DO UPDATE
+SET
+    last_required_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE
+    crate = ?1
+    AND version = ?2;

--- a/src/internal/cache/database/sql/cargo_install_operation_add_required_by.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_add_required_by.sql
@@ -1,0 +1,15 @@
+-- Add required_by relationship for cargo-install tool
+-- :param: ?1 crate - the crate used with 'cargo install'
+-- :param: ?2 version - the version of the tool
+-- :param: ?3 env_version_id - the id of the environment version that is requiring the tool
+INSERT INTO cargo_install_required_by (
+    crate,
+    version,
+    env_version_id
+)
+VALUES (
+    ?1,
+    ?2,
+    ?3
+)
+ON CONFLICT (crate, version, env_version_id) DO NOTHING;

--- a/src/internal/cache/database/sql/cargo_install_operation_add_versions.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_add_versions.sql
@@ -1,0 +1,19 @@
+-- Cache cargo versions for a given crate
+-- :param: ?1 crate - the crate used with 'cargo install'
+-- :param: ?2 versions - JSON array of String
+INSERT INTO cargo_versions (
+    crate,
+    versions,
+    fetched_at
+)
+VALUES (
+    ?1,
+    ?2,
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+)
+ON CONFLICT (crate) DO UPDATE
+SET
+    versions = ?2,
+    fetched_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE
+    crate = ?1;

--- a/src/internal/cache/database/sql/cargo_install_operation_cleanup.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_cleanup.sql
@@ -1,0 +1,13 @@
+-- Delete the cargo install versions that are not required by any workdir
+-- :param1: number of seconds of the grace period before a version can be removed
+DELETE FROM cargo_installed AS gi
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM cargo_install_required_by AS girb
+    WHERE girb.crate = gi.crate
+          AND girb.version = gi.version
+)
+AND (
+    CAST(strftime('%s', 'now') AS INTEGER) >
+    (CAST(strftime('%s', last_required_at) AS INTEGER) + ?1)
+);

--- a/src/internal/cache/database/sql/cargo_install_operation_get_versions.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_get_versions.sql
@@ -1,0 +1,9 @@
+-- Get the cargo versions cached for a given crate
+-- :param: ?1 crate - the crate used with 'cargo install'
+SELECT
+    versions,
+    fetched_at
+FROM
+    cargo_versions
+WHERE
+    crate = ?1;

--- a/src/internal/cache/database/sql/cargo_install_operation_list_installed.sql
+++ b/src/internal/cache/database/sql/cargo_install_operation_list_installed.sql
@@ -1,0 +1,6 @@
+-- List all the installed cargo tools
+SELECT
+    crate,
+    version
+FROM
+    cargo_installed;

--- a/src/internal/cache/mod.rs
+++ b/src/internal/cache/mod.rs
@@ -1,6 +1,10 @@
 pub(crate) mod asdf_operation;
 pub(crate) use asdf_operation::AsdfOperationCache;
 
+pub(crate) mod cargo_install;
+pub(crate) use cargo_install::CargoInstallOperationCache;
+pub(crate) use cargo_install::CargoInstallVersions;
+
 pub(crate) mod database;
 pub(crate) use database::CacheManager;
 pub(crate) use database::CacheManagerError;

--- a/src/internal/config/parser/cache/cargo_install.rs
+++ b/src/internal/config/parser/cache/cargo_install.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::internal::config::utils::parse_duration_or_default;
+use crate::internal::config::ConfigValue;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CargoInstallCacheConfig {
+    pub versions_expire: u64,
+    pub cleanup_after: u64,
+}
+
+impl Default for CargoInstallCacheConfig {
+    fn default() -> Self {
+        Self {
+            versions_expire: Self::DEFAULT_VERSIONS_EXPIRE,
+            cleanup_after: Self::DEFAULT_CLEANUP_AFTER,
+        }
+    }
+}
+
+impl CargoInstallCacheConfig {
+    const DEFAULT_VERSIONS_EXPIRE: u64 = 86400; // 1 day
+    const DEFAULT_CLEANUP_AFTER: u64 = 604800; // 1 week
+
+    pub fn from_config_value(config_value: Option<ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        let versions_expire = parse_duration_or_default(
+            config_value.get("versions_expire").as_ref(),
+            Self::DEFAULT_VERSIONS_EXPIRE,
+        );
+
+        let cleanup_after = parse_duration_or_default(
+            config_value.get("cleanup_after").as_ref(),
+            Self::DEFAULT_CLEANUP_AFTER,
+        );
+
+        Self {
+            versions_expire,
+            cleanup_after,
+        }
+    }
+}

--- a/src/internal/config/parser/cache/mod.rs
+++ b/src/internal/config/parser/cache/mod.rs
@@ -4,6 +4,9 @@ pub(crate) use root::CacheConfig;
 mod asdf;
 pub(crate) use asdf::AsdfCacheConfig;
 
+mod cargo_install;
+pub(crate) use cargo_install::CargoInstallCacheConfig;
+
 mod github_release;
 pub(crate) use github_release::GithubReleaseCacheConfig;
 

--- a/src/internal/config/parser/cache/root.rs
+++ b/src/internal/config/parser/cache/root.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::config::parser::cache::AsdfCacheConfig;
+use crate::internal::config::parser::cache::CargoInstallCacheConfig;
 use crate::internal::config::parser::cache::GithubReleaseCacheConfig;
 use crate::internal::config::parser::cache::GoInstallCacheConfig;
 use crate::internal::config::parser::cache::HomebrewCacheConfig;
@@ -15,6 +16,7 @@ pub struct CacheConfig {
     pub environment: UpEnvironmentCacheConfig,
     pub asdf: AsdfCacheConfig,
     pub github_release: GithubReleaseCacheConfig,
+    pub cargo_install: CargoInstallCacheConfig,
     pub go_install: GoInstallCacheConfig,
     pub homebrew: HomebrewCacheConfig,
 }
@@ -26,6 +28,7 @@ impl Default for CacheConfig {
             environment: UpEnvironmentCacheConfig::default(),
             asdf: AsdfCacheConfig::default(),
             github_release: GithubReleaseCacheConfig::default(),
+            cargo_install: CargoInstallCacheConfig::default(),
             go_install: GoInstallCacheConfig::default(),
             homebrew: HomebrewCacheConfig::default(),
         }
@@ -49,6 +52,8 @@ impl CacheConfig {
         let asdf = AsdfCacheConfig::from_config_value(config_value.get("asdf"));
         let github_release =
             GithubReleaseCacheConfig::from_config_value(config_value.get("github_release"));
+        let cargo_install =
+            CargoInstallCacheConfig::from_config_value(config_value.get("cargo_install"));
         let go_install = GoInstallCacheConfig::from_config_value(config_value.get("go_install"));
         let homebrew = HomebrewCacheConfig::from_config_value(config_value.get("homebrew"));
 
@@ -57,6 +62,7 @@ impl CacheConfig {
             environment,
             asdf,
             github_release,
+            cargo_install,
             go_install,
             homebrew,
         }

--- a/src/internal/config/up/asdf_base.rs
+++ b/src/internal/config/up/asdf_base.rs
@@ -269,13 +269,21 @@ pub struct UpConfigAsdfBase {
 }
 
 impl UpConfigAsdfBase {
+    pub fn new_any_version(tool: &str) -> Self {
+        Self {
+            tool: tool.to_string(),
+            version: "*".to_string(),
+            ..Default::default()
+        }
+    }
+
     pub fn new(tool: &str, version: &str, dirs: BTreeSet<String>, upgrade: bool) -> Self {
-        UpConfigAsdfBase {
+        Self {
             tool: tool.to_string(),
             version: version.to_string(),
             upgrade,
             dirs: dirs.clone(),
-            ..UpConfigAsdfBase::default()
+            ..Default::default()
         }
     }
 

--- a/src/internal/config/up/base.rs
+++ b/src/internal/config/up/base.rs
@@ -10,6 +10,7 @@ use crate::internal::config::up::utils::reshim;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::UpProgressHandler;
 use crate::internal::config::up::UpConfigAsdfBase;
+use crate::internal::config::up::UpConfigCargoInstalls;
 use crate::internal::config::up::UpConfigGithubReleases;
 use crate::internal::config::up::UpConfigGoInstalls;
 use crate::internal::config::up::UpConfigHomebrew;
@@ -315,6 +316,9 @@ impl UpConfig {
             cleanups.push(cleanup);
         }
         if let Some(cleanup) = UpConfigGoInstalls::cleanup(&progress_handler)? {
+            cleanups.push(cleanup);
+        }
+        if let Some(cleanup) = UpConfigCargoInstalls::cleanup(&progress_handler)? {
             cleanups.push(cleanup);
         }
 

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -1,0 +1,1441 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use itertools::Itertools;
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use tokio::process::Command as TokioCommand;
+
+use crate::internal::cache::up_environments::UpEnvironment;
+use crate::internal::cache::utils as cache_utils;
+use crate::internal::cache::CargoInstallOperationCache;
+use crate::internal::cache::CargoInstallVersions;
+use crate::internal::config::config;
+use crate::internal::config::global_config;
+use crate::internal::config::up::asdf_tool_path;
+use crate::internal::config::up::utils::cleanup_path;
+use crate::internal::config::up::utils::progress_handler::ProgressHandler;
+use crate::internal::config::up::utils::run_progress;
+use crate::internal::config::up::utils::RunConfig;
+use crate::internal::config::up::utils::UpProgressHandler;
+use crate::internal::config::up::utils::VersionMatcher;
+use crate::internal::config::up::utils::VersionParser;
+use crate::internal::config::up::UpConfigAsdfBase;
+use crate::internal::config::up::UpConfigTool;
+use crate::internal::config::up::UpError;
+use crate::internal::config::up::UpOptions;
+use crate::internal::config::ConfigValue;
+use crate::internal::env::data_home;
+use crate::internal::env::tmpdir_cleanup_prefix;
+use crate::internal::user_interface::StringColor;
+
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        fn cargo_install_bin_path() -> PathBuf {
+            PathBuf::from(data_home()).join("cargo-install")
+        }
+    } else {
+        use once_cell::sync::Lazy;
+
+        static CARGO_INSTALL_BIN_PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(data_home()).join("cargo-install"));
+
+        fn cargo_install_bin_path() -> PathBuf {
+            CARGO_INSTALL_BIN_PATH.clone()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct UpConfigCargoInstalls {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    crates: Vec<UpConfigCargoInstall>,
+}
+
+impl Serialize for UpConfigCargoInstalls {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.crates.len() {
+            0 => serializer.serialize_none(),
+            1 => serializer.serialize_newtype_struct("UpConfigCargoInstalls", &self.crates[0]),
+            _ => serializer.collect_seq(self.crates.iter()),
+        }
+    }
+}
+
+impl UpConfigCargoInstalls {
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => return Self::default(),
+        };
+
+        if let Some(_entry) = config_value.as_str_forced() {
+            return Self {
+                crates: vec![UpConfigCargoInstall::from_config_value(Some(config_value))],
+            };
+        }
+
+        if let Some(array) = config_value.as_array() {
+            return Self {
+                crates: array
+                    .iter()
+                    .map(|config_value| UpConfigCargoInstall::from_config_value(Some(config_value)))
+                    .collect(),
+            };
+        }
+
+        if let Some(table) = config_value.as_table() {
+            // Check if there is a 'crate' key, in which case it's a single
+            // crate and we can just parse it and return it
+            if table.contains_key("crate") {
+                return Self {
+                    crates: vec![UpConfigCargoInstall::from_config_value(Some(config_value))],
+                };
+            }
+
+            // Otherwise, we have a table of crates, where crates are
+            // the keys and the values are the configuration for the crate;
+            // we want to go over them in lexico-graphical order to ensure that
+            // the order is consistent
+            let mut crates = Vec::new();
+            for crate_name in table.keys().sorted() {
+                let value = table.get(crate_name).expect("crate config not found");
+                let crate_name = match ConfigValue::from_str(crate_name) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+
+                let mut crate_config = if let Some(table) = value.as_table() {
+                    table.clone()
+                } else if let Some(version) = value.as_str_forced() {
+                    let mut crate_config = HashMap::new();
+                    let value = match ConfigValue::from_str(&version) {
+                        Ok(value) => value,
+                        Err(_) => continue,
+                    };
+                    crate_config.insert("version".to_string(), value);
+                    crate_config
+                } else {
+                    HashMap::new()
+                };
+
+                crate_config.insert("crate".to_string(), crate_name);
+                crates.push(UpConfigCargoInstall::from_table(&crate_config));
+            }
+
+            return Self { crates };
+        }
+
+        UpConfigCargoInstalls::default()
+    }
+
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<(), UpError> {
+        if self.crates.len() == 1 {
+            progress_handler.init(self.crates[0].desc().light_blue());
+        } else {
+            progress_handler.init("cargo install:".light_blue());
+            if self.crates.is_empty() {
+                progress_handler.error_with_message("no crate".to_string());
+                return Err(UpError::Config("at least one crate required".to_string()));
+            }
+        }
+
+        let cargo_bin = self.get_cargo_bin(options, progress_handler)?;
+
+        let num = self.crates.len();
+        for (idx, tool) in self.crates.iter().enumerate() {
+            let subhandler = if self.crates.len() == 1 {
+                progress_handler
+            } else {
+                &progress_handler.subhandler(
+                    &format!(
+                        "[{current:padding$}/{total:padding$}] {tool} ",
+                        current = idx + 1,
+                        total = num,
+                        padding = format!("{}", num).len(),
+                        tool = tool.desc(),
+                    )
+                    .light_yellow(),
+                )
+            };
+            tool.up(options, environment, subhandler, &cargo_bin)
+                .inspect_err(|_err| {
+                    progress_handler.error();
+                })?;
+        }
+
+        progress_handler.success_with_message(self.get_up_message());
+
+        Ok(())
+    }
+
+    fn get_cargo_bin(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<PathBuf, UpError> {
+        progress_handler.progress("install dependencies".to_string());
+        let rust_tool = UpConfigTool::Asdf(UpConfigAsdfBase::new_any_version("rust"));
+
+        // We create a fake environment since we do not want to add this
+        // rust version as part of it, but we want to be able to use `cargo`
+        // to call `cargo install`
+        let mut fake_env = UpEnvironment::new();
+
+        let subhandler = progress_handler.subhandler(&"rust: ".light_black());
+        rust_tool.up(options, &mut fake_env, &subhandler)?;
+
+        // Grab the tool from inside go_tool
+        let asdf = match rust_tool {
+            UpConfigTool::Asdf(asdf) => asdf,
+            _ => unreachable!("rust_tool is not an asdf tool"),
+        };
+
+        let installed_version = asdf.version()?;
+        let install_path = PathBuf::from(asdf_tool_path("rust", &installed_version));
+        let cargo_bin = install_path.join("bin").join("cargo");
+
+        Ok(cargo_bin)
+    }
+
+    pub fn commit(&self, options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        for tool in &self.crates {
+            if tool.was_upped() {
+                tool.commit(options, env_version_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        self.crates.iter().any(|tool| tool.was_upped())
+    }
+
+    fn get_up_message(&self) -> String {
+        let count: HashMap<CargoInstallHandled, usize> = self
+            .crates
+            .iter()
+            .map(|tool| tool.handling())
+            .fold(HashMap::new(), |mut map, item| {
+                *map.entry(item).or_insert(0) += 1;
+                map
+            });
+        let handled: Vec<String> = self
+            .crates
+            .iter()
+            .filter_map(|tool| match tool.handling() {
+                CargoInstallHandled::Handled | CargoInstallHandled::Noop => Some(format!(
+                    "{}@{}",
+                    tool.crate_name,
+                    tool.actual_version
+                        .get()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                )),
+                _ => None,
+            })
+            .sorted()
+            .collect();
+
+        if handled.is_empty() {
+            return "nothing done".to_string();
+        }
+
+        let mut numbers = vec![];
+
+        if let Some(count) = count.get(&CargoInstallHandled::Handled) {
+            numbers.push(format!("{} installed", count).green());
+        }
+
+        if let Some(count) = count.get(&CargoInstallHandled::Noop) {
+            numbers.push(format!("{} already installed", count).light_black());
+        }
+
+        if numbers.is_empty() {
+            return "nothing done".to_string();
+        }
+
+        format!(
+            "{} {}",
+            numbers.join(", "),
+            format!("({})", handled.join(", ")).light_black().italic(),
+        )
+    }
+
+    pub fn down(&self, progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        if self.crates.len() == 1 {
+            return self.crates[0].down(progress_handler);
+        }
+
+        progress_handler.init("go install:".light_blue());
+        progress_handler.progress("updating dependencies".to_string());
+
+        let num = self.crates.len();
+        for (idx, tool) in self.crates.iter().enumerate() {
+            let subhandler = progress_handler.subhandler(
+                &format!(
+                    "[{current:padding$}/{total:padding$}] ",
+                    current = idx + 1,
+                    total = num,
+                    padding = format!("{}", num).len(),
+                )
+                .light_yellow(),
+            );
+            tool.down(&subhandler)?;
+        }
+
+        progress_handler.success_with_message("dependencies cleaned".light_green());
+
+        Ok(())
+    }
+
+    pub fn cleanup(progress_handler: &UpProgressHandler) -> Result<Option<String>, UpError> {
+        progress_handler.init("cargo install:".light_blue());
+        progress_handler.progress("checking for unused cargo-installed crates".to_string());
+
+        let cache = CargoInstallOperationCache::get();
+
+        // Cleanup removable crates from the database
+        cache.cleanup().map_err(|err| {
+            let msg = format!("failed to cleanup cargo install cache: {}", err);
+            progress_handler.progress(msg.clone());
+            UpError::Cache(msg)
+        })?;
+
+        // List crates that should exist
+        let expected_crates = cache.list_installed().map_err(|err| {
+            let msg = format!("failed to list cargo-installed crates: {}", err);
+            progress_handler.progress(msg.clone());
+            UpError::Cache(msg)
+        })?;
+
+        let expected_paths = expected_crates
+            .iter()
+            .map(|install| {
+                cargo_install_bin_path()
+                    .join(&install.crate_name)
+                    .join(&install.version)
+            })
+            .collect::<Vec<PathBuf>>();
+
+        let (root_removed, num_removed, removed_paths) = cleanup_path(
+            cargo_install_bin_path(),
+            expected_paths,
+            progress_handler,
+            true,
+        )?;
+
+        if root_removed {
+            return Ok(Some("removed all crates".to_string()));
+        }
+
+        if num_removed == 0 {
+            return Ok(None);
+        }
+
+        // We want to go over the paths that were removed to
+        // return a proper message about the go install
+        // that were removed
+        let removed_crates = removed_paths
+            .iter()
+            .filter_map(|path| {
+                // Path should starts with the bin path if it is a go-install tool
+                let rest_of_path = match path.strip_prefix(cargo_install_bin_path()) {
+                    Ok(rest_of_path) => rest_of_path,
+                    Err(_) => return None,
+                };
+
+                // Path should have 2 components after stripping the bin path:
+                // the crate name (1) and the version (1)
+                let parts = rest_of_path.components().collect::<Vec<_>>();
+                if parts.len() > 2 {
+                    return None;
+                }
+
+                let parts = parts
+                    .into_iter()
+                    .map(|part| part.as_os_str().to_string_lossy().to_string())
+                    .collect::<Vec<String>>();
+
+                let crate_name = parts[0].clone();
+                let version = if parts.len() > 1 {
+                    Some(parts[2].clone())
+                } else {
+                    None
+                };
+
+                Some((crate_name, version))
+            })
+            .collect::<Vec<_>>();
+
+        if removed_crates.is_empty() {
+            return Ok(Some(format!(
+                "removed {} cargo-installed crate{}",
+                num_removed.light_yellow(),
+                if num_removed > 1 { "s" } else { "" }
+            )));
+        }
+
+        let removed_crates = removed_crates
+            .iter()
+            .map(|(path, version)| match version {
+                Some(version) => format!("{}@{}", path.light_yellow(), version.light_yellow()),
+                None => format!("{} (all versions)", path.light_yellow(),),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Some(format!("removed {}", removed_crates.join(", "))))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Hash)]
+pub enum CargoInstallHandled {
+    Handled,
+    Noop,
+    Unhandled,
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum CargoInstallError {
+    #[error("invalid crate name: {0}")]
+    InvalidCrateName(String),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct UpConfigCargoInstall {
+    /// The name of the crate to install
+    pub crate_name: String,
+
+    /// The version of the crate to install
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Whether to install the exact version specified in the `version` field;
+    /// if `true`, there will be no check for the available versions and the
+    /// `cargo install` command will be called with the version specified;
+    /// if `false`, the latest version that matches the version will be installed.
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub exact: bool,
+
+    /// Whether to always upgrade the tool or use the latest matching
+    /// already installed version.
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub upgrade: bool,
+
+    /// Whether to install the pre-release version of the tool
+    /// if it is the most recent matching version
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub prerelease: bool,
+
+    /// Whether to allow versions containing build details
+    /// (e.g. 1.2.3+build)
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub build: bool,
+
+    /// The URL of the Crates API; this is only used for testing purposes
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_url: Option<String>,
+
+    /// In case there was an error while parsing the configuration, this field
+    /// will contain the error message
+    #[serde(default, skip)]
+    config_error: Option<String>,
+
+    #[serde(default, skip)]
+    actual_version: OnceCell<String>,
+
+    #[serde(default, skip)]
+    was_handled: OnceCell<CargoInstallHandled>,
+}
+
+impl Default for UpConfigCargoInstall {
+    fn default() -> Self {
+        UpConfigCargoInstall {
+            crate_name: "".to_string(),
+            version: None,
+            exact: false,
+            upgrade: false,
+            prerelease: false,
+            build: false,
+            api_url: None,
+            config_error: None,
+            actual_version: OnceCell::new(),
+            was_handled: OnceCell::new(),
+        }
+    }
+}
+
+impl UpConfigCargoInstall {
+    pub fn from_config_value(config_value: Option<&ConfigValue>) -> Self {
+        let config_value = match config_value {
+            Some(config_value) => config_value,
+            None => {
+                return Self {
+                    config_error: Some("no configuration provided".to_string()),
+                    ..Default::default()
+                }
+            }
+        };
+
+        if let Some(table) = config_value.as_table() {
+            Self::from_table(&table)
+        } else if let Some(crate_name) = config_value.as_str_forced() {
+            let (crate_name, version) = match parse_cargo_crate_name(&crate_name) {
+                Ok((crate_name, version)) => (crate_name, version),
+                Err(err) => {
+                    return Self {
+                        crate_name: crate_name.to_string(),
+                        config_error: Some(err.to_string()),
+                        ..Default::default()
+                    }
+                }
+            };
+
+            UpConfigCargoInstall {
+                crate_name,
+                version,
+                ..UpConfigCargoInstall::default()
+            }
+        } else {
+            Self {
+                config_error: Some("no crate provided".to_string()),
+                ..Default::default()
+            }
+        }
+    }
+
+    fn from_table(table: &HashMap<String, ConfigValue>) -> Self {
+        let crate_name = match table.get("crate") {
+            Some(crate_name) => {
+                if let Some(crate_name) = crate_name.as_str_forced() {
+                    crate_name.to_string()
+                } else {
+                    return UpConfigCargoInstall {
+                        config_error: Some("crate_name must be a string".to_string()),
+                        ..Default::default()
+                    };
+                }
+            }
+            None => {
+                if table.len() == 1 {
+                    let (key, value) = table.iter().next().unwrap();
+                    if let Some(version) = value.as_str_forced() {
+                        return UpConfigCargoInstall {
+                            crate_name: key.clone(),
+                            version: Some(version.to_string()),
+                            ..UpConfigCargoInstall::default()
+                        };
+                    } else if let (Some(table), Ok(crate_name_config_value)) =
+                        (value.as_table(), ConfigValue::from_str(key))
+                    {
+                        let mut crate_name_config = table.clone();
+                        crate_name_config.insert("crate_name".to_string(), crate_name_config_value);
+                        return UpConfigCargoInstall::from_table(&crate_name_config);
+                    } else if let (true, Ok(crate_name_config_value)) =
+                        (value.is_null(), ConfigValue::from_str(key))
+                    {
+                        let crate_name_config = HashMap::from_iter(vec![(
+                            "crate".to_string(),
+                            crate_name_config_value,
+                        )]);
+                        return UpConfigCargoInstall::from_table(&crate_name_config);
+                    }
+                }
+                return UpConfigCargoInstall {
+                    config_error: Some("crate is required".to_string()),
+                    ..Default::default()
+                };
+            }
+        };
+
+        let (crate_name, version) = match parse_cargo_crate_name(&crate_name) {
+            Ok((crate_name, version)) => (crate_name, version),
+            Err(err) => {
+                return UpConfigCargoInstall {
+                    crate_name,
+                    config_error: Some(err.to_string()),
+                    ..Default::default()
+                };
+            }
+        };
+
+        // If version is specified, it overrides the version in the crate_name
+        let version = match table
+            .get("version")
+            .map(|v| v.as_str_forced())
+            .unwrap_or(None)
+        {
+            Some(version) => Some(version.to_string()),
+            None => version,
+        };
+        let exact = table
+            .get("exact")
+            .map(|v| v.as_bool_forced())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let upgrade = table
+            .get("upgrade")
+            .map(|v| v.as_bool_forced())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let prerelease = table
+            .get("prerelease")
+            .map(|v| v.as_bool())
+            .unwrap_or(None)
+            .unwrap_or(false);
+        let build = table
+            .get("build")
+            .map(|v| v.as_bool())
+            .unwrap_or(None)
+            .unwrap_or(false);
+
+        UpConfigCargoInstall {
+            crate_name,
+            version,
+            exact,
+            upgrade,
+            prerelease,
+            build,
+            ..Default::default()
+        }
+    }
+
+    fn update_cache(
+        &self,
+        _options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &dyn ProgressHandler,
+    ) {
+        let version = match self.actual_version.get() {
+            Some(version) => version,
+            None => {
+                progress_handler.error_with_message("version not set".to_string());
+                return;
+            }
+        };
+
+        progress_handler.progress("updating cache".to_string());
+
+        if let Err(err) = CargoInstallOperationCache::get().add_installed(&self.crate_name, version)
+        {
+            progress_handler.progress(format!("failed to update github release cache: {}", err));
+            return;
+        }
+
+        let version_crate_name = self.version_crate_name(version);
+        environment.add_path(version_crate_name.join("bin"));
+
+        progress_handler.progress("updated cache".to_string());
+    }
+
+    fn short_crate_name(&self) -> String {
+        // Get the last, non-empty part of the crate_name
+        self.crate_name
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .last()
+            .unwrap_or("")
+            .to_string()
+    }
+
+    fn desc(&self) -> String {
+        if self.crate_name.is_empty() {
+            "go install:".to_string()
+        } else if self.config_error.is_some() {
+            format!("{}:", self.crate_name)
+        } else {
+            format!(
+                "{} ({}):",
+                self.short_crate_name(),
+                match self.version {
+                    None => "latest".to_string(),
+                    Some(ref version) if version.is_empty() => "latest".to_string(),
+                    Some(ref version) => version.clone(),
+                }
+            )
+        }
+    }
+
+    pub fn up(
+        &self,
+        options: &UpOptions,
+        environment: &mut UpEnvironment,
+        progress_handler: &UpProgressHandler,
+        cargo_bin: &Path,
+    ) -> Result<(), UpError> {
+        progress_handler.init(self.desc().light_blue());
+
+        if let Some(config_error) = &self.config_error {
+            progress_handler.error_with_message(config_error.clone());
+            return Err(UpError::Config(config_error.clone()));
+        }
+
+        if self.crate_name.is_empty() {
+            progress_handler.error_with_message("crate_name is required".to_string());
+            return Err(UpError::Config("crate_name is required".to_string()));
+        }
+
+        let installed = self.resolve_and_install_version(cargo_bin, options, progress_handler)?;
+
+        self.update_cache(options, environment, progress_handler);
+
+        let version = match self.actual_version.get() {
+            Some(version) => version.to_string(),
+            None => "unknown".to_string(),
+        };
+        let msg = match installed {
+            true => format!("{} installed", version.light_yellow()),
+            false => format!("{} already installed", version).light_black(),
+        };
+        progress_handler.success_with_message(msg);
+
+        Ok(())
+    }
+
+    pub fn was_upped(&self) -> bool {
+        matches!(
+            self.was_handled.get(),
+            Some(CargoInstallHandled::Handled) | Some(CargoInstallHandled::Noop)
+        )
+    }
+
+    pub fn commit(&self, _options: &UpOptions, env_version_id: &str) -> Result<(), UpError> {
+        let version = match self.actual_version.get() {
+            Some(version) => version,
+            None => {
+                return Err(UpError::Exec("version not set".to_string()));
+            }
+        };
+
+        if let Err(err) = CargoInstallOperationCache::get().add_required_by(
+            env_version_id,
+            &self.crate_name,
+            version,
+        ) {
+            return Err(UpError::Cache(format!(
+                "failed to update go install cache: {}",
+                err
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn down(&self, _progress_handler: &UpProgressHandler) -> Result<(), UpError> {
+        Ok(())
+    }
+
+    fn handling(&self) -> CargoInstallHandled {
+        match self.was_handled.get() {
+            Some(handled) => handled.clone(),
+            None => CargoInstallHandled::Unhandled,
+        }
+    }
+
+    fn upgrade_tool(&self, options: &UpOptions) -> bool {
+        self.upgrade || options.upgrade || config(".").up_command.upgrade
+    }
+
+    fn resolve_and_install_version(
+        &self,
+        cargo_bin: &Path,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<bool, UpError> {
+        if self.exact {
+            let version = self.version.clone().unwrap_or("latest".to_string());
+            if version == "latest" {
+                progress_handler.error_with_message("exact version cannot be 'latest'".to_string());
+                return Err(UpError::Config(
+                    "exact version cannot be 'latest'".to_string(),
+                ));
+            }
+
+            match self.install_version(cargo_bin, options, &version, progress_handler) {
+                Ok(installed) => return self.handle_installed(&version, Ok(installed)),
+                Err(err) => {
+                    progress_handler.error_with_message(err.message());
+                    return Err(err);
+                }
+            }
+        }
+
+        let mut version = "".to_string();
+        let mut install_version = Err(UpError::Exec("did not even try".to_string()));
+        let mut versions = None;
+
+        // If the options do not include upgrade, then we can try using
+        // an already-installed version if any matches the requirements
+        if !self.upgrade_tool(options) {
+            let resolve_str = match self.version.as_ref() {
+                Some(version) if version != "latest" => version.to_string(),
+                _ => {
+                    let list_versions = self.list_versions(options, progress_handler)?;
+                    versions = Some(list_versions.clone());
+                    let latest = self.latest_version(&list_versions)?;
+                    progress_handler.progress(
+                        format!("considering installed versions matching {}", latest).light_black(),
+                    );
+                    latest
+                }
+            };
+
+            let installed_versions = self.list_installed_versions(progress_handler)?;
+            match self.resolve_version_from_str(&resolve_str, &installed_versions) {
+                Ok(installed_version) => {
+                    progress_handler.progress(format!(
+                        "found matching installed version {}",
+                        installed_version.light_yellow(),
+                    ));
+
+                    version = installed_version;
+                    install_version = Ok(false);
+                }
+                Err(_err) => {
+                    progress_handler.progress("no matching version installed".to_string());
+                }
+            }
+        }
+
+        if version.is_empty() {
+            let versions = match versions {
+                Some(versions) => versions,
+                None => self.list_versions(options, progress_handler)?,
+            };
+            version = match self.resolve_version(&versions.versions) {
+                Ok(version) => version,
+                Err(err) => {
+                    // If the versions are not fresh of now, and we failed to
+                    // resolve the version to install, we should try to refresh the
+                    // versions list and try again
+                    if options.read_cache && !versions.is_fresh() {
+                        progress_handler.progress("no matching version found in cache".to_string());
+
+                        let versions = self.list_versions(
+                            &UpOptions {
+                                read_cache: false,
+                                ..options.clone()
+                            },
+                            progress_handler,
+                        )?;
+
+                        self.resolve_version(&versions.versions)
+                            .inspect_err(|err| {
+                                progress_handler.error_with_message(err.message());
+                            })?
+                    } else {
+                        progress_handler.error_with_message(err.message());
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Try installing the version found
+            install_version = self.install_version(cargo_bin, options, &version, progress_handler);
+            if install_version.is_err() && !options.fail_on_upgrade {
+                // If we get here and there is an issue downloading the version,
+                // list all installed versions and check if one of those could
+                // fit the requirement, in which case we can fallback to it
+                let installed_versions = self.list_installed_versions(progress_handler)?;
+                match self.resolve_version(&installed_versions) {
+                    Ok(installed_version) => {
+                        progress_handler.progress(format!(
+                            "falling back to {}@{}",
+                            self.crate_name,
+                            installed_version.light_yellow(),
+                        ));
+
+                        version = installed_version;
+                        install_version = Ok(false);
+                    }
+                    Err(_err) => {}
+                }
+            }
+        }
+
+        self.handle_installed(&version, install_version)
+    }
+
+    fn handle_installed(
+        &self,
+        version: &str,
+        installed: Result<bool, UpError>,
+    ) -> Result<bool, UpError> {
+        if let Ok(installed) = &installed {
+            self.actual_version.set(version.to_string()).map_err(|_| {
+                let errmsg = "failed to set actual version".to_string();
+                UpError::Exec(errmsg)
+            })?;
+
+            if self
+                .was_handled
+                .set(if *installed {
+                    CargoInstallHandled::Handled
+                } else {
+                    CargoInstallHandled::Noop
+                })
+                .is_err()
+            {
+                unreachable!("failed to set was_handled");
+            }
+        }
+
+        installed
+    }
+
+    fn list_versions(
+        &self,
+        options: &UpOptions,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<CargoInstallVersions, UpError> {
+        let cache = CargoInstallOperationCache::get();
+        let cached_versions = if options.read_cache {
+            if let Some(versions) = cache.get_versions(&self.crate_name) {
+                let versions = versions.clone();
+                let config = global_config();
+                let expire = config.cache.go_install.versions_expire;
+                if !versions.is_stale(expire) {
+                    progress_handler.progress("using cached version list".light_black());
+                    return Ok(versions);
+                }
+                Some(versions)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        progress_handler.progress("refreshing versions list".to_string());
+        match self.list_versions_from_api(progress_handler) {
+            Ok(versions) => {
+                if options.write_cache {
+                    progress_handler.progress("updating cache with version list".to_string());
+                    if let Err(err) = cache.add_versions(&self.crate_name, &versions) {
+                        progress_handler.progress(format!("failed to update cache: {}", err));
+                    }
+                }
+
+                Ok(versions)
+            }
+            Err(err) => {
+                if let Some(cached_versions) = cached_versions {
+                    progress_handler.progress(format!(
+                        "{}; {}",
+                        format!("error refreshing version list: {}", err).red(),
+                        "using cached data".light_black()
+                    ));
+                    Ok(cached_versions)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    fn list_versions_from_api(
+        &self,
+        progress_handler: &UpProgressHandler,
+    ) -> Result<CargoInstallVersions, UpError> {
+        // Use https://crates.io/api/v1/crates/<crate>/versions URL
+        // to list the available versions for the crate
+        let api_url = self
+            .api_url
+            .clone()
+            .unwrap_or("https://crates.io/api/v1".to_string());
+        let versions_url = format!(
+            "{}/crates/{}/versions",
+            api_url.trim_end_matches('/'),
+            self.crate_name
+        );
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        );
+
+        let client = match reqwest::blocking::Client::builder()
+            .user_agent(format!("omni {}", env!("CARGO_PKG_VERSION")))
+            .default_headers(headers)
+            .build()
+        {
+            Ok(client) => client,
+            Err(err) => {
+                let errmsg = format!("failed to create client: {}", err);
+                progress_handler.error_with_message(errmsg.clone());
+                return Err(UpError::Exec(errmsg));
+            }
+        };
+
+        let response = client.get(&versions_url).send().map_err(|err| {
+            let errmsg = format!("failed to get versions: {}", err);
+            progress_handler.error_with_message(errmsg.clone());
+            UpError::Exec(errmsg)
+        })?;
+
+        let status = response.status();
+        let contents = response.text().map_err(|err| {
+            let errmsg = format!("failed to read response: {}", err);
+            progress_handler.error_with_message(errmsg.clone());
+            UpError::Exec(errmsg)
+        })?;
+
+        if !status.is_success() {
+            // Try parsing the error message from the body, and default to
+            // the body if we can't parse it
+            let errmsg = match CratesApiError::from_json(&contents) {
+                Ok(err) => err.detail(),
+                Err(_) => contents.clone(),
+            };
+
+            let errmsg = format!("{}: {} ({})", versions_url, errmsg, status);
+            progress_handler.error_with_message(errmsg.to_string());
+            return Err(UpError::Exec(errmsg));
+        }
+
+        let versions = CratesApiVersions::from_json(&contents).map_err(|err| {
+            let errmsg = format!("failed to parse versions: {}", err);
+            progress_handler.error_with_message(errmsg.clone());
+            UpError::Exec(errmsg)
+        })?;
+
+        Ok(CargoInstallVersions::new(versions.versions()))
+    }
+
+    fn latest_version(&self, versions: &CargoInstallVersions) -> Result<String, UpError> {
+        let latest = self.resolve_version_from_str("latest", &versions.versions)?;
+        Ok(VersionParser::parse(&latest)
+            .expect("failed to parse version string")
+            .major()
+            .to_string())
+    }
+
+    fn resolve_version(&self, versions: &[String]) -> Result<String, UpError> {
+        let match_version = self.version.clone().unwrap_or_else(|| "latest".to_string());
+        self.resolve_version_from_str(&match_version, versions)
+    }
+
+    fn resolve_version_from_str(
+        &self,
+        match_version: &str,
+        versions: &[String],
+    ) -> Result<String, UpError> {
+        let mut matcher = VersionMatcher::new(match_version);
+        matcher.prerelease(self.prerelease);
+        matcher.build(self.build);
+        matcher.prefix(true);
+
+        let version = versions
+            .iter()
+            .filter_map(|version| VersionParser::parse(version))
+            .sorted()
+            .rev()
+            .find(|version| matcher.matches(&version.to_string()))
+            .ok_or_else(|| {
+                UpError::Exec(format!(
+                    "no matching version found for {}@{}",
+                    self.crate_name, match_version,
+                ))
+            })?;
+
+        Ok(version.to_string())
+    }
+
+    fn list_installed_versions(
+        &self,
+        _progress_handler: &dyn ProgressHandler,
+    ) -> Result<Vec<String>, UpError> {
+        let version_crate_name = cargo_install_bin_path().join(&self.crate_name);
+
+        if !version_crate_name.exists() {
+            return Ok(vec![]);
+        }
+
+        let installed_versions = std::fs::read_dir(&version_crate_name)
+            .map_err(|err| {
+                let errmsg = format!("failed to read directory: {}", err);
+                UpError::Exec(errmsg)
+            })?
+            .filter_map(|entry| {
+                entry.ok().and_then(|entry| {
+                    if entry.file_type().ok()?.is_dir() {
+                        entry.file_name().into_string().ok()
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        Ok(installed_versions)
+    }
+
+    fn install_version(
+        &self,
+        cargo_bin: &Path,
+        options: &UpOptions,
+        version: &str,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<bool, UpError> {
+        let install_path = self.version_crate_name(version);
+
+        if options.read_cache && install_path.exists() && install_path.is_dir() {
+            progress_handler.progress(
+                format!("installed {}@{} (cached)", self.crate_name, version).light_black(),
+            );
+
+            return Ok(false);
+        }
+
+        // Make a temporary directory to download the release
+        let tmp_dir = tempfile::Builder::new()
+            .prefix(&tmpdir_cleanup_prefix("cargo-install"))
+            .tempdir()
+            .map_err(|err| {
+                progress_handler.error_with_message(format!("failed to create temp dir: {}", err));
+                UpError::Exec(format!("failed to create temp dir: {}", err))
+            })?;
+        let tmp_bin_path = tmp_dir.path().join("bin");
+
+        // CARGO_HOME and RUSTUP_HOME need to be set to the cargo binary install path
+        // We need to get the parent() twice to get the cargo home directory
+        let cargo_home = cargo_bin
+            .parent()
+            .expect("cargo bin has no parent")
+            .parent()
+            .expect("cargo bin has no parent");
+
+        let mut cargo_install_cmd = TokioCommand::new(cargo_bin);
+        cargo_install_cmd.arg("install");
+        cargo_install_cmd.arg(&self.crate_name);
+        cargo_install_cmd.arg("--version");
+        cargo_install_cmd.arg(version);
+        cargo_install_cmd.arg("--no-track");
+        cargo_install_cmd.arg("--root");
+        cargo_install_cmd.arg(&tmp_dir.path());
+        cargo_install_cmd.arg("--bins");
+        cargo_install_cmd.arg("--force");
+
+        // Override GO environment variables to ensure that the
+        // installation is done in the temporary directory
+        cargo_install_cmd.env("CARGO_HOME", cargo_home);
+        cargo_install_cmd.env("RUSTUP_HOME", cargo_home);
+        cargo_install_cmd.env("CARGO_INSTALL_ROOT", &tmp_dir.path());
+
+        cargo_install_cmd.stdout(std::process::Stdio::piped());
+        cargo_install_cmd.stderr(std::process::Stdio::piped());
+
+        run_progress(
+            &mut cargo_install_cmd,
+            Some(progress_handler),
+            RunConfig::default().with_askpass(),
+        )?;
+
+        if !tmp_bin_path.exists() {
+            let msg = "failed to install (bin directory empty)".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(UpError::Exec(msg));
+        }
+
+        // Move the installed version to the correct crate_name
+        std::fs::create_dir_all(&install_path).map_err(|err| {
+            progress_handler.error_with_message(format!("failed to create dir: {}", err));
+            UpError::Exec(format!("failed to create dir: {}", err))
+        })?;
+
+        // Move the tmp_bin_crate_name to the install_crate_name/<bin> directory
+        std::fs::rename(&tmp_bin_path, install_path.join("bin")).map_err(|err| {
+            progress_handler.error_with_message(format!("failed to move bin: {}", err));
+            UpError::Exec(format!("failed to move bin: {}", err))
+        })?;
+
+        Ok(true)
+    }
+
+    fn version_crate_name(&self, version: &str) -> PathBuf {
+        cargo_install_bin_path()
+            .join(&self.crate_name)
+            .join(version)
+    }
+}
+
+/// Main function that parses and validates a complete go install string
+fn parse_cargo_crate_name<T>(input: T) -> Result<(String, Option<String>), CargoInstallError>
+where
+    T: AsRef<str>,
+{
+    let input = input.as_ref();
+    let parts: Vec<&str> = input.split('@').collect();
+    if parts.len() > 2 {
+        return Err(CargoInstallError::InvalidCrateName(
+            "multiple @ symbols found".to_string(),
+        ));
+    }
+
+    let crate_name = parts[0].to_string();
+
+    let version = if parts.len() == 2 {
+        Some(parts[1].to_string())
+    } else {
+        None
+    };
+
+    Ok((crate_name, version))
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct CratesApiError {
+    #[serde(default)]
+    errors: Vec<CratesApiErrorItem>,
+}
+
+impl CratesApiError {
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    pub fn detail(&self) -> String {
+        self.errors
+            .iter()
+            .map(|error| error.detail.clone())
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct CratesApiErrorItem {
+    #[serde(default)]
+    detail: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct CratesApiVersions {
+    #[serde(default)]
+    versions: Vec<CratesApiVersion>,
+}
+
+impl CratesApiVersions {
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    pub fn versions(&self) -> Vec<String> {
+        self.versions
+            .iter()
+            .filter_map(|version| {
+                // Skip yanked versions
+                if version.yanked {
+                    None
+                } else {
+                    Some(version.num.clone())
+                }
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct CratesApiVersion {
+    #[serde(default)]
+    num: String,
+    #[serde(default)]
+    yanked: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::os::unix::fs::PermissionsExt;
+
+    use crate::internal::testutils::run_with_env;
+
+    mod parse_cargo_crate_name {
+        use super::*;
+
+        #[test]
+        fn simple_crate() {
+            let (name, version) = parse_cargo_crate_name("serde").unwrap();
+            assert_eq!(name, "serde");
+            assert_eq!(version, None);
+        }
+
+        #[test]
+        fn crate_with_version() {
+            let (name, version) = parse_cargo_crate_name("serde@1.0.0").unwrap();
+            assert_eq!(name, "serde");
+            assert_eq!(version, Some("1.0.0".to_string()));
+        }
+
+        #[test]
+        fn invalid_multiple_at() {
+            let result = parse_cargo_crate_name("serde@1.0.0@latest");
+            assert!(matches!(
+                result,
+                Err(CargoInstallError::InvalidCrateName(_))
+            ));
+        }
+    }
+
+    mod install {
+        use super::*;
+
+        #[test]
+        fn latest_version() {
+            test_install_crate(
+                TestOptions::default().version("1.2.3"),
+                UpConfigCargoInstall {
+                    crate_name: "test-crate".to_string(),
+                    ..UpConfigCargoInstall::default()
+                },
+            );
+        }
+
+        #[test]
+        fn specific_version() {
+            test_install_crate(
+                TestOptions::default().version("1.0.0"),
+                UpConfigCargoInstall {
+                    crate_name: "test-crate".to_string(),
+                    version: Some("1.0.0".to_string()),
+                    exact: true,
+                    ..UpConfigCargoInstall::default()
+                },
+            );
+        }
+
+        #[test]
+        fn with_prerelease() {
+            test_install_crate(
+                TestOptions::default().version("2.0.0-alpha"),
+                UpConfigCargoInstall {
+                    crate_name: "test-crate".to_string(),
+                    prerelease: true,
+                    ..UpConfigCargoInstall::default()
+                },
+            );
+        }
+
+        #[derive(Default)]
+        struct TestOptions {
+            expected_version: Option<String>,
+        }
+
+        impl TestOptions {
+            fn version(mut self, version: &str) -> Self {
+                self.expected_version = Some(version.to_string());
+                self
+            }
+        }
+
+        fn test_install_crate(test: TestOptions, config: UpConfigCargoInstall) {
+            run_with_env(&[], || {
+                let mut mock_server = mockito::Server::new();
+                let api_url = mock_server.url();
+
+                let config = UpConfigCargoInstall {
+                    api_url: Some(api_url.to_string()),
+                    ..config
+                };
+
+                // Mock the crates.io API response
+                let versions_response = format!(
+                    r#"{{
+                        "versions": [
+                            {{"num": "2.0.0-alpha", "yanked": false}},
+                            {{"num": "1.2.3", "yanked": false}},
+                            {{"num": "1.0.0", "yanked": false}}
+                        ]
+                    }}"#
+                );
+
+                let mock_versions = mock_server
+                    .mock(
+                        "GET",
+                        format!("/crates/{}/versions", config.crate_name).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(versions_response)
+                    .create();
+
+                // Create a temporary cargo binary for testing
+                let temp_dir = tempfile::tempdir().unwrap();
+                let cargo_bin = temp_dir.path().join("cargo");
+                std::fs::write(&cargo_bin, "#!/bin/sh\nexit 0").unwrap();
+                std::fs::set_permissions(&cargo_bin, std::fs::Permissions::from_mode(0o755))
+                    .expect("failed to set permissions");
+
+                let options = UpOptions::default().cache_disabled();
+                let mut environment = UpEnvironment::new();
+                let progress_handler = UpProgressHandler::new(None);
+
+                let result = config.up(&options, &mut environment, &progress_handler, &cargo_bin);
+
+                assert!(result.is_ok(), "result should be ok, got {:?}", result);
+                mock_versions.assert();
+
+                // Verify the installed version
+                if let Some(expected_version) = test.expected_version {
+                    assert_eq!(
+                        config.actual_version.get(),
+                        Some(&expected_version),
+                        "Wrong version installed"
+                    );
+                }
+            });
+        }
+    }
+
+    mod cleanup {
+        use super::*;
+
+        #[test]
+        fn cleanup_removes_unused() {
+            run_with_env(&[], || {
+                let progress_handler = UpProgressHandler::new_void();
+
+                // Create some fake installed crates
+                let base_path = cargo_install_bin_path();
+                std::fs::create_dir_all(&base_path).unwrap();
+
+                // Create test structure
+                std::fs::create_dir_all(base_path.join("serde/1.0.0/bin")).unwrap();
+                std::fs::create_dir_all(base_path.join("tokio/1.0.0/bin")).unwrap();
+                std::fs::create_dir_all(base_path.join("old-crate/0.1.0/bin")).unwrap();
+
+                // Add some crates to cache as "in use"
+                let cache = CargoInstallOperationCache::get();
+                cache.add_installed("serde", "1.0.0").unwrap();
+                cache.add_installed("tokio", "1.0.0").unwrap();
+
+                let result = UpConfigCargoInstalls::cleanup(&progress_handler).unwrap();
+
+                // Verify cleanup message
+                assert!(result.is_some());
+                assert!(result.unwrap().contains("old-crate"));
+
+                // Verify directory structure
+                assert!(base_path.join("serde/1.0.0").exists());
+                assert!(base_path.join("tokio/1.0.0").exists());
+                assert!(!base_path.join("old-crate").exists());
+            });
+        }
+    }
+}

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -1355,9 +1355,22 @@ mod tests {
             );
         }
 
+        #[test]
+        fn with_build() {
+            test_install_crate(
+                TestOptions::default().version("2.0.0+build"),
+                UpConfigCargoInstall {
+                    crate_name: "test-crate".to_string(),
+                    build: true,
+                    ..UpConfigCargoInstall::default()
+                },
+            );
+        }
+
         struct TestOptions {
             expected_version: Option<String>,
             list_versions: bool,
+            versions: CratesApiVersions,
         }
 
         impl Default for TestOptions {
@@ -1365,6 +1378,30 @@ mod tests {
                 TestOptions {
                     expected_version: None,
                     list_versions: true,
+                    versions: CratesApiVersions {
+                        versions: vec![
+                            CratesApiVersion {
+                                num: "1.0.0".to_string(),
+                                yanked: false,
+                            },
+                            CratesApiVersion {
+                                num: "1.2.3".to_string(),
+                                yanked: false,
+                            },
+                            CratesApiVersion {
+                                num: "2.0.0-alpha".to_string(),
+                                yanked: false,
+                            },
+                            CratesApiVersion {
+                                num: "2.0.0+build".to_string(),
+                                yanked: false,
+                            },
+                            CratesApiVersion {
+                                num: "3.0.0".to_string(),
+                                yanked: true,
+                            },
+                        ],
+                    },
                 }
             }
         }
@@ -1392,15 +1429,8 @@ mod tests {
                 };
 
                 // Mock the crates.io API response
-                let versions_response = format!(
-                    r#"{{
-                        "versions": [
-                            {{"num": "2.0.0-alpha", "yanked": false}},
-                            {{"num": "1.2.3", "yanked": false}},
-                            {{"num": "1.0.0", "yanked": false}}
-                        ]
-                    }}"#
-                );
+                let versions_response =
+                    serde_json::to_string(&test.versions).expect("failed to serialize versions");
 
                 let mock_versions = mock_server
                     .mock(

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -1384,7 +1384,7 @@ mod tests {
 
                 let options = UpOptions::default().cache_disabled();
                 let mut environment = UpEnvironment::new();
-                let progress_handler = UpProgressHandler::new(None);
+                let progress_handler = UpProgressHandler::new_void();
 
                 let result = config.up(&options, &mut environment, &progress_handler, &cargo_bin);
 

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -1129,7 +1129,7 @@ impl UpConfigCargoInstall {
         cargo_install_cmd.arg(version);
         cargo_install_cmd.arg("--no-track");
         cargo_install_cmd.arg("--root");
-        cargo_install_cmd.arg(&tmp_dir.path());
+        cargo_install_cmd.arg(tmp_dir.path());
         cargo_install_cmd.arg("--bins");
         cargo_install_cmd.arg("--force");
 
@@ -1137,7 +1137,7 @@ impl UpConfigCargoInstall {
         // installation is done in the temporary directory
         cargo_install_cmd.env("CARGO_HOME", cargo_home);
         cargo_install_cmd.env("RUSTUP_HOME", cargo_home);
-        cargo_install_cmd.env("CARGO_INSTALL_ROOT", &tmp_dir.path());
+        cargo_install_cmd.env("CARGO_INSTALL_ROOT", tmp_dir.path());
 
         cargo_install_cmd.stdout(std::process::Stdio::piped());
         cargo_install_cmd.stderr(std::process::Stdio::piped());

--- a/src/internal/config/up/mod.rs
+++ b/src/internal/config/up/mod.rs
@@ -10,6 +10,9 @@ pub(crate) use tool::UpConfigTool;
 pub(crate) mod bundler;
 pub(crate) use bundler::UpConfigBundler;
 
+pub(crate) mod cargo_install;
+pub(crate) use cargo_install::UpConfigCargoInstalls;
+
 pub(crate) mod custom;
 pub(crate) use custom::UpConfigCustom;
 

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -59,7 +59,7 @@ impl<'a> UpProgressHandler<'a> {
             ..Default::default()
         };
 
-        if let Err(_) = new.handler.set(Box::new(handler)) {
+        if new.handler.set(Box::new(handler)).is_err() {
             panic!("failed to set progress handler");
         }
 

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -20,6 +20,9 @@ use crate::omni_error;
 use crate::omni_info;
 use crate::omni_warning;
 
+#[cfg(test)]
+use crate::internal::config::up::utils::VoidProgressHandler;
+
 pub struct UpProgressHandler<'a> {
     handler: OnceCell<Box<dyn ProgressHandler>>,
     handler_id: Option<String>,
@@ -31,20 +34,46 @@ pub struct UpProgressHandler<'a> {
     desc: OnceCell<String>,
 }
 
-impl<'a> UpProgressHandler<'a> {
-    pub fn new(progress: Option<(usize, usize)>) -> Self {
-        // Generate a random handler ID
-        let handler_id = uuid::Uuid::new_v4().to_string();
-
+impl Default for UpProgressHandler<'_> {
+    fn default() -> Self {
         UpProgressHandler {
             handler: OnceCell::new(),
-            handler_id: Some(handler_id),
-            step: progress,
+            handler_id: None,
+            step: None,
             prefix: "".to_string(),
             parent: None,
             allow_ending: true,
             sync_file: None,
             desc: OnceCell::new(),
+        }
+    }
+}
+
+impl<'a> UpProgressHandler<'a> {
+    #[cfg(test)]
+    pub fn new_void() -> Self {
+        let handler = VoidProgressHandler::new();
+
+        let new = UpProgressHandler {
+            handler: OnceCell::new(),
+            ..Default::default()
+        };
+
+        if let Err(_) = new.handler.set(Box::new(handler)) {
+            panic!("failed to set progress handler");
+        }
+
+        new
+    }
+
+    pub fn new(progress: Option<(usize, usize)>) -> Self {
+        // Generate a random handler ID
+        let handler_id = uuid::Uuid::new_v4().to_string();
+
+        UpProgressHandler {
+            handler_id: Some(handler_id),
+            step: progress,
+            ..Default::default()
         }
     }
 

--- a/src/internal/config/up/utils/void_progress_handler.rs
+++ b/src/internal/config/up/utils/void_progress_handler.rs
@@ -4,6 +4,7 @@ use crate::internal::config::up::utils::ProgressHandler;
 pub struct VoidProgressHandler {}
 
 impl VoidProgressHandler {
+    #[cfg(test)]
     pub fn new() -> Self {
         VoidProgressHandler {}
     }

--- a/src/internal/config/up/utils/void_progress_handler.rs
+++ b/src/internal/config/up/utils/void_progress_handler.rs
@@ -3,6 +3,12 @@ use crate::internal::config::up::utils::ProgressHandler;
 #[derive(Debug, Clone)]
 pub struct VoidProgressHandler {}
 
+impl VoidProgressHandler {
+    pub fn new() -> Self {
+        VoidProgressHandler {}
+    }
+}
+
 impl ProgressHandler for VoidProgressHandler {
     fn println(&self, _message: String) {
         // do nothing

--- a/src/internal/testutils.rs
+++ b/src/internal/testutils.rs
@@ -15,7 +15,7 @@ cfg_if::cfg_if! {
             // Take the lock, we need to manage it ourselves because we want to
             // avoid side-effects of the environment variables being already set
             // for another test, which could impact this test
-            let _lock = RUN_WITH_ENV_LOCK.lock().unwrap();
+            let _lock = RUN_WITH_ENV_LOCK.lock().expect("failed to lock");
 
             // We create a temporary directory which will host all file-system
             // related operations for the test environment

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-cargo-install.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-cargo-install.md
@@ -1,22 +1,22 @@
 ---
-description: Configuration of the `go-install` kind of `up` parameter
+description: Configuration of the `cargo-install` kind of `up` parameter
 ---
 
-# `go-install` operation
+# `cargo-install` operation
 
-Install a tool through `go install`.
+Install a tool through `cargo install`.
 
 This is done in a way that is shareable across work directories managed by omni; i.e. once a tool is installed in a given version, if required from another work directory it will not need to be reinstalled.
 
-This will automatically install a version of [`go`](go) if none is available through omni to run the `go install` command, but won't add it to the dynamic environment.
+This will automatically install a version of [`rust`](rust) if none is available through omni to run the `cargo install` command, but won't add it to the dynamic environment.
 
 ## Parameters
 
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
-| `path` | string | The `<path>` part of `go install <path>[@<version>]` |
+| `crate` | string | The name of the crate to install |
 | `version` | string | The version to install; see [version handling](#version-handling) below for more details. |
-| `exact` | boolean | Whether to match the exact version or not; if set to `true`, `go install <path>@<version>` will be called directly instead of listing the available versions and following the [version handling](#version-handling) rules *(default: `false`)* |
+| `exact` | boolean | Whether to match the exact version or not; if set to `true`, `cargo install <crate>@<version>` will be called directly instead of listing the available versions and following the [version handling](#version-handling) rules *(default: `false`)* |
 | `upgrade` | boolean | whether or not to always upgrade to the most up to date matching release, even if an already-installed version matches the requirements *(default: false)* |
 | `prerelease` | boolean | Whether to download a prerelease version or only match stable releases; this will also apply to versions with prerelease specification, e.g. `1.2.3-alpha`. Ignored when `exact` is set to `true` *(default: `false`)* |
 | `build` | boolean | Whether to download a version with build specification, e.g. `1.2.3+build`. Ignored when `exact` is set to `true` *(default: `false`)* |
@@ -48,52 +48,52 @@ The latest version satisfying the requirements will be installed.
 ```yaml
 up:
   # Will error out since no repository is provided
-  - go-install
+  - cargo-install
 
-  # Will install the latest release of `protoc-gen-go`
-  - go-install: google.golang.org/protobuf/cmd/protoc-gen-go
+  # Will install the latest release of `ripgrep`
+  - cargo-install: ripgrep
 
   # Will also install the latest version
-  - go-install:
-      path: google.golang.org/protobuf/cmd/protoc-gen-go
+  - cargo-install:
+      crate: ripgrep
       version: latest
 
-  # Will install any version starting with 1.27
-  - go-install:
-      path: google.golang.org/protobuf/cmd/protoc-gen-go
-      version: 1.27
+  # Will install any version starting with 14.0
+  - cargo-install:
+      crate: ripgrep
+      version: 14.0
 
-  # Will install any version starting with 1
-  - go-install:
-      path: google.golang.org/protobuf/cmd/protoc-gen-go
-      version: 1
+  # Will install any version starting with 14
+  - cargo-install:
+      crate: ripgrep
+      version: 14
 
   # Full specification of the parameter to identify the version;
-  # this will install any version starting with 1.27.0
-  - go-install:
-      path: google.golang.org/protobuf/cmd/protoc-gen-go
-      version: 1.27.0
+  # this will install any version starting with 14.0.1
+  - cargo-install:
+      crate: ripgrep
+      version: 14.0.1
 
-  # Will install any version starting with 1, including
+  # Will install any version starting with 14, including
   # any pre-release versions
-  - go-install:
-      path: google.golang.org/protobuf/cmd/protoc-gen-go
-      version: 1
+  - cargo-install:
+      path: ripgrep
+      version: 14
       prerelease: true
 
   # Will install all the specified releases
-  - go-install:
-      google.golang.org/protobuf/cmd/protoc-gen-go: 1.27.0
-      google.golang.org/grpc/cmd/protoc-gen-go-grpc:
-        version: 1.5.0
-        prerelease: true
+  - cargo-install:
+      ripgrep: 14.0.1
+      exa:
+        version: 0.9.0
+        build: true
 
   # Will install all the listed releases
-  - go-install:
-      - google.golang.org/protobuf/cmd/protoc-gen-go@1.27.0
-      - google.golang.org/grpc/cmd/protoc-gen-go: 1.27.1
-      - path: google.golang.org/grpc/cmd/protoc-gen-go-grpc
-        version: 1.5.0
+  - cargo-install:
+      - ripgrep@14.0.1
+      - exa: 0.9.0
+      - crate: bat
+        version: 0.15.0
 ```
 
 ## Dynamic environment

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up/010250-self.md
@@ -18,6 +18,7 @@ Each entry in the list can either be a single string (loads the operation with d
 | `apt` | [apt](up/apt) | Install packages with `apt` for ubuntu and debian-based systems |
 | `bash` | [bash](up/bash) | Install bash |
 | `bundler` | [bundler](up/bundler) | Install dependencies with bundler |
+| `cargo-install` | [cargo-install](up/cargo-install) | Install a tool using `cargo install` |
 | `custom` | [custom](up/custom) | A custom, user-defined operation |
 | `dnf` | [dnf](up/dnf) | Install packages with `dnf` for fedora-based systems |
 | `github-release` | [github-release](up/github-release) | Install a tool from a GitHub release |

--- a/website/contents/reference/03-custom-commands/0302-path/030203-argument-parser.md
+++ b/website/contents/reference/03-custom-commands/0302-path/030203-argument-parser.md
@@ -6,7 +6,7 @@ description: The argument parser for custom commands
 
 Omni provides an argument parser for custom commands. This argument parser reads the command metadata to parse the user input, and puts the resulting data into environment variables to be consumed by the command.
 
-To configure the argument parser, set the [`argparser` metadata](metadata#argparser) to `true`, and define the required arguments and optional parameters using the [`arg` and `opt` metadata](metadata#args). The argument parser can be used for path commands and configuration commands.
+To configure the argument parser, set the [`argparser` metadata](metadata#argparser) to `true`, and define the required arguments and optional parameters using the [`arg` and `opt` metadata](metadata#arg-and-opt). The argument parser can be used for path commands and configuration commands.
 
 ## Environment variables
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,7 +27,8 @@ const config = {
   projectName: 'omni', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
This introduces a new `cargo-install` operation for `up`, which installs a tool using `cargo install`. This supports finding available versions through the crates.io API, or using exactly the specified version without lookup. This also takes care of loading a `rust` version to call the `cargo` commands with.

Closes https://github.com/XaF/omni/issues/798