### PR TITLE
chore(`IsTerminal`): use the `std` trait `IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,12 +956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,17 +1323,6 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1749,7 +1732,6 @@ dependencies = [
  "humantime",
  "imara-diff",
  "indicatif",
- "is-terminal",
  "itertools",
  "lazy_static",
  "libz-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ globset = "0.4.14"
 humantime = "2.1.0"
 imara-diff = "0.1.6"
 indicatif = "0.17.9"
-is-terminal = "0.4.13"
 itertools = "0.14.0"
 lazy_static = "1.4.0"
 libz-sys = { version = "1.1.21", features = ["static"] }  # So we can force static linking

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::process::exit;
 
 use regex::Regex;
@@ -241,6 +242,13 @@ impl StatusCommand {
         if yaml_lines[0] == "---" {
             // Remove the first line if it's "---"; as it's not very useful
             yaml_lines.remove(0);
+        }
+
+        // If the output is not a terminal, return the yaml as is;
+        // this is required as usually we do not colorize when
+        // both stdout and stderr are not terminals
+        if !std::io::stdout().is_terminal() {
+            return yaml_lines.join("\n");
         }
 
         let pattern = r#"^(\s*)(\-\s*)?(("[^"]+"|([^:]|:[^ ])+)\s*:)(\s+|$)"#;

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
+use std::io::IsTerminal;
 use std::io::Write;
 use std::panic::catch_unwind;
 use std::path::PathBuf;
@@ -12,7 +13,6 @@ use fs4::fs_std::FileExt;
 use gethostname::gethostname;
 use git2::Repository;
 use git_url_parse::GitUrl;
-use is_terminal::IsTerminal;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
 use petname::Generator;

--- a/src/internal/user_interface/colors.rs
+++ b/src/internal/user_interface/colors.rs
@@ -1,6 +1,6 @@
-use is_terminal::IsTerminal;
-use lazy_static::lazy_static;
+use std::io::IsTerminal;
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::internal::env::shell_is_interactive;
@@ -73,6 +73,8 @@ fn enable_colors() -> bool {
     if std::env::var_os("CLICOLOR_FORCE").is_some() {
         return true;
     }
+    // TODO: find an approach to not depend on the stderr check for the
+    //       PS1 colorization
     std::io::stdout().is_terminal() || std::io::stderr().is_terminal()
 }
 


### PR DESCRIPTION
The `is_terminal()` method is now part of the standard library since rust 1.70.0, so we can remove the dependency to the `is-terminal` crate.