### PR TITLE
feat(`up`): ✨ add supply-chain checks

### DIFF
--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -135,8 +135,9 @@ impl UpCommandOperationConfig {
     }
 
     pub fn is_go_install_source_allowed(&self, source: &str) -> bool {
-        check_url_allowed(source, &self.sources)
-            && check_url_allowed(source, &self.go_install.sources)
+        let source = format!("https://{}", source.trim_start_matches("https://"));
+        check_url_allowed(&source, &self.sources)
+            && check_url_allowed(&source, &self.go_install.sources)
     }
 
     pub fn is_cargo_install_crate_allowed(&self, crate_name: &str) -> bool {

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -431,7 +431,6 @@ impl UrlPattern {
     }
 
     fn matches(&self, other_url: &UrlPattern) -> bool {
-        eprintln!("\tpattern: {:?}", self);
         for param in &[
             (self.scheme.as_deref(), other_url.scheme.as_deref()),
             (self.host.as_deref(), other_url.host.as_deref()),
@@ -444,11 +443,9 @@ impl UrlPattern {
         ] {
             let (pattern, component) = param;
             if !Self::_matches_pattern(*component, *pattern) {
-                eprintln!("\t\tfailed on {:?}", param);
                 return false;
             }
         }
-        eprintln!("\t\tmatched");
         true
     }
 

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -13,7 +13,8 @@ pub struct UpCommandConfig {
     pub preferred_tools: Vec<String>,
     pub mise_version: String,
     pub upgrade: bool,
-    pub operations: Vec<UpCommandOperationConfig>,
+    #[serde(default, skip_serializing_if = "UpCommandOperationConfig::is_empty")]
+    pub operations: UpCommandOperationConfig,
 }
 
 impl Default for UpCommandConfig {
@@ -84,6 +85,7 @@ impl UpCommandConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 struct UpCommandOperationConfig {
     pub allowed: Vec<String>,
     pub sources: Vec<String>,
@@ -91,6 +93,20 @@ struct UpCommandOperationConfig {
     // pub cargo_install: UpCommandOperationCargoConfig,
     // pub go_install: UpCommandOperationGoConfig,
     // pub github_release: UpCommandOperationGithubReleaseConfig,
+}
+
+impl UpCommandOperationConfig {
+    fn is_empty(&self) -> bool {
+        self.allowed.is_empty() && self.sources.is_empty()
+    }
+
+    fn is_operation_allowed(&self, operation: &str) -> bool {
+        check_allowed(operation, &self.allowed)
+    }
+
+    fn is_source_allowed(&self, source: &str) -> bool {
+        check_allowed(source, &self.sources)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -365,7 +365,7 @@ impl UrlPattern {
                     Err(err) => Err(err),
                 }
             }
-            Ok(url) => return Ok(url.into()),
+            Ok(url) => Ok(url.into()),
             Err(url::ParseError::RelativeUrlWithoutBase) => {
                 let prefixed_url = format!("https://{}", url_str);
                 match Self::parse(&prefixed_url) {
@@ -467,19 +467,19 @@ impl From<url::Url> for UrlPattern {
                 "" => None,
                 scheme => Some(scheme.to_string()),
             },
-            host: url.host_str().map(|h| h.to_string()).into(),
-            port: url.port().map(|p| p.to_string()).into(),
+            host: url.host_str().map(|h| h.to_string()),
+            port: url.port().map(|p| p.to_string()),
             username: match url.username() {
                 "" => None,
                 username => Some(username.to_string()),
             },
-            password: url.password().map(|p| p.to_string()).into(),
+            password: url.password().map(|p| p.to_string()),
             path: match url.path().strip_prefix('/').unwrap_or(url.path()) {
                 "" => None,
                 path => Some(path.to_string()),
             },
-            query: url.query().map(|q| q.to_string()).into(),
-            fragment: url.fragment().map(|f| f.to_string()).into(),
+            query: url.query().map(|q| q.to_string()),
+            fragment: url.fragment().map(|f| f.to_string()),
         }
     }
 }

--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -13,6 +13,7 @@ pub struct UpCommandConfig {
     pub preferred_tools: Vec<String>,
     pub mise_version: String,
     pub upgrade: bool,
+    pub operations: Vec<UpCommandOperationConfig>,
 }
 
 impl Default for UpCommandConfig {
@@ -78,6 +79,383 @@ impl UpCommandConfig {
             upgrade: config_value
                 .get_as_bool_forced("upgrade")
                 .unwrap_or(Self::DEFAULT_UPGRADE),
+            operations: UpCommandOperationConfig::from_config_value(config_value),
         }
+    }
+}
+
+struct UpCommandOperationConfig {
+    pub allowed: Vec<String>,
+    pub sources: Vec<String>,
+    // pub mise: UpCommandOperationMiseConfig,
+    // pub cargo_install: UpCommandOperationCargoConfig,
+    // pub go_install: UpCommandOperationGoConfig,
+    // pub github_release: UpCommandOperationGithubReleaseConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct UrlPattern {
+    scheme: Option<String>,
+    host: Option<String>,
+    port: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+    path: Option<String>,
+    query: Option<String>,
+    fragment: Option<String>,
+}
+
+impl UrlPattern {
+    fn parse(url_str: &str) -> Result<Self, url::ParseError> {
+        match url::Url::parse(url_str) {
+            Ok(url) if url.host_str().is_none() || url.cannot_be_a_base() => {
+                let prefixed_url = format!("https://{}", url_str);
+                match Self::parse(&prefixed_url) {
+                    Ok(mut url) => {
+                        url.scheme = None;
+                        Ok(url)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            Ok(url) => return Ok(url.into()),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                let prefixed_url = format!("https://{}", url_str);
+                match Self::parse(&prefixed_url) {
+                    Ok(mut url) => {
+                        url.scheme = None;
+                        Ok(url)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            Err(url::ParseError::InvalidPort) => {
+                let (cleared_url, port) = Self::_remove_url_port(url_str);
+                let port = match port {
+                    Some(port) => port,
+                    None => return Err(url::ParseError::InvalidPort),
+                };
+
+                match Self::parse(&cleared_url) {
+                    Ok(mut url) => {
+                        url.port = Some(port);
+                        Ok(url)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// This identifies if there is a port specified in the URL and
+    /// removes it if it's the case, this supports any port even if
+    /// it would be considered as an invalid port, which allows to
+    /// handle glob patterns
+    fn _remove_url_port(url: &str) -> (String, Option<String>) {
+        // (A) Find scheme end
+        let after_scheme = url.find("://").map(|pos| pos + 3).unwrap_or(0);
+
+        // (B) Find path start
+        let path_start = url[after_scheme..]
+            .find('/')
+            .map(|pos| pos + after_scheme)
+            .unwrap_or(url.len());
+
+        // (C) Find auth end
+        let auth_end = url[after_scheme..path_start]
+            .find('@')
+            .map(|pos| pos + after_scheme)
+            .unwrap_or(0);
+
+        // (D) Find last colon before path
+        if let Some(colon_pos) = url[auth_end..path_start].rfind(':') {
+            let port_start = auth_end + colon_pos;
+            let port_end = path_start;
+
+            let port = url[port_start + 1..port_end].to_string();
+            if !port.is_empty() {
+                let url = url[..port_start].to_string() + &url[port_end..];
+                return (url, Some(port));
+            }
+        }
+
+        (url.to_string(), None)
+    }
+
+    fn matches(&self, other_url: &UrlPattern) -> bool {
+        eprintln!("\tpattern: {:?}", self);
+        for param in &[
+            (self.scheme.as_deref(), other_url.scheme.as_deref()),
+            (self.host.as_deref(), other_url.host.as_deref()),
+            (self.port.as_deref(), other_url.port.as_deref()),
+            (self.username.as_deref(), other_url.username.as_deref()),
+            (self.password.as_deref(), other_url.password.as_deref()),
+            (self.path.as_deref(), other_url.path.as_deref()),
+            (self.query.as_deref(), other_url.query.as_deref()),
+            (self.fragment.as_deref(), other_url.fragment.as_deref()),
+        ] {
+            let (pattern, component) = param;
+            if !Self::_matches_pattern(*component, *pattern) {
+                eprintln!("\t\tfailed on {:?}", param);
+                return false;
+            }
+        }
+        eprintln!("\t\tmatched");
+        true
+    }
+
+    fn _matches_pattern(component: Option<&str>, pattern: Option<&str>) -> bool {
+        match (component, pattern) {
+            (_, None) => true,
+            (c, Some(p)) => glob::Pattern::new(p).map_or(false, |pat| pat.matches(c.unwrap_or(""))),
+        }
+    }
+}
+
+impl From<url::Url> for UrlPattern {
+    fn from(url: url::Url) -> Self {
+        Self {
+            scheme: match url.scheme() {
+                "" => None,
+                scheme => Some(scheme.to_string()),
+            },
+            host: url.host_str().map(|h| h.to_string()).into(),
+            port: url.port().map(|p| p.to_string()).into(),
+            username: match url.username() {
+                "" => None,
+                username => Some(username.to_string()),
+            },
+            password: url.password().map(|p| p.to_string()).into(),
+            path: match url.path().strip_prefix('/').unwrap_or(url.path()) {
+                "" => None,
+                path => Some(path.to_string()),
+            },
+            query: url.query().map(|q| q.to_string()).into(),
+            fragment: url.fragment().map(|f| f.to_string()).into(),
+        }
+    }
+}
+
+fn check_url_allowed(url_str: &str, patterns: &[String]) -> bool {
+    let url = match UrlPattern::parse(url_str) {
+        Ok(url) => url,
+        Err(_) => return false, // Invalid URL
+    };
+
+    for pattern in patterns {
+        let is_deny = pattern.starts_with('!');
+        let pattern_str = if is_deny { &pattern[1..] } else { pattern };
+
+        let pattern_url = match UrlPattern::parse(pattern_str) {
+            Ok(url) => url,
+            Err(_err) => continue, // Skip invalid patterns
+        };
+
+        let matches = pattern_url.matches(&url);
+        if matches {
+            return !is_deny; // Early return on match
+        }
+    }
+
+    // Get the last pattern's deny status (if any) for the default case
+    let default = patterns.last().map_or(true, |p| p.starts_with('!'));
+    default
+}
+
+fn check_allowed(value: &str, patterns: &[String]) -> bool {
+    for pattern in patterns {
+        let is_deny = pattern.starts_with('!');
+        let pattern_str = if is_deny { &pattern[1..] } else { pattern };
+
+        let matches = glob::Pattern::new(pattern_str).map_or(false, |pat| pat.matches(value));
+        if matches {
+            return !is_deny; // Early return on match
+        }
+    }
+
+    // Get the last pattern's deny status (if any) for the default case
+    let default = patterns.last().map_or(true, |p| p.starts_with('!'));
+    default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_matching() {
+        let patterns = vec![
+            "!example1.com/org/forbidden".to_string(),
+            "example1.com/org/*".to_string(),
+        ];
+
+        // Should match with or without protocol
+        assert!(check_url_allowed("example1.com/org/allowed", &patterns));
+        assert!(check_url_allowed(
+            "https://example1.com/org/allowed",
+            &patterns
+        ));
+        assert!(check_url_allowed(
+            "http://example1.com/org/allowed",
+            &patterns
+        ));
+
+        // No protocol in URL should match any of the two
+        assert!(!check_url_allowed("example1.com/org/forbidden", &patterns));
+        assert!(!check_url_allowed(
+            "http://example1.com/org/forbidden",
+            &patterns
+        ));
+
+        // Should not match because different address than allowed
+        assert!(!check_url_allowed("example2.com/org/repo", &patterns));
+    }
+
+    #[test]
+    fn test_protocol_matching() {
+        let patterns = vec![
+            "https://example1.com/*".to_string(),
+            "!http://example1.com/*".to_string(),
+        ];
+
+        assert!(check_url_allowed(
+            "https://example1.com/org/repo",
+            &patterns
+        ));
+        assert!(!check_url_allowed(
+            "http://example1.com/org/repo",
+            &patterns
+        ));
+
+        // No protocol in URL should not match any of the two, hence
+        // match since ending with a deny pattern
+        assert!(check_url_allowed("example1.com/org/repo", &patterns));
+    }
+
+    #[test]
+    fn test_port_matching() {
+        let patterns = vec![
+            "!example1.com:8123/*".to_string(),
+            "example1.com:8*/*".to_string(),
+            "example2.com:*/*".to_string(),
+        ];
+
+        assert!(check_url_allowed("example1.com:8080/repo", &patterns));
+        assert!(check_url_allowed("example1.com:80/repo", &patterns));
+        assert!(check_url_allowed("example2.com:1234/repo", &patterns));
+        assert!(check_url_allowed("example2.com/repo", &patterns));
+        assert!(!check_url_allowed("example1.com:8123/repo", &patterns));
+        assert!(!check_url_allowed("example1.com:9090/repo", &patterns));
+    }
+
+    #[test]
+    fn test_auth_matching() {
+        let patterns = vec![
+            "user@example1.com/*".to_string(),
+            "user:pass@example2.com/*".to_string(),
+            "!baduser@example1.com/*".to_string(),
+            "!*:*@example2.com/*".to_string(),
+            "*".to_string(),
+        ];
+
+        assert!(check_url_allowed("user@example1.com/repo", &patterns));
+        assert!(check_url_allowed("user:pass@example2.com/repo", &patterns));
+        assert!(!check_url_allowed(
+            "user:otherpass@example2.com/repo",
+            &patterns
+        ));
+        assert!(check_url_allowed("example1.com/repo", &patterns)); // No auth specified
+        assert!(!check_url_allowed("baduser@example1.com/repo", &patterns));
+    }
+
+    #[test]
+    fn test_path_matching() {
+        let patterns = vec![
+            "example1.com/org/*/src".to_string(),
+            "example1.com/org/repo/**/test".to_string(),
+            "!example1.com/org/*/docs".to_string(),
+        ];
+
+        assert!(check_url_allowed("example1.com/org/repo/src", &patterns));
+        assert!(check_url_allowed(
+            "example1.com/org/repo/deep/test",
+            &patterns
+        ));
+        assert!(!check_url_allowed("example1.com/org/repo/docs", &patterns));
+    }
+
+    #[test]
+    fn test_query_matching() {
+        let patterns = vec![
+            "example1.com/*?branch=main".to_string(),
+            "example2.com/*?branch=*".to_string(),
+            "!example1.com/*?branch=dev".to_string(),
+        ];
+
+        assert!(check_url_allowed(
+            "example1.com/repo?branch=main",
+            &patterns
+        ));
+        assert!(check_url_allowed(
+            "example2.com/repo?branch=anything",
+            &patterns
+        ));
+        assert!(check_url_allowed("example2.com/repo", &patterns)); // No query specified
+        assert!(!check_url_allowed(
+            "example1.com/repo?branch=dev",
+            &patterns
+        ));
+    }
+
+    #[test]
+    fn test_fragment_matching() {
+        let patterns = vec![
+            "example1.com/*#readme".to_string(),
+            "example2.com/*#*".to_string(),
+            "!*.com/*#private".to_string(),
+        ];
+
+        assert!(check_url_allowed("example1.com/repo#readme", &patterns));
+        assert!(check_url_allowed("example2.com/repo#anything", &patterns));
+        assert!(check_url_allowed("example2.com/repo", &patterns)); // No fragment specified
+        assert!(check_url_allowed("example2.com/repo#private", &patterns));
+        assert!(!check_url_allowed("example1.com/repo#private", &patterns));
+    }
+
+    #[test]
+    fn test_default_behavior() {
+        // Empty pattern list
+        assert!(check_url_allowed("example1.com/repo", &[]));
+
+        // Last pattern determines default
+        let allow_patterns = vec![
+            "example1.com/allowed/*".to_string(),
+            "example2.com/*".to_string(),
+        ];
+        assert!(!check_url_allowed("example3.org/repo", &allow_patterns));
+
+        let deny_patterns = vec![
+            "example1.com/allowed/*".to_string(),
+            "!example2.com/*".to_string(),
+        ];
+        assert!(check_url_allowed("example3.org/repo", &deny_patterns));
+    }
+
+    #[test]
+    fn test_invalid_urls() {
+        let patterns = vec!["example1.com/*".to_string()];
+
+        assert!(!check_url_allowed("not a url", &patterns));
+        assert!(!check_url_allowed("http://", &patterns));
+        assert!(!check_url_allowed("://invalid", &patterns));
+    }
+
+    #[test]
+    fn test_invalid_patterns() {
+        let patterns = vec!["not a url".to_string(), "example1.com/*".to_string()];
+
+        // Should ignore invalid pattern and match against valid one
+        assert!(check_url_allowed("example1.com/repo", &patterns));
     }
 }

--- a/src/internal/config/up/bundler.rs
+++ b/src/internal/config/up/bundler.rs
@@ -6,6 +6,7 @@ use tokio::process::Command as TokioCommand;
 
 use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::commands::utils::abs_path;
+use crate::internal::config::global_config;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::ProgressHandler;
 use crate::internal::config::up::utils::RunConfig;
@@ -50,6 +51,17 @@ impl UpConfigBundler {
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.init("bundler".light_blue());
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("bundler")
+        {
+            let errmsg = "bundler operation is not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
+
         progress_handler.progress("install Gemfile dependencies".to_string());
 
         if let Some(path) = &self.path {

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -151,6 +151,16 @@ impl UpConfigCargoInstalls {
             }
         }
 
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("cargo-install")
+        {
+            let errmsg = "cargo-install operation not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
+
         let cargo_bin = self.get_cargo_bin(options, progress_handler)?;
 
         let num = self.crates.len();
@@ -704,6 +714,16 @@ impl UpConfigCargoInstall {
         if self.crate_name.is_empty() {
             progress_handler.error_with_message("crate_name is required".to_string());
             return Err(UpError::Config("crate_name is required".to_string()));
+        }
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_cargo_install_crate_allowed(&self.crate_name)
+        {
+            let errmsg = format!("crate {} not allowed", self.crate_name);
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
         }
 
         let installed = self.resolve_and_install_version(cargo_bin, options, progress_handler)?;

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -156,7 +156,7 @@ impl UpConfigCargoInstalls {
             .operations
             .is_operation_allowed("cargo-install")
         {
-            let errmsg = "cargo-install operation not allowed".to_string();
+            let errmsg = "cargo-install operation is not allowed".to_string();
             progress_handler.error_with_message(errmsg.clone());
             return Err(UpError::Config(errmsg));
         }

--- a/src/internal/config/up/custom.rs
+++ b/src/internal/config/up/custom.rs
@@ -7,6 +7,7 @@ use tokio::process::Command as TokioCommand;
 
 use crate::internal::cache::up_environments::UpEnvVar;
 use crate::internal::cache::up_environments::UpEnvironment;
+use crate::internal::config::global_config;
 use crate::internal::config::parser::EnvOperationEnum;
 use crate::internal::config::up::utils::data_path_dir_hash;
 use crate::internal::config::up::utils::run_progress;
@@ -97,6 +98,16 @@ impl UpConfigCustom {
         };
 
         progress_handler.init(format!("{}:", name).light_blue());
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("custom")
+        {
+            let errmsg = "custom operation is not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
 
         if self.met().unwrap_or(false) {
             progress_handler.success_with_message("skipping (already met)".light_black());

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -173,7 +173,7 @@ impl UpConfigGithubReleases {
             .operations
             .is_operation_allowed("github-release")
         {
-            let errmsg = "github-release operation not allowed".to_string();
+            let errmsg = "github-release operation is not allowed".to_string();
             progress_handler.error_with_message(errmsg.clone());
             return Err(UpError::Config(errmsg));
         }

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -168,6 +168,16 @@ impl UpConfigGithubReleases {
             return Err(UpError::Config("at least one release required".to_string()));
         }
 
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("github-release")
+        {
+            let errmsg = "github-release operation not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
+
         progress_handler.progress("install dependencies".to_string());
 
         let num = self.releases.len();
@@ -723,6 +733,16 @@ impl UpConfigGithubRelease {
         if self.repository.is_empty() {
             progress_handler.error_with_message("repository is required".to_string());
             return Err(UpError::Config("repository is required".to_string()));
+        }
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_github_repository_allowed(&self.repository)
+        {
+            let errmsg = format!("repository {} not allowed", self.repository);
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
         }
 
         let installed = self.resolve_and_download_release(options, progress_handler)?;

--- a/src/internal/config/up/go_install.rs
+++ b/src/internal/config/up/go_install.rs
@@ -157,6 +157,16 @@ impl UpConfigGoInstalls {
             }
         }
 
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("go-install")
+        {
+            let errmsg = "go-install operation not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
+
         let go_bin = self.get_go_bin(options, progress_handler)?;
 
         let num = self.tools.len();
@@ -705,6 +715,16 @@ impl UpConfigGoInstall {
         if self.path.is_empty() {
             progress_handler.error_with_message("path is required".to_string());
             return Err(UpError::Config("path is required".to_string()));
+        }
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_go_install_source_allowed(&self.path)
+        {
+            let errmsg = format!("go-install source not allowed: {}", self.path);
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
         }
 
         let installed = self.resolve_and_install_version(go_bin, options, progress_handler)?;

--- a/src/internal/config/up/go_install.rs
+++ b/src/internal/config/up/go_install.rs
@@ -162,7 +162,7 @@ impl UpConfigGoInstalls {
             .operations
             .is_operation_allowed("go-install")
         {
-            let errmsg = "go-install operation not allowed".to_string();
+            let errmsg = "go-install operation is not allowed".to_string();
             progress_handler.error_with_message(errmsg.clone());
             return Err(UpError::Config(errmsg));
         }
@@ -726,6 +726,8 @@ impl UpConfigGoInstall {
             progress_handler.error_with_message(errmsg.clone());
             return Err(UpError::Config(errmsg));
         }
+
+        eprintln!("HELLOOOOOOOOOOOOOOOOOOOOOOOOOOO");
 
         let installed = self.resolve_and_install_version(go_bin, options, progress_handler)?;
 

--- a/src/internal/config/up/homebrew.rs
+++ b/src/internal/config/up/homebrew.rs
@@ -15,6 +15,7 @@ use crate::internal::cache::utils as cache_utils;
 use crate::internal::cache::CacheManagerError;
 use crate::internal::cache::HomebrewOperationCache;
 use crate::internal::config;
+use crate::internal::config::global_config;
 use crate::internal::config::up::utils::get_command_output;
 use crate::internal::config::up::utils::run_progress;
 use crate::internal::config::up::utils::ProgressHandler;
@@ -54,6 +55,17 @@ impl UpConfigHomebrew {
         progress_handler: &UpProgressHandler,
     ) -> Result<(), UpError> {
         progress_handler.init("homebrew:".light_blue());
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("homebrew")
+        {
+            let errmsg = "homebrew operation is not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
+
         progress_handler.progress("installing homebrew dependencies".to_string());
 
         let num_taps = self.tap.len();

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -1194,6 +1194,20 @@ impl UpConfigMise {
             }
         }
 
+        let override_tool_url = match &override_tool_url {
+            Some(url) => Some(url.to_string()),
+            None => match global_config()
+                .up_command
+                .operations
+                .mise
+                .default_plugin_sources
+                .get(&tool)
+            {
+                Some(url) => Some(url.to_string()),
+                None => None,
+            },
+        };
+
         let tool_url = match &override_tool_url {
             Some(url) => Some(url.to_string()),
             None => params.tool_url.clone(),

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -1246,7 +1246,7 @@ impl UpConfigMise {
             )
             .map_err(|err| {
                 UpError::Exec(format!(
-                    "failed to resolve tool '{}': {:?}",
+                    "failed to resolve tool '{}': {}",
                     self.requested_tool, err,
                 ))
             })
@@ -1361,7 +1361,10 @@ impl UpConfigMise {
             .operations
             .is_operation_allowed("mise")
         {
-            return Err(UpError::Exec("mise operations are not allowed".to_string()));
+            return Err(UpError::Exec(format!(
+                "mise operations ({}) are not allowed",
+                self.requested_tool,
+            )));
         }
 
         let result = self.run_up(options, environment, progress_handler);

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -788,7 +788,7 @@ impl MiseRegistry {
             (backend.is_none() || backend.unwrap() == entry.backend)
                 && config.is_mise_backend_allowed(&entry.backend)
                 && match entry.repository {
-                    Some(ref repo) => config.is_mise_source_allowed(&repo),
+                    Some(ref repo) => config.is_mise_source_allowed(repo),
                     None => true,
                 }
                 && (name == entry.short_name

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -800,7 +800,6 @@ struct MiseRegistryEntry {
     full_name: String,
     clean_name: String,
     backend: String,
-    #[allow(dead_code)]
     repository: Option<String>,
 }
 
@@ -922,7 +921,6 @@ impl FullyQualifiedToolName {
         &self.plugin_name
     }
 
-    #[allow(dead_code)]
     pub fn backend(&self) -> Option<String> {
         self.backend.clone()
     }

--- a/src/internal/config/up/nix.rs
+++ b/src/internal/config/up/nix.rs
@@ -11,6 +11,7 @@ use tokio::process::Command as TokioCommand;
 
 use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::commands::utils::abs_path;
+use crate::internal::config::global_config;
 use crate::internal::config::parser::EnvOperationEnum;
 use crate::internal::config::up::utils::get_command_output;
 use crate::internal::config::up::utils::run_progress;
@@ -159,6 +160,16 @@ impl UpConfigNix {
 
         // Prepare the progress handler
         progress_handler.init(format!("nix ({}):", nix_handler.nix_source.name()).light_blue());
+
+        if !global_config()
+            .up_command
+            .operations
+            .is_operation_allowed("nix")
+        {
+            let errmsg = "nix operation is not allowed".to_string();
+            progress_handler.error_with_message(errmsg.clone());
+            return Err(UpError::Config(errmsg));
+        }
 
         // If the profile already exists, we don't need to do anything
         if options.read_cache && nix_handler.exists()? {

--- a/tests/test_omni_up_custom.bats
+++ b/tests/test_omni_up_custom.bats
@@ -660,3 +660,30 @@ EOF
   [ "$MULTI_REPEAT_ENV_VAR" = "val1:val2" ]
 }
 
+# bats test_tags=omni:up,omni:up:custom,supply-chain
+@test "[omni_up_custom=23] omni up custom operation fails when custom is disabled through the supply chain" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    allowed:
+      - '!custom'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - custom:
+      name: "Custom Operation"
+      meet: "customcmd run"
+EOF
+
+  add_fakebin "${HOME}/bin/customcmd"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"custom operation is not allowed"* ]]
+}
+

--- a/tests/test_omni_up_go_install.bats
+++ b/tests/test_omni_up_go_install.bats
@@ -10,10 +10,10 @@ setup() {
   setup_omni_config 3>&-
 
   # Add one repository
-  setup_git_dir "git/github.com/test1org/test1repo" "git@github.com:test1org/test1repo.git"
+  setup_git_dir "git/example.com/test1org/test1repo" "git@example.com:test1org/test1repo.git"
 
   # Change directory to the repository
-  cd "git/github.com/test1org/test1repo"
+  cd "git/example.com/test1org/test1repo"
 }
 
 teardown() {
@@ -46,7 +46,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - github.com/test/tool
+    - example.com/test/tool
 EOF
 
   go_version=$(mise_tool_latest_version go)
@@ -54,9 +54,9 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool \
+  add_command go list -m -versions -json example.com/test/tool \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0"]}'
-  add_command go install -v github.com/test/tool@v2.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v2.0.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -69,7 +69,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - github.com/my/super/test/tool
+    - example.com/my/super/test/tool
 EOF
 
   go_version=$(mise_tool_latest_version go)
@@ -77,12 +77,12 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/my/super/test/tool exit=1
-  add_command go list -m -versions -json github.com/my/super/test exit=1
-  add_command go list -m -versions -json github.com/my/super <<< '{"Version":"v0.0.0"}'
-  add_command go list -m -versions -json github.com/my \
+  add_command go list -m -versions -json example.com/my/super/test/tool exit=1
+  add_command go list -m -versions -json example.com/my/super/test exit=1
+  add_command go list -m -versions -json example.com/my/super <<< '{"Version":"v0.0.0"}'
+  add_command go list -m -versions -json example.com/my \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0"]}'
-  add_command go install -v github.com/my/super/test/tool@v2.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/my/super/test/tool@v2.0.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -95,7 +95,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - path: github.com/test/tool
+    - path: example.com/test/tool
       version: v1.1.0
 EOF
 
@@ -104,9 +104,9 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool \
+  add_command go list -m -versions -json example.com/test/tool \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0"]}'
-  add_command go install -v github.com/test/tool@v1.1.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v1.1.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -119,7 +119,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - path: github.com/test/tool
+    - path: example.com/test/tool
       prerelease: true
 EOF
 
@@ -128,9 +128,9 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool \
+  add_command go list -m -versions -json example.com/test/tool \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0-beta"]}'
-  add_command go install -v github.com/test/tool@v2.0.0-beta <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v2.0.0-beta <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -143,7 +143,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - path: github.com/test/tool
+    - path: example.com/test/tool
       build: true
 EOF
 
@@ -152,9 +152,9 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool \
+  add_command go list -m -versions -json example.com/test/tool \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0+build"]}'
-  add_command go install -v github.com/test/tool@v2.0.0+build <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v2.0.0+build <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -167,7 +167,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - path: github.com/test/tool
+    - path: example.com/test/tool
       version: v1.0.0
       exact: true
 EOF
@@ -177,7 +177,7 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go install -v github.com/test/tool@v1.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v1.0.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -190,7 +190,7 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - path: github.com/test/tool
+    - path: example.com/test/tool
       version: v0.0.0-20210101000000-abcdef123456
       exact: true
 EOF
@@ -200,7 +200,7 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go install -v github.com/test/tool@v0.0.0-20210101000000-abcdef123456 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool@v0.0.0-20210101000000-abcdef123456 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -213,8 +213,8 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - github.com/test/tool1
-    - github.com/test/tool2
+    - example.com/test/tool1
+    - example.com/test/tool2
 EOF
 
   go_version=$(mise_tool_latest_version go)
@@ -222,13 +222,13 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go list -m -versions -json github.com/test/tool1 \
+  add_command go list -m -versions -json example.com/test/tool1 \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v1.1.0","v2.0.0"]}'
-  add_command go install -v github.com/test/tool1@v2.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool1@v2.0.0 <<< "$(go_install_success)"
 
-  add_command go list -m -versions -json github.com/test/tool2 \
+  add_command go list -m -versions -json example.com/test/tool2 \
     <<< '{"Version":"v0.0.0","Versions":["v3.0.0","v4.4.0","v5.0.0"]}'
-  add_command go install -v github.com/test/tool2@v5.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool2@v5.0.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -241,11 +241,11 @@ EOF
   cat > .omni.yaml <<EOF
 up:
   - go-install:
-    - github.com/test/tool1@v2.0.0
-    - github.com/test/tool2: v5.0.0
-    - github.com/test/tool3:
+    - example.com/test/tool1@v2.0.0
+    - example.com/test/tool2: v5.0.0
+    - example.com/test/tool3:
         version: 4
-    - github.com/test/tool4:
+    - example.com/test/tool4:
 EOF
 
   go_version=$(mise_tool_latest_version go)
@@ -253,19 +253,19 @@ EOF
   add_brew_golang_calls
   add_mise_golang_calls version="$go_version"
 
-  add_command go install -v github.com/test/tool1@v2.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool1@v2.0.0 <<< "$(go_install_success)"
 
-  add_command go list -m -versions -json github.com/test/tool2 \
+  add_command go list -m -versions -json example.com/test/tool2 \
     <<< '{"Version":"v0.0.0","Versions":["v3.0.0","v4.4.0","v5.0.0"]}'
-  add_command go install -v github.com/test/tool2@v5.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool2@v5.0.0 <<< "$(go_install_success)"
 
-  add_command go list -m -versions -json github.com/test/tool3 \
+  add_command go list -m -versions -json example.com/test/tool3 \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v4.0.0","v7.0.0"]}'
-  add_command go install -v github.com/test/tool3@v4.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool3@v4.0.0 <<< "$(go_install_success)"
 
-  add_command go list -m -versions -json github.com/test/tool4 \
+  add_command go list -m -versions -json example.com/test/tool4 \
     <<< '{"Version":"v0.0.0","Versions":["v1.0.0","v7.0.0","v42.0.0"]}'
-  add_command go install -v github.com/test/tool4@v42.0.0 <<< "$(go_install_success)"
+  add_command go install -v example.com/test/tool4@v42.0.0 <<< "$(go_install_success)"
 
   run omni up --trust 3>&-
   echo "STATUS: $status"
@@ -304,3 +304,140 @@ EOF
   echo "OUTPUT: $output"
   [ "$status" -eq 1 ]
 }
+
+# bats test_tags=omni:up,omni:up:go-install,supply-chain
+@test "[omni_up_go_install=12] omni up go-install operation fails when go-install is disabled through the supply chain" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    allowed:
+      - '!go-install'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - go-install:
+    - example.com/test/tool
+EOF
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"go-install operation is not allowed"* ]]
+}
+
+# bats test_tags=omni:up,omni:up:go-install,supply-chain
+@test "[omni_up_go_install=13] omni up go-install operation fails when go-install is not allow-listed but others are through the supply chain" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    allowed:
+      - 'blah'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - go-install:
+    - example.com/test/tool
+EOF
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"go-install operation is not allowed"* ]]
+}
+
+# bats test_tags=omni:up,omni:up:go-install,supply-chain
+@test "[omni_up_go_install=14] omni up go-install operation fails when a specific url is disabled through the supply chain (global)" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    sources:
+      - '!https://example.com/test/tool'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - go-install:
+    - example.com/test/tool
+EOF
+
+  go_version=$(mise_tool_latest_version go)
+  add_fakebin "$(mise_tool_path go "$go_version")/bin/go"
+  add_brew_golang_calls
+  add_mise_golang_calls version="$go_version"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"go-install source not allowed: example.com/test/tool"* ]]
+}
+
+# bats test_tags=omni:up,omni:up:go-install,supply-chain
+@test "[omni_up_go_install=15] omni up go-install operation fails when a specific url is disabled through the supply chain (global, wildcard)" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    sources:
+      - '!https://example.com/test/*'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - go-install:
+    - example.com/test/tool
+EOF
+
+  go_version=$(mise_tool_latest_version go)
+  add_fakebin "$(mise_tool_path go "$go_version")/bin/go"
+  add_brew_golang_calls
+  add_mise_golang_calls version="$go_version"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"go-install source not allowed: example.com/test/tool"* ]]
+}
+
+# bats test_tags=omni:up,omni:up:go-install,supply-chain
+@test "[omni_up_go_install=16] omni up go-install operation fails when a specific url is disabled through the supply chain (mise)" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    go-install:
+      sources:
+        - '!https://example.com/test/tool'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - go-install:
+    - example.com/test/tool
+EOF
+
+  go_version=$(mise_tool_latest_version go)
+  add_fakebin "$(mise_tool_path go "$go_version")/bin/go"
+  add_brew_golang_calls
+  add_mise_golang_calls version="$go_version"
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 1 ]
+
+  # Check that the right error was emitted
+  [[ "${output}" == *"go-install source not allowed: example.com/test/tool"* ]]
+}
+

--- a/tests/test_omni_up_python.bats
+++ b/tests/test_omni_up_python.bats
@@ -749,3 +749,23 @@ EOF
   [[ "${output}" == *"installing python 3.12.0"* ]]
   [[ "${output}" == *"python 3.11.7, 3.11.9, 3.12.0 installed"* ]]
 }
+
+# bats test_tags=omni:up,omni:up:python,supply-chain
+@test "[omni_up_python=34] omni up python operation fails when mise is disabled through the supply chain" {
+  cat >> ~/.config/omni/config.yaml <<EOF
+up_command:
+  operations:
+    allowed:
+      - '!mise'
+EOF
+
+  cat > .omni.yaml <<EOF
+up:
+  - python
+EOF
+
+  run omni up --trust 3>&-
+  echo "STATUS: $status"
+  echo "OUTPUT: $output"
+  [ "$status" -eq 0 ]
+}

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -29,12 +29,14 @@ Configuration related to the `omni up` command.
 | `go-install` | `GoInstall` object | configuration of the `go-install` operations |
 | `github-release` | `GithubRelease` object | configuration of the `github-release` operations |
 
-::: tip
+:::info
+
 When using the allow/deny lists, the last entry will indicate the default behavior for all values that are not matched by any of the previous entries.
 
 For example, if the list is `['!a*', 'b*']`, all values starting with `a` will be denied, all values starting with `b` will be allowed, and all other values will be denied (opposite of the last entry, which is an allow).
 
 In contrast, if the list is `['b*', '!a*']`, all values starting with `b` will be allowed, and all values starting with `a` will be denied, then all other values will be allowed (opposite of the last entry, which is a deny).
+
 :::
 
 #### `Mise` object

--- a/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
+++ b/website/contents/reference/01-configuration/0102-parameters/010250-up_command.md
@@ -16,16 +16,120 @@ Configuration related to the `omni up` command.
 | `preferred_tools` | list | list of preferred tools for [`any` operations](up/any) when running `omni up`; those tools will be preferred over others, in the order they are defined |
 | `mise_version` | string | the version of [`mise`](https://mise.jdx.dev/) to use for the installation of tools that depend on it *(default: `latest`)* |
 | `upgrade` | boolean | whether or not to always upgrade to the most up to date matching version of the dependencies when running `omni up`, even if an already-installed version matches the requirements *(default: false)* |
+| `operations` | `Operations` object | configuration of the `up` operations, with a number of settings oriented toward supply-chain management and security |
+
+### `Operations` object
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `allowed` | list | list of allowed operations (e.g. `go-install`, `github-release`, etc.) to be run when executing `omni up`. If empty, all operations are allowed. Entries in the list prefixed by `!` are disallowed, and wildcards are allowed. Entries are processed in order, so the first match (either allowed or disallowed) is used. For operations using `mise` as backend, only the `mise` operation name will be matched on. *(default: empty)* |
+| `sources` | list | list of allowed sources (urls) for the operations to be run when executing `omni up`. If empty, all sources are allowed. Entries in the list prefixed by `!` are disallowed, and wildcards are allowed. Entries are processed in order, so the first match (either allowed or disallowed) is used. This parameter applies over all operations using sources (e.g. `go-install`, `github-releases`, `mise` plugins, etc.) *(default: empty)* |
+| `mise` | `Mise` object | configuration of the `mise` operations, i.e. of all the operations that use `mise` as backend |
+| `cargo-install` | `CargoInstall` object | configuration of the `cargo-install` operations |
+| `go-install` | `GoInstall` object | configuration of the `go-install` operations |
+| `github-release` | `GithubRelease` object | configuration of the `github-release` operations |
+
+::: tip
+When using the allow/deny lists, the last entry will indicate the default behavior for all values that are not matched by any of the previous entries.
+
+For example, if the list is `['!a*', 'b*']`, all values starting with `a` will be denied, all values starting with `b` will be allowed, and all other values will be denied (opposite of the last entry, which is an allow).
+
+In contrast, if the list is `['b*', '!a*']`, all values starting with `b` will be allowed, and all values starting with `a` will be denied, then all other values will be allowed (opposite of the last entry, which is a deny).
+:::
+
+#### `Mise` object
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `backends` | list | list of allowed backends (e.g. `core`, `aqua`, `vfox`, `asdf`, etc.) for the `mise` operations. If empty, all backends are allowed. Entries in the list prefixed by `!` are disallowed, and wildcards are allowed. Entries are processed in order, so the first match (either allowed or disallowed) is used. The special `custom` backend can be used to represent any plugin installed from a provided URL. *(default: empty)* |
+| `sources` | list | same as `sources` in the `Operations` object, but applies only to `mise` operations *(default: empty)* |
+| `default_plugin_sources` | map | map of default sources for the `mise` operations, where the key is the tool name (e.g. `python`) and the value is the source URL (e.g. `https://github.com/asdf-community/asdf-python`). This is used when no source is provided in the configuration of the operation, and overrides any default URL that would be read from the `mise` registry. *(default: empty)* |
+
+#### `CargoInstall` object
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `crates` | list | list of allowed crates for the `cargo-install` operations. If empty, all crates are allowed. Entries in the list prefixed by `!` are disallowed, and wildcards are allowed. Entries are processed in order, so the first match (either allowed or disallowed) is used. *(default: empty)* |
+
+#### `GoInstall` object
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `sources` | list | same as `sources` in the `Operations` object, but applies only to `go-install` operations *(default: empty)* |
+
+#### `GithubRelease` object
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `repositories` | list | list of allowed repositories in the `<owner>/<repo>` format for the `github-release` operations. If empty, all repositories are allowed. Entries in the list prefixed by `!` are disallowed, and wildcards are allowed. Entries are processed in order, so the first match (either allowed or disallowed) is used. *(default: empty)* |
 
 ## Example
 
 ```yaml
 up_command:
+  # Whether or not to automatically infer the `--bootstrap` parameter when running `omni up`
   auto_bootstrap: true
+
+  # Whether or not to notify the user about the workdir configuration
   notify_workdir_config_updated: true
+
+  # Whether or not to notify the user about the available workdir configuration
   notify_workdir_config_available: true
+
+  # List of preferred tools for `any` operations when running `omni up`
   preferred_tools:
   - nix
   - brew
   - apt
+
+  # The version of `mise` to use for the installation of tools that depend on it
+  mise_version: latest
+
+  # Whether or not to always upgrade to the most up to date matching
+  # version of the dependencies when running `omni up`
+  upgrade: false
+
+  # Configuration of the up operations
+  operations:
+    # List of allowed/denied operations
+    allowed:
+      - go-install
+      - mise
+      - '!cargo-install'
+      - '!github-release'
+      - '!nix'
+
+    # Global URL allow/deny list
+    sources:
+      - 'github.com/trusted-org/*'
+      - 'gitlab.com/trusted-org/*'
+      - '!github.com/bad-owner/*'
+      - '!*.suspicious-domain.com'
+
+    # Operation-specific configuration
+    mise:
+      backends:
+        - asdf
+        - aqua
+        - '!a*'  # Disallow all backends starting with 'a', allow all others
+      sources:
+        - 'github.com/additional-trusted-org/trusted-*'
+        - '!github.com/additional-trusted-org/*'
+      default_plugin_sources:
+        python: 'https://github.com/custom-org/asdf-python.git'
+        node: 'https://github.com/custom-org/asdf-node.git'
+
+    cargo-install:
+      crates:
+        - ripgrep  # Allow ripgrep, deny all others
+
+    go-install:
+      sources:
+        - 'golang.org/*'
+        - '!github.com/method-specific-blocked-org/*'
+
+    github-release:
+      repositories:
+        - 'owner/*'
+        - '!owner/legacy-*'
 ```


### PR DESCRIPTION
When using many sources to install tools for an environment, there can be supply chain concerns. This aims at addressing those by adding configuration to allow/deny specific operations for the `up` command, as well as specific sources for those operations. This also allows to allow/deny specific backends for mise, including a special "custom" backend for user-provided or system-provided urls.

A special parameter also allows to set default URLs for specific tools, allowing to override the plugin to be used by default for a tool.

Closes https://github.com/XaF/omni/issues/600