### PR TITLE
build(`cross`): 👷 fix for `actions-rust-cross`'s v1

### DIFF
--- a/.github/workflows/build-and-test-target.yaml
+++ b/.github/workflows/build-and-test-target.yaml
@@ -123,6 +123,17 @@ jobs:
           perl -i -pe 's/^version = "0\.0\.0-git"$/version = "${{ inputs.release_version }}"/' Cargo.toml
           perl -i -pe 's/^version = "0\.0\.0-git"$/version = "${{ inputs.release_version }}"/' Cargo.lock
 
+      - name: Run tests
+        uses: houseabsolute/actions-rust-cross@v1
+        env:
+          RUSTFLAGS: "-C prefer-dynamic=no"
+        with:
+          command: test
+          target: ${{ inputs.target }}
+          toolchain: stable
+          args: "--locked --release"
+          use-rust-cache: false  # We already have a cache step
+
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1
         timeout-minutes: 30
@@ -135,20 +146,13 @@ jobs:
           toolchain: stable
           args: "--locked --release"
           strip: true
-
-      - name: Run tests
-        if: inputs.run_tests
-        uses: houseabsolute/actions-rust-cross@v1
-        with:
-          command: test
-          target: ${{ inputs.target }}
-          toolchain: stable
-          args: "--locked --release"
+          use-rust-cache: false  # We already have a cache step
 
       - name: Package as archive
         shell: bash
         run: |
           cd "target/${{ inputs.target }}/release" && \
+            ls -als && \
             tar czvf ../../../${{ env.BUILD_FILENAME }}.tar.gz omni && \
             cd -
 


### PR DESCRIPTION
This introduces the use of the cache which is wiping the cargo directory and leading to failures in building binaries. This is fixed by disabling the cache for this action on top of reordering operations, since we already are handling the cache ourselves anyway.