### PR TITLE
feat(`github-releases`): ✨ optimize version fetching

### DIFF
--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use globset::Glob;
 use itertools::Itertools;
 use lazy_static::lazy_static;

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -479,13 +479,22 @@ impl GithubReleases {
             Err(err) => return Err(format!("failed to parse releases: {}", err)),
         };
 
-        // TODO: Check if we need to continue fetching more releases, i.e. if we
-        //       added all the releases we just fetched, or if we hit the releases
-        //       we already had in the cache (i.e. at least one release was not new)
-        self.releases.extend(releases);
+        let existing_tag_names: HashSet<String> =
+            self.releases.iter().map(|r| r.tag_name.clone()).collect();
+
+        let mut dup = false;
+        for release in releases {
+            if existing_tag_names.contains(&release.tag_name) {
+                dup = true;
+                break;
+            }
+
+            self.releases.push(release);
+        }
+
         self.fetched_at = OffsetDateTime::now_utc();
 
-        Ok(true)
+        Ok(!dup)
     }
 
     pub fn is_fresh(&self) -> bool {


### PR DESCRIPTION
Following https://github.com/XaF/omni/pull/863, we now can end-up getting a lot of pages of releases each time we refresh the list of available releases.

Since GitHub new releases are added in the first pages, we can use the existing cached releases (unless called with `--no-cache`) to simply add new releases and thus only query the first few pages until we get to releases we already know about.

This will reduce the usage of the API to the bare minimum necessary to be aware of new releases.