### PR TITLE
feat(`up`): ✨ handle hanging process with mismatched init

### DIFF
--- a/src/internal/config/parser/up_command.rs
+++ b/src/internal/config/parser/up_command.rs
@@ -42,7 +42,7 @@ impl Default for UpCommandConfig {
 }
 
 impl UpCommandConfig {
-    const DEFAULT_ATTACH_KILL_TIMEOUT: u64 = 300; // 5 minutes
+    const DEFAULT_ATTACH_KILL_TIMEOUT: u64 = 600; // 10 minutes
     const DEFAULT_ATTACH_LOCK_TIMEOUT: u64 = 5; // 5 seconds
     const DEFAULT_AUTO_BOOTSTRAP: bool = true;
     const DEFAULT_NOTIFY_WORKDIR_CONFIG_UPDATED: bool = true;

--- a/src/internal/config/up/utils/up_progress_handler.rs
+++ b/src/internal/config/up/utils/up_progress_handler.rs
@@ -361,26 +361,24 @@ impl SyncUpdateListener<'_> {
             }
 
             if let Some(pid) = self.attached_pid {
-                if shell_is_interactive() {
-                    if last_activity.elapsed() > timeout_duration {
-                        // Hide the progress handler if any
-                        if let Some(handler) = &self.current_handler {
-                            handler.hide();
-                        }
-
-                        // Suggest to kill the process if it seems to be hanging
-                        if suggest_and_kill(pid) {
-                            break Ok(false);
-                        }
-
-                        // Show the progress handler again if we pursued
-                        if let Some(handler) = &self.current_handler {
-                            handler.show();
-                        }
-
-                        // Reset the last activity time
-                        last_activity = StdInstant::now();
+                if shell_is_interactive() && last_activity.elapsed() > timeout_duration {
+                    // Hide the progress handler if any
+                    if let Some(handler) = &self.current_handler {
+                        handler.hide();
                     }
+
+                    // Suggest to kill the process if it seems to be hanging
+                    if suggest_and_kill(pid) {
+                        break Ok(false);
+                    }
+
+                    // Show the progress handler again if we pursued
+                    if let Some(handler) = &self.current_handler {
+                        handler.show();
+                    }
+
+                    // Reset the last activity time
+                    last_activity = StdInstant::now();
                 }
             }
 
@@ -410,7 +408,10 @@ impl SyncUpdateListener<'_> {
 
                     // If the file last modified time is more than the configured
                     // timeout, offer to kill the process
-                    if self.since_modified > timeout && suggest_and_kill(pid) {
+                    if shell_is_interactive()
+                        && self.since_modified > timeout
+                        && suggest_and_kill(pid)
+                    {
                         return Ok(false);
                     }
                 }

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -1123,7 +1123,7 @@ impl WorkDirEnv {
                     }
                 }
             }
-            Err(SyncUpdateError::MismatchedInit(actual, _expected)) => {
+            Err(SyncUpdateError::MismatchedInit { actual, .. }) => {
                 // If the init operation is mismatched, we need to wait for the lock to be released
                 omni_info!(format!(
                     "waiting for running {} operation to finish",

--- a/src/internal/errors.rs
+++ b/src/internal/errors.rs
@@ -7,8 +7,11 @@ use crate::internal::config::up::utils::SyncUpdateInit;
 pub enum SyncUpdateError {
     #[error("error during file operation: {0}")]
     IO(#[from] std::io::Error),
-    #[error("actual init operation `{0}` is different from expected `{1}`")]
-    MismatchedInit(Box<SyncUpdateInit>, Box<SyncUpdateInit>),
+    #[error("actual init operation `{actual}` is different from expected `{expected}`")]
+    MismatchedInit {
+        actual: Box<SyncUpdateInit>,
+        expected: Box<SyncUpdateInit>,
+    },
     #[error("the expected run has more options than the attached run")]
     MissingInitOptions,
     #[error("already initialized, but read another init operation")]

--- a/tests/fixtures/omni/status-config.txt
+++ b/tests/fixtures/omni/status-config.txt
@@ -65,7 +65,7 @@ path_repo_updates:
   self_update: ask
 repo_path_format: '%{host}/%{org}/%{repo}'
 up_command:
-  attach_kill_timeout: 300
+  attach_kill_timeout: 600
   attach_lock_timeout: 5
   auto_bootstrap: true
   mise_version: latest


### PR DESCRIPTION
Previous commit added the query for same init when the process seems to be hanging, this adds a check of the file last modified time right as we read the init data, allowing to offer killing the running process if it has been hanging for longer than expected, no matter if the init contents is matching or not.