### PR TITLE
feat(`up`): allow to configure `mise` version

### DIFF
--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -11,6 +11,7 @@ pub struct UpCommandConfig {
     pub notify_workdir_config_available: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub preferred_tools: Vec<String>,
+    pub mise_version: String,
     pub upgrade: bool,
 }
 
@@ -21,6 +22,7 @@ impl Default for UpCommandConfig {
             notify_workdir_config_updated: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED,
             notify_workdir_config_available: Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE,
             preferred_tools: Vec::new(),
+            mise_version: Self::DEFAULT_MISE_VERSION.to_string(),
             upgrade: Self::DEFAULT_UPGRADE,
         }
     }
@@ -30,6 +32,7 @@ impl UpCommandConfig {
     const DEFAULT_AUTO_BOOTSTRAP: bool = true;
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED: bool = true;
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE: bool = true;
+    const DEFAULT_MISE_VERSION: &str = "latest";
     const DEFAULT_UPGRADE: bool = false;
 
     pub(super) fn from_config_value(config_value: Option<ConfigValue>) -> Self {
@@ -68,6 +71,9 @@ impl UpCommandConfig {
                 .get_as_bool_forced("notify_workdir_config_available")
                 .unwrap_or(Self::DEFAULT_NOTIFY_WORKDIR_CONFIG_AVAILABLE),
             preferred_tools,
+            mise_version: config_value_global
+                .get_as_str_forced("mise_version")
+                .unwrap_or(Self::DEFAULT_MISE_VERSION.to_string()),
             // The upgrade option is fine to handle as a workdir option too
             upgrade: config_value
                 .get_as_bool_forced("upgrade")

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -525,10 +525,10 @@ impl Default for UpConfigGithubRelease {
 }
 
 impl UpConfigGithubRelease {
-    pub fn new_latest_version(repository: &str) -> Self {
+    pub fn new_with_version(repository: &str, version: &str) -> Self {
         Self {
             repository: repository.to_string(),
-            version: Some("latest".to_string()),
+            version: Some(version.to_string()),
             upgrade: true,
             ..UpConfigGithubRelease::default()
         }

--- a/tests/fixtures/omni/status-config.txt
+++ b/tests/fixtures/omni/status-config.txt
@@ -66,6 +66,7 @@ path_repo_updates:
 repo_path_format: '%{host}/%{org}/%{repo}'
 up_command:
   auto_bootstrap: true
+  mise_version: latest
   notify_workdir_config_available: true
   notify_workdir_config_updated: true
   upgrade: false

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -14,6 +14,7 @@ Configuration related to the `omni up` command.
 | `notify_workdir_config_updated` | boolean | whether or not to print a message on the prompt if the `up` configuration of the work directory has been updated since the last `omni up` *(default: true)* |
 | `notify_workdir_config_available` | boolean | whether or not to print a message on the prompt if the current work directory has an available `up` configuration but `omni up` has not been run yet *(default: true)* |
 | `preferred_tools` | list | list of preferred tools for [`any` operations](up/any) when running `omni up`; those tools will be preferred over others, in the order they are defined |
+| `mise_version` | string | the version of [`mise`](https://mise.jdx.dev/) to use for the installation of tools that depend on it *(default: `latest`)* |
 | `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version of the dependencies when running `omni up`, even if an already-installed version matches the requirements *(default: false)* |
 
 ## Example


### PR DESCRIPTION
By default, `omni` will install and update `mise` regularly to keep using the latest version. This parameter however will allow to pin `mise` to a given version. The version can be defined the same way as any version can be defined when using github releases.