### PR TITLE
fix(`auto`): do not return an error if no version detected

### DIFF
--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -1661,6 +1661,9 @@ impl UpConfigMise {
 
         if detected_versions.is_empty() {
             progress_handler.success_with_message("no version detected".to_string());
+            self.actual_versions
+                .set(BTreeMap::new())
+                .expect("failed to set installed versions");
             return Ok(());
         }
 


### PR DESCRIPTION
Since the switch to associate an environment at the end of up, we depend on getting the version of the tool at the end to link required versions to the environment that required them.

When `auto` is used, if no version is detected, no version gets set in the list of resolved versions, which thus led to an error.

This fixes that issue by setting the versions to an empty list when running an operation with `auto` which did not detect any version to install.

Closes https://github.com/XaF/omni/issues/852