### PR TITLE
feat(`self-update`): add `omni --self-update` support

### DIFF
--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -378,7 +378,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
         return (HashSet::new(), HashSet::new());
     }
 
-    self_update();
+    self_update(false);
 
     // Nothing more to do if nothing is in the omnipath, or if we are running
     // as sudo since we don't want the repositories to be updated in that case

--- a/src/internal/self_updater.rs
+++ b/src/internal/self_updater.rs
@@ -181,17 +181,19 @@ pub fn compatible_release_os() -> Vec<String> {
     }
 }
 
-pub fn self_update() {
-    // Check if OMNI_SKIP_SELF_UPDATE is set
-    if let Some(skip_self_update) = std::env::var_os("OMNI_SKIP_SELF_UPDATE") {
-        if !skip_self_update.to_str().unwrap().is_empty() {
+pub fn self_update(force: bool) {
+    if !force {
+        // Check if OMNI_SKIP_SELF_UPDATE is set
+        if let Some(skip_self_update) = std::env::var_os("OMNI_SKIP_SELF_UPDATE") {
+            if !skip_self_update.to_str().unwrap().is_empty() {
+                return;
+            }
+        }
+
+        let config = config(".");
+        if config.path_repo_updates.self_update.do_not_check() {
             return;
         }
-    }
-
-    let config = config(".");
-    if config.path_repo_updates.self_update.do_not_check() {
-        return;
     }
 
     if let Some(omni_release) = OmniRelease::latest() {


### PR DESCRIPTION
This will only trigger updating omni itself if a new version is available.

Closes https://github.com/XaF/omni/issues/897