### PR TITLE
feat(`up`): ✨ timeout and offer to kill running `up` if hanging

### DIFF
--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -1515,13 +1515,17 @@ impl BuiltinCommand for UpCommand {
             if suggest_clone {
                 init_options.insert(SyncUpdateInitOption::SuggestClone);
             }
-            SyncUpdateInit::Up(
-                head_commit.clone(),
-                init_options,
-                self.cli_args().cache_enabled,
-            )
+            SyncUpdateInit::Up {
+                commit: head_commit.clone(),
+                options: init_options,
+                cache: self.cli_args().cache_enabled,
+                pid: Some(std::process::id()),
+            }
         } else {
-            SyncUpdateInit::Down(self.cli_args().cache_enabled)
+            SyncUpdateInit::Down {
+                cache: self.cli_args().cache_enabled,
+                pid: Some(std::process::id()),
+            }
         };
 
         // Prepare a listener in case the operation is already running

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -17,6 +17,8 @@ pub enum SyncUpdateError {
     InvalidFormat(#[from] serde_json::Error),
     #[error("progress handler was not initialized")]
     NoProgressHandler,
+    #[error("timeout during operation")]
+    Timeout,
 }
 
 #[derive(Error, Debug)]

--- a/tests/fixtures/omni/status-config.txt
+++ b/tests/fixtures/omni/status-config.txt
@@ -65,6 +65,8 @@ path_repo_updates:
   self_update: ask
 repo_path_format: '%{host}/%{org}/%{repo}'
 up_command:
+  attach_kill_timeout: 300
+  attach_lock_timeout: 5
   auto_bootstrap: true
   mise_version: latest
   notify_workdir_config_available: true


### PR DESCRIPTION
The `omni up` (and respectively `omni down`) command will try to attach to any running `omni up` or `omni down` command that is already running for the current work directory. However, in cases where there is a connectivity issue (e.g. computer going to sleep), it is possible for the `omni up` command to hang indefinitely (e.g. waiting for a network response).

When attaching to a running process, this will trigger a timeout after a few minutes if the process seems to be hanging, offering the user to kill the running process.

Closes https://github.com/XaF/omni/issues/877