### PR TITLE
fix(`mise`): 🐛 add the `mise` binary in the `PATH` for `mise` commands

### DIFF
--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -107,11 +107,9 @@ where
     // Add mise itself to the path
     let path_env = std::env::var("PATH").unwrap_or_default();
     let new_paths = std::env::join_paths(
-        vec![PathBuf::from(mise_bin_dir())].into_iter().chain(
-            std::env::split_paths(&path_env)
-                .into_iter()
-                .filter(|p| p != Path::new(mise_bin_dir())),
-        ),
+        vec![PathBuf::from(mise_bin_dir())]
+            .into_iter()
+            .chain(std::env::split_paths(&path_env).filter(|p| p != Path::new(mise_bin_dir()))),
     )
     .expect("failed to join paths");
     command.env("PATH", new_paths);


### PR DESCRIPTION
When `asdf` was used, we added the `asdf` binary in the `PATH` as some plugins depend on being able to call `asdf`. For `mise`, we initially removed that believing that the `mise` binary didn't depend on plugins being able to call back `mise`, or that for some reason `mise` would add itself to the `PATH` when operating on `asdf` plugins. This does not seem to be the case however, and thus this adds the `mise/bin/` directory to the `PATH`, which restore the behavior we had with `asdf`.