### PR TITLE
chore(@-version): handle @-version as exact matching

### DIFF
--- a/tests/test_omni_up_go_install.bats
+++ b/tests/test_omni_up_go_install.bats
@@ -244,7 +244,7 @@ up:
     - github.com/test/tool1@v2.0.0
     - github.com/test/tool2: v5.0.0
     - github.com/test/tool3:
-        version: v4.0.0
+        version: 4
     - github.com/test/tool4:
 EOF
 
@@ -253,8 +253,6 @@ EOF
   add_brew_golang_calls
   add_asdf_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool1 \
-    <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0"]}'
   add_command go install -v github.com/test/tool1@v2.0.0 <<< "$(go_install_success)"
 
   add_command go list -m -versions -json github.com/test/tool2 \


### PR DESCRIPTION
The new `cargo-install` and `go-install` operations support specifying versions using the `@` symbol, like when using the tool with either `cargo install <crate>[@<version>]` or `go install <path>[@<version>]`, but this was interpreted the same was as a weak version specification.

This changes that by considering that `@`-versions are an exact specification.