### PR TITLE
feat(`github-release`): ✨ support extracting `.tar.xz` archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "machine-uid"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1790,7 @@ dependencies = [
  "walkdir",
  "which",
  "whoami",
+ "xz2",
  "zip-extract",
 ]
 
@@ -3541,6 +3553,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ uuid = { version = "1.12.0", features = ["v4", "fast-rng"] }
 walkdir = "2.4.0"
 which = "7.0.1"
 whoami = "1.5.2"
+xz2 = "0.1.7"
 zip-extract = "0.2.1"
 
 [package.metadata.cargo-machete]

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -663,12 +663,19 @@ pub struct GithubReleaseAsset {
 
 impl GithubReleaseAsset {
     const TAR_GZ_EXTS: [&'static str; 2] = [".tar.gz", ".tgz"];
+    const TAR_XZ_EXTS: [&'static str; 2] = [".tar.xz", ".txz"];
     const ZIP_EXTS: [&'static str; 1] = [".zip"];
 
     pub fn file_type(&self) -> Option<(GithubReleaseAssetType, String)> {
         for ext in Self::TAR_GZ_EXTS.iter() {
             if let Some(prefix) = self.name.strip_suffix(ext) {
                 return Some((GithubReleaseAssetType::TarGz, prefix.to_string()));
+            }
+        }
+
+        for ext in Self::TAR_XZ_EXTS.iter() {
+            if let Some(prefix) = self.name.strip_suffix(ext) {
+                return Some((GithubReleaseAssetType::TarXz, prefix.to_string()));
             }
         }
 
@@ -703,6 +710,7 @@ impl GithubReleaseAsset {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum GithubReleaseAssetType {
     TarGz,
+    TarXz,
     Zip,
     Binary,
 }
@@ -714,6 +722,10 @@ impl GithubReleaseAssetType {
 
     pub fn is_tgz(&self) -> bool {
         matches!(self, Self::TarGz)
+    }
+
+    pub fn is_txz(&self) -> bool {
+        matches!(self, Self::TarXz)
     }
 
     pub fn is_binary(&self) -> bool {

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -1674,6 +1674,14 @@ impl UpConfigGithubRelease {
                         progress_handler.error_with_message(errmsg.clone());
                         UpError::Exec(errmsg)
                     })?;
+                } else if asset_type.is_txz() {
+                    let tar = xz2::read::XzDecoder::new(archive_file);
+                    let mut archive = tar::Archive::new(tar);
+                    archive.unpack(&target_dir).map_err(|err| {
+                        let errmsg = format!("failed to extract {}: {}", asset_name, err);
+                        progress_handler.error_with_message(errmsg.clone());
+                        UpError::Exec(errmsg)
+                    })?;
                 } else {
                     let errmsg = format!("file extension not supported: {}", asset_name);
                     progress_handler.error_with_message(errmsg.clone());


### PR DESCRIPTION
On top of the already-supported `.tar.gz` and `.zip` archives.