### PR TITLE
fix(`github-release`): 🐛 detect the lib version needed (musl/libc)

### DIFF
--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -517,14 +517,6 @@ pub struct UpConfigGithubRelease {
     )]
     pub prefer_dist: bool,
 
-    /// Whether to prefer the 'musl' assets over the 'glibc' assets.
-    /// This defaults to false to use native glibc binaries by default
-    #[serde(
-        default = "cache_utils::set_false",
-        skip_serializing_if = "cache_utils::is_false"
-    )]
-    pub prefer_musl: bool,
-
     /// The URL of the GitHub API; this is only required if downloading
     /// using Github Enterprise. By default, this is set to the public
     /// GitHub API URL (https://api.github.com). If you are using
@@ -572,7 +564,6 @@ impl Default for UpConfigGithubRelease {
             skip_os_matching: false,
             skip_arch_matching: false,
             prefer_dist: false,
-            prefer_musl: false,
             api_url: None,
             checksum: GithubReleaseChecksumConfig::default(),
             auth: GithubAuthConfig::default(),
@@ -742,11 +733,6 @@ impl UpConfigGithubRelease {
             false,
             &error_handler.with_key("prefer_dist"),
         );
-        let prefer_musl = config_value.get_as_bool_or_default(
-            "prefer_musl",
-            false,
-            &error_handler.with_key("prefer_musl"),
-        );
         let api_url =
             config_value.get_as_str_or_none("api_url", &error_handler.with_key("api_url"));
         let checksum = GithubReleaseChecksumConfig::from_config_value(
@@ -769,7 +755,6 @@ impl UpConfigGithubRelease {
             skip_os_matching,
             skip_arch_matching,
             prefer_dist,
-            prefer_musl,
             api_url,
             checksum,
             auth,
@@ -1321,7 +1306,6 @@ impl UpConfigGithubRelease {
                     .skip_os_matching(self.skip_os_matching)
                     .skip_arch_matching(self.skip_arch_matching)
                     .prefer_dist(self.prefer_dist)
-                    .prefer_musl(self.prefer_musl)
                     .checksum_lookup(self.checksum.is_enabled())
                     .checksum_algorithm(self.checksum.algorithm.clone().map(|a| a.to_string()))
                     .checksum_asset_name(self.checksum.asset_name.clone()),

--- a/src/internal/utils/libc.rs
+++ b/src/internal/utils/libc.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+/// Detects the C library used by the current system.
+/// Returns true for glibc and false for musl.
+#[cfg(target_os = "linux")]
+#[inline]
+pub fn detect_libc() -> bool {
+    // First try filesystem check as it's faster
+    if Path::new("/lib/ld-musl-x86_64.so.1").exists() {
+        return false;
+    }
+
+    if Path::new("/lib64/ld-linux-x86-64.so.2").exists() {
+        return true;
+    }
+
+    // Fallback to ldd check
+    match StdCommand::new("ldd")
+        .arg("--version")
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .output()
+    {
+        Ok(output) => {
+            let error_str = String::from_utf8_lossy(&output.stderr);
+            error_str.contains("GNU") || error_str.contains("GLIBC")
+        }
+        Err(_) => true, // Default to glibc if we can't determine
+    }
+}

--- a/src/internal/utils/mod.rs
+++ b/src/internal/utils/mod.rs
@@ -1,2 +1,7 @@
 pub(crate) mod base62;
 pub(crate) use base62::encode as base62_encode;
+
+#[cfg(target_os = "linux")]
+mod libc;
+#[cfg(target_os = "linux")]
+pub(crate) use libc::detect_libc;

--- a/website/contents/reference/configuration/parameters/up/github-release.md
+++ b/website/contents/reference/configuration/parameters/up/github-release.md
@@ -45,7 +45,6 @@ This supports authenticated requests using [the `gh` command line interface](htt
 | `skip_os_matching` | boolean | Whether to skip the OS matching when downloading assets. If set to `true`, this will download all assets regardless of the OS *(default: `false`)* |
 | `skip_arch_matching` | boolean | Whether to skip the architecture matching when downloading assets. If set to `true`, this will download all assets regardless of the architecture *(default: `false`)* |
 | `prefer_dist` | boolean | Whether to prefer downloading assets with a `dist` tag in the name, if available; when set to `false`, will prefer downloading assets without `dist` in the name *(default: `false`)* |
-| `prefer_musl` | boolean | Whether to prefer downloading assets with a `musl` tag in the name, if available; when set to `false`, will prefer downloading assets without `musl` in the name *(default: `false`)* |
 | `api_url` | string | The URL of the GitHub API to use, useful to use GitHub Enterprise (e.g. `https://github.example.com/api/v3`); defaults to `https://api.github.com` |
 | `checksum` | object | The configuration to verify the checksum of the downloaded asset; see [checksum configuration](#checksum-configuration) below |
 | `auth` | [`Auth`](../github#auth-object) object | The configuration to authenticate the GitHub API requests for this release; if specified, will override the global configuration |


### PR DESCRIPTION
This replaces the `prefer_musl` flag by a detection, which makes more sense actually, since it would depend on the current system.

Partially reverts 24faed98d19a529196915b70ac51731c0eca8802