### PR TITLE
feat(`help`): ✨ add `--output` flag which can take `plain` or `json`

### DIFF
--- a/src/internal/cache/utils.rs
+++ b/src/internal/cache/utils.rs
@@ -27,3 +27,7 @@ pub fn origin_of_time() -> OffsetDateTime {
 pub fn is_origin_of_time(value: &OffsetDateTime) -> bool {
     *value == origin_of_time()
 }
+
+pub fn is_zero(x: &usize) -> bool {
+    *x == 0
+}

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -45,7 +45,7 @@ impl From<BTreeMap<String, ParseArgsValue>> for HelpCommandArgs {
         };
         let output = match args.get("output") {
             Some(ParseArgsValue::SingleString(Some(value))) => match value.as_str() {
-                "json" => HelpCommandOutput::JSON,
+                "json" => HelpCommandOutput::Json,
                 "plain" => HelpCommandOutput::Plain,
                 _ => unreachable!("unknown value for output"),
             },
@@ -63,7 +63,7 @@ impl From<BTreeMap<String, ParseArgsValue>> for HelpCommandArgs {
 #[derive(Debug, Clone)]
 enum HelpCommandOutput {
     Plain,
-    JSON,
+    Json,
 }
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ impl HelpCommand {
 
         let printer: Box<dyn HelpCommandPrinter> = match args.output {
             HelpCommandOutput::Plain => Box::new(HelpCommandPlainPrinter::new()),
-            HelpCommandOutput::JSON => Box::new(HelpCommandJsonPrinter::new()),
+            HelpCommandOutput::Json => Box::new(HelpCommandJsonPrinter::new()),
         };
 
         let argv = args.command.clone();

--- a/src/internal/config/up/utils/progress_handler.rs
+++ b/src/internal/config/up/utils/progress_handler.rs
@@ -1,6 +1,5 @@
 use std::io::Write;
 
-use regex::Regex;
 use tempfile::NamedTempFile;
 use time::format_description::well_known::Rfc3339;
 use tokio::io::AsyncBufReadExt;
@@ -12,6 +11,7 @@ use tokio::time::Duration;
 
 use crate::internal::config::up::utils::RunConfig;
 use crate::internal::config::up::UpError;
+use crate::internal::user_interface::print::filter_control_characters;
 use crate::internal::user_interface::StringColor;
 use crate::omni_warning;
 
@@ -412,9 +412,4 @@ where
     }
 
     Ok(())
-}
-
-fn filter_control_characters(input: &str) -> String {
-    let control_chars_regex = Regex::new(r"(\x1B\[[0-9;]*[ABCDK]|\x0D)").unwrap();
-    control_chars_regex.replace_all(input, "").to_string()
 }

--- a/src/internal/user_interface/print.rs
+++ b/src/internal/user_interface/print.rs
@@ -185,6 +185,10 @@ pub fn strip_ansi_codes(text: &str) -> String {
     COLOR_PATTERN.replace_all(text, "").to_string()
 }
 
+pub fn filter_control_characters(input: &str) -> String {
+    let control_chars_regex = Regex::new(r"(\x1B\[[0-9;]*[ABCDK]|\x0D)").unwrap();
+    control_chars_regex.replace_all(input, "").to_string()
+}
 pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
     let mut lines = vec![];
     let mut line = String::new();

--- a/tests/fixtures/omni/help-cd-json.txt
+++ b/tests/fixtures/omni/help-cd-json.txt
@@ -1,4 +1,5 @@
 {
+  "name": "cd",
   "usage": "omni cd [OPTIONS] [WORKDIR]",
   "source": "builtin",
   "category": [

--- a/tests/fixtures/omni/help-cd-json.txt
+++ b/tests/fixtures/omni/help-cd-json.txt
@@ -1,0 +1,29 @@
+{
+  "usage": "omni cd [OPTIONS] [WORKDIR]",
+  "source": "builtin",
+  "category": [
+    "Git commands"
+  ],
+  "short_help": "Change directory to the root of the specified work directory",
+  "help": "Change directory to the root of the specified work directory\n\nIf no work directory is specified, change to the git directory of the main org as specified by OMNI_ORG, if specified, or errors out if not specified.",
+  "arguments": [
+    {
+      "name": "[WORKDIR]",
+      "desc": "The name of the work directory to change directory to; this can be in the format <org>/<repo>, or just <repo>, in which case the work directory will be searched for in all the organizations, trying to use OMNI_ORG if it is set, and then trying all the other organizations alphabetically."
+    }
+  ],
+  "options": [
+    {
+      "name": "-l, --locate",
+      "desc": "If provided, will only return the path to the work directory instead of switching directory to it. When this flag is passed, interactions are also disabled, as it is assumed to be used for command line purposes. This will exit with 0 if the work directory is found, 1 otherwise."
+    },
+    {
+      "name": "-p, --include-packages",
+      "desc": "If provided, will include packages when running the command; this defaults to including packages when using --locate, and not including packages otherwise."
+    },
+    {
+      "name": "--no-include-packages",
+      "desc": "If provided, will NOT include packages when running the command; this defaults to including packages when using --locate, and not including packages otherwise."
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-config-bootstrap-json.txt
+++ b/tests/fixtures/omni/help-config-bootstrap-json.txt
@@ -1,0 +1,27 @@
+{
+  "usage": "omni config bootstrap [OPTIONS]",
+  "source": "builtin",
+  "category": [
+    "General"
+  ],
+  "short_help": "Bootstraps the configuration of omni",
+  "help": "Bootstraps the configuration of omni\n\nThis will walk you through setting up the initial configuration to use omni, such as setting up the worktree, format to use when cloning repositories, and setting up initial organizations.\n",
+  "options": [
+    {
+      "name": "--worktree",
+      "desc": "Bootstrap the main worktree location"
+    },
+    {
+      "name": "--repo-path-format",
+      "desc": "Bootstrap the repository path format"
+    },
+    {
+      "name": "--organizations",
+      "desc": "Bootstrap the organizations"
+    },
+    {
+      "name": "--shell",
+      "desc": "Bootstrap the shell integration"
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-config-bootstrap-json.txt
+++ b/tests/fixtures/omni/help-config-bootstrap-json.txt
@@ -1,4 +1,5 @@
 {
+  "name": "config bootstrap",
   "usage": "omni config bootstrap [OPTIONS]",
   "source": "builtin",
   "category": [

--- a/tests/fixtures/omni/help-config-json.txt
+++ b/tests/fixtures/omni/help-config-json.txt
@@ -1,4 +1,5 @@
 {
+  "name": "config",
   "usage": "omni config <SUBCOMMAND> [OPTIONS]...",
   "source": "auto-generated",
   "short_help": "Provides config commands",

--- a/tests/fixtures/omni/help-config-json.txt
+++ b/tests/fixtures/omni/help-config-json.txt
@@ -1,0 +1,46 @@
+{
+  "usage": "omni config <SUBCOMMAND> [OPTIONS]...",
+  "source": "auto-generated",
+  "short_help": "Provides config commands",
+  "help": "Provides config commands",
+  "arguments": [
+    {
+      "name": "<SUBCOMMAND>",
+      "desc": "Subcommand to be called"
+    },
+    {
+      "name": "[OPTIONS]...",
+      "desc": "Options to pass to the subcommand"
+    }
+  ],
+  "subcommands": [
+    {
+      "name": "bootstrap",
+      "category": [
+        "General"
+      ],
+      "desc": "Bootstraps the configuration of omni"
+    },
+    {
+      "name": "path switch",
+      "category": [
+        "General"
+      ],
+      "desc": "Switch the source of a repository in the omnipath"
+    },
+    {
+      "name": "reshim",
+      "category": [
+        "General"
+      ],
+      "desc": "Regenerate the shims for the environments managed by omni"
+    },
+    {
+      "name": "trust, untrust",
+      "category": [
+        "General"
+      ],
+      "desc": "Trust or untrust a work directory."
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-help.txt
+++ b/tests/fixtures/omni/help-help.txt
@@ -9,6 +9,7 @@ Arguments:
   [COMMAND]...   The command to get help for
 
 Options:
-  --unfold       Show all subcommands
+  --unfold               Show all subcommands
+  -o, --output <OUTPUT>  Output format [default: plain] [possible values: json, plain]
 
 Source: builtin

--- a/tests/fixtures/omni/help-json.txt
+++ b/tests/fixtures/omni/help-json.txt
@@ -1,3 +1,4 @@
+{
   "usage": "omni <command> [options] ARG...",
   "subcommands": [
     {

--- a/tests/fixtures/omni/help-json.txt
+++ b/tests/fixtures/omni/help-json.txt
@@ -1,0 +1,69 @@
+  "usage": "omni <command> [options] ARG...",
+  "subcommands": [
+    {
+      "name": "config",
+      "category": [
+        "General"
+      ],
+      "desc": "Provides config commands",
+      "folded": 6
+    },
+    {
+      "name": "help",
+      "category": [
+        "General"
+      ],
+      "desc": "Show help for omni commands"
+    },
+    {
+      "name": "hook",
+      "category": [
+        "General"
+      ],
+      "desc": "Call one of omni's hooks for the shell\n",
+      "folded": 4
+    },
+    {
+      "name": "status",
+      "category": [
+        "General"
+      ],
+      "desc": "Show the status of omni"
+    },
+    {
+      "name": "cd",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Change directory to the root of the specified work directory"
+    },
+    {
+      "name": "clone",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Clone the specified repository"
+    },
+    {
+      "name": "up, down",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Sets up or tear down a repository depending on its up configuration"
+    },
+    {
+      "name": "scope",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Runs an omni command in the context of the specified repository"
+    },
+    {
+      "name": "tidy",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Organize your git repositories using the configured format"
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-unfold-json.txt
+++ b/tests/fixtures/omni/help-unfold-json.txt
@@ -1,3 +1,4 @@
+{
   "usage": "omni <command> [options] ARG...",
   "subcommands": [
     {

--- a/tests/fixtures/omni/help-unfold-json.txt
+++ b/tests/fixtures/omni/help-unfold-json.txt
@@ -1,0 +1,109 @@
+  "usage": "omni <command> [options] ARG...",
+  "subcommands": [
+    {
+      "name": "config bootstrap",
+      "category": [
+        "General"
+      ],
+      "desc": "Bootstraps the configuration of omni"
+    },
+    {
+      "name": "config path switch",
+      "category": [
+        "General"
+      ],
+      "desc": "Switch the source of a repository in the omnipath"
+    },
+    {
+      "name": "config reshim",
+      "category": [
+        "General"
+      ],
+      "desc": "Regenerate the shims for the environments managed by omni"
+    },
+    {
+      "name": "config trust, config untrust",
+      "category": [
+        "General"
+      ],
+      "desc": "Trust or untrust a work directory."
+    },
+    {
+      "name": "help",
+      "category": [
+        "General"
+      ],
+      "desc": "Show help for omni commands"
+    },
+    {
+      "name": "hook",
+      "category": [
+        "General"
+      ],
+      "desc": "Call one of omni's hooks for the shell\n"
+    },
+    {
+      "name": "hook env",
+      "category": [
+        "General"
+      ],
+      "desc": "Hook used to update the dynamic environment"
+    },
+    {
+      "name": "hook init",
+      "category": [
+        "General"
+      ],
+      "desc": "Hook used to initialize the shell"
+    },
+    {
+      "name": "hook uuid",
+      "category": [
+        "General"
+      ],
+      "desc": "Hook to generate a UUID"
+    },
+    {
+      "name": "status",
+      "category": [
+        "General"
+      ],
+      "desc": "Show the status of omni"
+    },
+    {
+      "name": "cd",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Change directory to the root of the specified work directory"
+    },
+    {
+      "name": "clone",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Clone the specified repository"
+    },
+    {
+      "name": "up, down",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Sets up or tear down a repository depending on its up configuration"
+    },
+    {
+      "name": "scope",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Runs an omni command in the context of the specified repository"
+    },
+    {
+      "name": "tidy",
+      "category": [
+        "Git commands"
+      ],
+      "desc": "Organize your git repositories using the configured format"
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-up-json.txt
+++ b/tests/fixtures/omni/help-up-json.txt
@@ -1,0 +1,51 @@
+{
+  "usage": "omni up [OPTIONS]",
+  "source": "builtin",
+  "category": [
+    "Git commands"
+  ],
+  "short_help": "Sets up or tear down a repository depending on its up configuration",
+  "help": "Sets up or tear down a repository depending on its up configuration",
+  "options": [
+    {
+      "name": "--no-cache",
+      "desc": "Whether we should disable the cache while running the command (default: no)"
+    },
+    {
+      "name": "--fail-on-upgrade",
+      "desc": "If provided, will fail the operation if a resource failed to upgrade, even if a currently-existing version can satisfy the dependencies (default: no)"
+    },
+    {
+      "name": "--bootstrap",
+      "desc": "Same as using --update-user-config --clone-suggested; if any of the options are directly provided, they will take precedence over the default values of the options"
+    },
+    {
+      "name": "--clone-suggested [CLONE_SUGGESTED]",
+      "desc": "Whether we should clone suggested repositories found in the configuration of the repository if any (yes/ask/no) [default: no] [default missing value: ask] [possible values: yes, ask, no]"
+    },
+    {
+      "name": "--prompt <PROMPT_ID>",
+      "desc": "Trigger prompts for the given prompt ids, specified as arguments, as well as the currently unanswered prompts"
+    },
+    {
+      "name": "--prompt-all",
+      "desc": "Trigger all prompts for the current work directory, even if they have already been answered"
+    },
+    {
+      "name": "--trust [TRUST]",
+      "desc": "Define how to trust the repository (always/yes/no) to run the command [default missing value: yes] [possible values: always, yes, no]"
+    },
+    {
+      "name": "--update-repository",
+      "desc": "Whether we should update the repository before running the command; if the repository is already up to date, the rest of the process will be skipped"
+    },
+    {
+      "name": "--update-user-config [UPDATE_USER_CONFIG]",
+      "desc": "Whether we should handle suggestions found in the configuration of the repository if any (yes/ask/no); When using up, the suggest_config configuration will be copied to the home directory of the user to be loaded on every omni call [default: no] [default missing value: ask] [possible values: yes, ask, no]"
+    },
+    {
+      "name": "--upgrade",
+      "desc": "Whether we should upgrade the resources when the currently-installed version already matches version constraints. If false, this also means that if an already installed version for another repository matches version contraints, we will avoid downloading and building a more recent version"
+    }
+  ]
+}

--- a/tests/fixtures/omni/help-up-json.txt
+++ b/tests/fixtures/omni/help-up-json.txt
@@ -1,4 +1,5 @@
 {
+  "name": "up",
   "usage": "omni up [OPTIONS]",
   "source": "builtin",
   "category": [

--- a/tests/test_omni_help.bats
+++ b/tests/test_omni_help.bats
@@ -31,12 +31,25 @@ setup() {
   validate_test_output omni/help.txt skip_lines=1 omni help
 }
 
+# bats test_tags=generate,omni:help,omni:help:self,omni:help:json
+@test "omni help shows in JSON the help message with default omni commands" {
+# Avoiding any shorter-than-expected wrapping
+  export COLUMNS=1000
+
+    validate_test_output omni/help-json.txt skip_lines=1 omni help --output json
+}
+
 # bats test_tags=generate,omni:help,omni:help:self
 @test "omni help shows the help message with all omni commands when using --unfold" {
   # Avoiding any shorter-than-expected wrapping
   export COLUMNS=1000
 
   validate_test_output omni/help-unfold.txt skip_lines=1 omni help --unfold
+}
+
+# bats test_tags=generate,omni:help,omni:help:self,omni:help:json
+@test "omni help shows in JSON the help message with all omni commands when using --unfold" {
+  validate_test_output omni/help-unfold-json.txt skip_lines=1 omni help --unfold --output json
 }
 
 # bats test_tags=generate,omni:help
@@ -52,9 +65,19 @@ setup() {
   validate_test_output omni/help-config.txt skip_lines=1 omni help config
 }
 
+# bats test_tags=generate,omni:help,omni:help:json
+@test "omni help config shows in JSON the help message for the command" {
+  validate_test_output omni/help-config-json.txt omni help -o json config
+}
+
 # bats test_tags=generate,omni:help
 @test "omni help config bootstrap shows the help message for the command" {
   validate_test_output omni/help-config-bootstrap.txt skip_lines=1 omni help config bootstrap
+}
+
+# bats test_tags=generate,omni:help,omni:help:json
+@test "omni help config bootstrap shows in JSON the help message for the command" {
+  validate_test_output omni/help-config-bootstrap-json.txt omni help -o json config bootstrap
 }
 
 # bats test_tags=generate,omni:help
@@ -117,6 +140,11 @@ setup() {
   validate_test_output omni/help-cd.txt skip_lines=1 omni help cd
 }
 
+# bats test_tags=generate,omni:help,omni:help:json
+@test "omni help cd shows in JSON the help message for the command" {
+  validate_test_output omni/help-cd-json.txt omni help -o json cd
+}
+
 # bats test_tags=generate,omni:help
 @test "omni help clone shows the help message for the command" {
   validate_test_output omni/help-clone.txt skip_lines=1 omni help clone
@@ -140,6 +168,11 @@ setup() {
 # bats test_tags=generate,omni:help,omni:help:up
 @test "omni help up shows the help message for the command" {
   validate_test_output omni/help-up.txt skip_lines=1 omni help up
+}
+
+# bats test_tags=generate,omni:help,omni:help:up,omni:help:json
+@test "omni help up shows in JSON the help message for the command" {
+  validate_test_output omni/help-up-json.txt omni help -o json up
 }
 
 setup_very_long_config_command() {

--- a/tests/test_omni_help.bats
+++ b/tests/test_omni_help.bats
@@ -33,10 +33,7 @@ setup() {
 
 # bats test_tags=generate,omni:help,omni:help:self,omni:help:json
 @test "omni help shows in JSON the help message with default omni commands" {
-# Avoiding any shorter-than-expected wrapping
-  export COLUMNS=1000
-
-    validate_test_output omni/help-json.txt skip_lines=1 omni help --output json
+  validate_test_output omni/help-json.txt omni help --output json
 }
 
 # bats test_tags=generate,omni:help,omni:help:self
@@ -49,7 +46,7 @@ setup() {
 
 # bats test_tags=generate,omni:help,omni:help:self,omni:help:json
 @test "omni help shows in JSON the help message with all omni commands when using --unfold" {
-  validate_test_output omni/help-unfold-json.txt skip_lines=1 omni help --unfold --output json
+  validate_test_output omni/help-unfold-json.txt omni help --unfold --output json
 }
 
 # bats test_tags=generate,omni:help


### PR DESCRIPTION
This allows to get the help messages in a programmatically parseable way, which can open the door for generating documentation from the help output of omni.

Closes https://github.com/XaF/omni/issues/809