### PR TITLE
fix(`argparser`): `last` argument is now shown after `--` in the help

### DIFF
--- a/.omni.yaml
+++ b/.omni.yaml
@@ -89,7 +89,7 @@ commands:
       generate:
         desc: Generates the fixtures for the tests
         run: |
-          GENERATE_FIXTURES=true bats --filter-tags generate tests/
+          GENERATE_FIXTURES=true bats --filter-tags generate tests/ "$@"
 
       renumber:
         desc: Renumber the bats tests

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -263,6 +263,10 @@ impl Command {
 
                 // Finally, we're only left with positional parameters
                 for param in params {
+                    if param.is_last() {
+                        usage += " --";
+                    }
+
                     let param_usage = format!(" {}", param.usage());
                     usage += &param_usage;
                 }

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -277,6 +277,7 @@ impl BuiltinCommand for TidyCommand {
                     ),
                     last_arg_double_hyphen: true,
                     arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::String)),
+                    requires: vec!["up-all".to_string()],
                     ..Default::default()
                 },
             ],

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -1135,6 +1135,10 @@ impl SyntaxOptArg {
         !self.name().starts_with('-')
     }
 
+    pub fn is_last(&self) -> bool {
+        self.last_arg_double_hyphen
+    }
+
     pub fn takes_value(&self) -> bool {
         if matches!(
             self.arg_type(),

--- a/tests/fixtures/omni/help-tidy.txt
+++ b/tests/fixtures/omni/help-tidy.txt
@@ -6,7 +6,7 @@ the path they should be at if they had been cloned using omni clone. This is use
 have a bunch of repositories that you have cloned manually, and you want to start using
 omni, or if you changed your mind on the repo path format you wish to use.
 
-Usage: omni tidy [OPTIONS] [UP_ARGS]...
+Usage: omni tidy [OPTIONS] -- [UP_ARGS]...
 
 Arguments:
   [UP_ARGS]...   Arguments to pass to omni up when running with --up-all


### PR DESCRIPTION
Closes https://github.com/XaF/omni/issues/853