### PR TITLE
fix(`config check`): 🐛 pattern locality 

### DIFF
--- a/src/internal/commands/builtin/config/check.rs
+++ b/src/internal/commands/builtin/config/check.rs
@@ -517,7 +517,7 @@ impl ConfigCheckCommand {
         let cliarg_patterns: Vec<String> = args
             .patterns
             .iter()
-            .map(|value| path_pattern_from_str(value, None))
+            .map(|value| path_pattern_from_str(value, None, true))
             .collect();
 
         // Filter and sort the errors

--- a/src/internal/config/utils.rs
+++ b/src/internal/config/utils.rs
@@ -84,9 +84,156 @@ pub fn check_allowed(value: &str, patterns: &[String]) -> bool {
         if matches {
             return !is_deny; // Early return on match
         }
+
+        if pattern_str.ends_with('*') {
+            continue;
+        }
+
+        // If the pattern does not end with a wildcard, try checking
+        // for the pattern as a directory that should prefix the file
+        let dir_pattern = format!("{}/**", pattern_str.trim_end_matches('/'));
+        let matches = glob::Pattern::new(&dir_pattern).is_ok_and(|pat| pat.matches(value));
+        if matches {
+            return !is_deny; // Early return on match
+        }
     }
 
     // Get the last pattern's deny status (if any) for the default case
     let default = patterns.last().map_or(true, |p| p.starts_with('!'));
     default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod check_allowed {
+        use super::*;
+
+        #[test]
+        fn test_empty_patterns() {
+            assert!(check_allowed("any/path", &[]));
+            assert!(check_allowed("", &[]));
+        }
+
+        #[test]
+        fn test_exact_matches() {
+            // Test exact path matching
+            assert!(check_allowed("src/main.rs", &["src/main.rs".to_string()]));
+
+            // Test exact path with deny
+            assert!(!check_allowed("src/main.rs", &["!src/main.rs".to_string()]));
+        }
+
+        #[test]
+        fn test_wildcard_patterns() {
+            // Test with * wildcard
+            assert!(check_allowed("src/test.rs", &["src/*.rs".to_string()]));
+
+            // Test with multiple patterns including wildcard
+            assert!(check_allowed(
+                "src/lib.rs",
+                &["src/*.rs".to_string(), "!src/test.rs".to_string()]
+            ));
+
+            // Test with ** wildcard
+            assert!(check_allowed(
+                "src/subfolder/test.rs",
+                &["src/**/*.rs".to_string()]
+            ));
+        }
+
+        #[test]
+        fn test_directory_prefix_matching() {
+            // Test directory prefix without trailing slash
+            assert!(check_allowed(
+                "src/subfolder/file.rs",
+                &["src/subfolder".to_string()]
+            ));
+
+            // Test directory prefix with trailing slash
+            assert!(check_allowed(
+                "src/subfolder/file.rs",
+                &["src/subfolder/".to_string()]
+            ));
+
+            // Test nested directory matching
+            assert!(check_allowed(
+                "src/deep/nested/file.rs",
+                &["src/deep".to_string()]
+            ));
+        }
+
+        #[test]
+        fn test_multiple_patterns() {
+            let patterns = vec![
+                "src/secret/public.rs".to_string(),
+                "!src/secret/**".to_string(),
+                "src/**".to_string(),
+            ];
+
+            // Should match general src pattern
+            assert!(check_allowed("src/main.rs", &patterns));
+
+            // Should be denied by secret pattern
+            assert!(!check_allowed("src/secret/private.rs", &patterns));
+
+            // Should be explicitly allowed despite being in secret dir
+            assert!(check_allowed("src/secret/public.rs", &patterns));
+        }
+
+        #[test]
+        fn test_default_behavior() {
+            // Test default allow (last pattern is negative)
+            assert!(check_allowed(
+                "random.txt",
+                &["src/**".to_string(), "!tests/**".to_string()]
+            ));
+
+            // Test default deny (last pattern is positive)
+            assert!(!check_allowed(
+                "random.txt",
+                &["!src/**".to_string(), "src/allowed.rs".to_string()]
+            ));
+        }
+
+        #[test]
+        fn test_pattern_priority() {
+            let patterns = vec![
+                "docs/internal/public/**".to_string(),
+                "!docs/internal/**".to_string(),
+                "docs/**".to_string(),
+            ];
+
+            // Should match third pattern
+            assert!(check_allowed("docs/api.md", &patterns));
+
+            // Should be denied by second pattern
+            assert!(!check_allowed("docs/internal/secret.md", &patterns));
+
+            // Should be allowed by first pattern
+            assert!(check_allowed("docs/internal/public/readme.md", &patterns));
+        }
+
+        #[test]
+        fn test_directory_prefix() {
+            let patterns = vec!["src".to_string()];
+
+            assert!(check_allowed("src", &patterns));
+            assert!(check_allowed("src/test", &patterns));
+            assert!(check_allowed("src/another/test", &patterns));
+        }
+
+        #[test]
+        fn test_edge_cases() {
+            // Test root pattern
+            assert!(check_allowed("any/path", &["**".to_string()]));
+
+            // Test single negative pattern
+            assert!(!check_allowed("any/path", &["!**".to_string()]));
+
+            // Test pattern with just trailing wildcard
+            assert!(check_allowed("src/anything", &["src/*".to_string()]));
+        }
+    }
 }

--- a/website/contents/reference/configuration/parameters/check.md
+++ b/website/contents/reference/configuration/parameters/check.md
@@ -15,6 +15,7 @@ This is expected to be a list of objects containing the following parameters:
 | `patterns` | list of strings | Pattern of files to include (or exclude, if starting by `!`) in the check. Allows for glob patterns to be used. |
 | `ignore` | list of strings | [Error codes](/reference/builtin-commands/config/check#error-codes) to ignore. |
 | `select` | list of strings | [Error codes](/reference/builtin-commands/config/check#error-codes) to select. |
+| `tags` | list of strings or objects | Tags to include in the check, and how to validate them. The elements of the list can be a string, in which case it is assumed to be a tag name to require, or a key-value pair where the value is a [Filter](github#filter-object) object. |
 
 ## Example
 
@@ -39,4 +40,12 @@ check:
     - "C001" # Select all errors of type C001
     - "M"    # Select all errors of type M
     - "P0"   # Select all errors of type P
+
+  tags:
+    - should exist
+    - should match: 'val*'
+    - should exactly match:
+        exact: 'value'
+    - should be a number:
+        regex: '^\d+$'
 ```


### PR DESCRIPTION
This improves the handling of the location of the patterns when passed
from configuration files or from the command line.