### PR TITLE
feat(`argparser`): ✨ add auto-completion support

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -387,6 +387,10 @@ impl Command {
                 omni_print!(format!("{} {}", "error building parser:".red(), err));
                 exit(1);
             }
+            Err(ParseArgsErrorKind::InvalidValue(err)) => {
+                omni_print!(format!("{} {}", "error parsing arguments:".red(), err));
+                exit(1);
+            }
             Err(ParseArgsErrorKind::ArgumentParsingError(err)) => {
                 let clap_rich_error = err.render().ansi().to_string();
                 let clap_rich_error = strip_colors_if_needed(&clap_rich_error);
@@ -822,9 +826,14 @@ impl Command {
                 return Ok(None);
             }
 
-            // TODO: add type to autocomplete with repositories too?
-            if arg_type == SyntaxOptArgType::Path {
-                path_auto_complete(&comp_value, false)
+            if matches!(
+                arg_type,
+                SyntaxOptArgType::DirPath | SyntaxOptArgType::FilePath | SyntaxOptArgType::RepoPath
+            ) {
+                let include_repositories = matches!(arg_type, SyntaxOptArgType::RepoPath);
+                let include_files = matches!(arg_type, SyntaxOptArgType::FilePath);
+
+                path_auto_complete(&comp_value, include_repositories, include_files)
                     .iter()
                     .for_each(|s| println!("{}", s));
 

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -767,10 +767,7 @@ impl Command {
         }
 
         // TODO: add support for autocompleting paths value types
-        Ok(matches!(
-            state,
-            AutocompleteState::Value | AutocompleteState::ValueAndParameters
-        ))
+        Ok(matches!(state, AutocompleteState::Parameters))
     }
 
     fn command_type_sort_order(&self) -> usize {

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -822,6 +822,7 @@ impl Command {
                 return Ok(None);
             }
 
+            // TODO: add type to autocomplete with repositories too?
             if arg_type == SyntaxOptArgType::Path {
                 path_auto_complete(&comp_value, false)
                     .iter()

--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -736,6 +736,15 @@ impl Command {
                 parameters.retain(|param| !param.all_names().iter().any(|name| name == conflict));
             }
 
+            // The conflicts can be declared the other way around too, so go over
+            // the parameters removing any that conflicts with the current parameter
+            parameters.retain(|param| {
+                !param
+                    .conflicts_with
+                    .iter()
+                    .any(|conflict| parameter.all_names().iter().any(|name| name == conflict))
+            });
+
             // Consume values as needed
             if parameter.takes_value() {
                 // How many values to consume at most?

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -285,7 +285,7 @@ impl BuiltinCommand for CdCommand {
         if parameter.unwrap_or_default() == "workdir" {
             let repo = argv.get(comp_cword).map_or("", String::as_str);
 
-            path_auto_complete(repo, true)
+            path_auto_complete(repo, true, false)
                 .iter()
                 .for_each(|s| println!("{}", s));
         }

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -274,24 +274,21 @@ impl BuiltinCommand for CdCommand {
 
     fn autocompletion(&self) -> CommandAutocompletion {
         // TODO: convert to partial
-        CommandAutocompletion::Full
+        CommandAutocompletion::Partial
     }
 
     fn autocomplete(
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        _parameter: Option<String>,
+        parameter: Option<String>,
     ) -> Result<(), ()> {
-        if comp_cword > 0 {
+        // We only have the work directory to autocomplete
+        if parameter.unwrap_or_default() != "workdir" {
             return Ok(());
         }
 
-        let repo = if !argv.is_empty() {
-            argv[0].clone()
-        } else {
-            "".to_string()
-        };
+        let repo = argv.get(comp_cword).map_or("", String::as_str).to_string();
 
         // Figure out if this is a path, so we can avoid the expensive repository search
         let path_only = repo.starts_with('/')

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -5,6 +5,7 @@ use std::process::exit;
 use shell_escape::escape;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::utils::omni_cmd;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
@@ -271,11 +272,17 @@ impl BuiltinCommand for CdCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        // TODO: convert to partial
+        CommandAutocompletion::Full
     }
 
-    fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(
+        &self,
+        comp_cword: usize,
+        argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         if comp_cword > 0 {
             return Ok(());
         }

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::process::exit;
 
 use shell_escape::escape;
@@ -7,6 +6,7 @@ use shell_escape::escape;
 use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::utils::omni_cmd;
+use crate::internal::commands::utils::path_auto_complete;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
 use crate::internal::config::parser::ParseArgsValue;
@@ -14,8 +14,6 @@ use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 use crate::internal::config::SyntaxOptArgType;
 use crate::internal::env::omni_cmd_file;
-use crate::internal::env::user_home;
-use crate::internal::env::Shell;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
@@ -284,68 +282,12 @@ impl BuiltinCommand for CdCommand {
         parameter: Option<String>,
     ) -> Result<(), ()> {
         // We only have the work directory to autocomplete
-        if parameter.unwrap_or_default() != "workdir" {
-            return Ok(());
-        }
+        if parameter.unwrap_or_default() == "workdir" {
+            let repo = argv.get(comp_cword).map_or("", String::as_str);
 
-        let repo = argv.get(comp_cword).map_or("", String::as_str).to_string();
-
-        // Figure out if this is a path, so we can avoid the expensive repository search
-        let path_only = repo.starts_with('/')
-            || repo.starts_with('.')
-            || repo.starts_with("~/")
-            || repo == "~"
-            || repo == "-";
-
-        // Print all the completion related to path completion
-        let (list_dir, strip_path_prefix, replace_home_prefix) = if repo == "~" {
-            (user_home(), false, true)
-        } else if let Some(repo) = repo.strip_prefix("~/") {
-            if let Some(slash) = repo.rfind('/') {
-                let abspath = format!("{}/{}", user_home(), &repo[..(slash + 1)]);
-                (abspath, false, true)
-            } else {
-                (user_home(), false, true)
-            }
-        } else if let Some(slash) = repo.rfind('/') {
-            (repo[..(slash + 1)].to_string(), false, false)
-        } else {
-            (".".to_string(), true, false)
-        };
-        if let Ok(files) = std::fs::read_dir(&list_dir) {
-            for path in files.flatten() {
-                if path.path().is_dir() {
-                    let path_buf;
-                    let path_obj = path.path();
-                    let path = if strip_path_prefix {
-                        path_obj.strip_prefix(&list_dir).unwrap()
-                    } else if replace_home_prefix {
-                        if let Ok(path_obj) = path_obj.strip_prefix(user_home()) {
-                            path_buf = PathBuf::from("~").join(path_obj);
-                            path_buf.as_path()
-                        } else {
-                            path_obj.as_path()
-                        }
-                    } else {
-                        path_obj.as_path()
-                    };
-                    let path_str = path.to_str().unwrap();
-
-                    if !path_str.starts_with(repo.as_str()) {
-                        continue;
-                    }
-
-                    println!("{}/", path.display());
-                }
-            }
-        }
-
-        // Get all the repositories per org
-        if !path_only {
-            let add_space = if Shell::current().is_fish() { " " } else { "" };
-            for match_repo in ORG_LOADER.complete(&repo) {
-                println!("{}{}", match_repo, add_space);
-            }
+            path_auto_complete(repo, true)
+                .iter()
+                .for_each(|s| println!("{}", s));
         }
 
         Ok(())

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -214,6 +214,7 @@ impl BuiltinCommand for CdCommand {
                         .to_string()
                     ),
                     arg_type: SyntaxOptArgType::Flag,
+                    conflicts_with: vec!["--no-include-packages".to_string()],
                     ..Default::default()
                 },
                 SyntaxOptArg {
@@ -273,7 +274,6 @@ impl BuiltinCommand for CdCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO: convert to partial
         CommandAutocompletion::Partial
     }
 

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -11,6 +11,7 @@ use shell_words::join as shell_join;
 use tokio::process::Command as TokioCommand;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::UpCommand;
 use crate::internal::commands::utils::omni_cmd;
 use crate::internal::commands::Command;
@@ -488,11 +489,16 @@ impl BuiltinCommand for CloneCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::TidyGitRepo;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::commands::utils::file_auto_complete;
@@ -137,16 +138,16 @@ impl BuiltinCommand for ConfigBootstrapCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        println!("--organizations");
-        println!("--repo-path-format");
-        println!("--shell");
-        println!("--worktree");
-
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/check.rs
+++ b/src/internal/commands/builtin/config/check.rs
@@ -6,6 +6,7 @@ use std::process::exit;
 use itertools::Itertools;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::frompath::PathCommand;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
@@ -305,12 +306,17 @@ impl BuiltinCommand for ConfigCheckCommand {
         self.filter_and_print_errors(&error_handler, &args);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -7,6 +7,7 @@ use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::CloneCommand;
 use crate::internal::commands::builtin::TidyGitRepo;
 use crate::internal::commands::builtin::UpCommand;
@@ -471,11 +472,16 @@ impl BuiltinCommand for ConfigPathSwitchCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/reshim.rs
+++ b/src/internal/commands/builtin/config/reshim.rs
@@ -1,6 +1,7 @@
 use std::process::exit;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::up::utils::reshim;
 use crate::internal::config::up::utils::PrintProgressHandler;
@@ -79,11 +80,16 @@ impl BuiltinCommand for ConfigReshimCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::process::exit;
 
 use crate::internal::cache::WorkdirsCache;
@@ -15,7 +14,6 @@ use crate::internal::workdir;
 use crate::internal::workdir::add_trust;
 use crate::internal::workdir::is_trusted;
 use crate::internal::workdir::remove_trust;
-use crate::internal::ORG_LOADER;
 use crate::omni_error;
 use crate::omni_info;
 
@@ -117,6 +115,7 @@ impl BuiltinCommand for ConfigTrustCommand {
                         )
                         .to_string(),
                     ),
+                    arg_type: SyntaxOptArgType::RepoPath,
                     ..Default::default()
                 },
             ],
@@ -136,20 +135,8 @@ impl BuiltinCommand for ConfigTrustCommand {
                 .expect("should have args to parse"),
         );
 
-        let path = if let Some(repo) = &args.workdir {
-            if let Some(repo_path) = ORG_LOADER.find_repo(repo, true, false, false) {
-                repo_path
-            } else {
-                omni_error!(format!("repository not found: {}", repo));
-                exit(1);
-            }
-        } else {
-            PathBuf::from(".")
-        };
-
-        let path_str = path.display().to_string();
-
-        let wd = workdir(path_str.as_str());
+        let path_str = args.workdir.as_deref().unwrap_or(".");
+        let wd = workdir(path_str);
         let wd_id = match wd.id() {
             Some(id) => id,
             None => {
@@ -161,7 +148,7 @@ impl BuiltinCommand for ConfigTrustCommand {
             }
         };
 
-        let is_trusted = is_trusted(path_str.as_str());
+        let is_trusted = is_trusted(path_str);
 
         if args.check_status {
             if is_trusted {
@@ -186,7 +173,7 @@ impl BuiltinCommand for ConfigTrustCommand {
                 exit(0);
             }
 
-            if add_trust(path_str.as_str()) {
+            if add_trust(path_str) {
                 omni_info!(
                     format!("work directory is now {}", "trusted".light_green()),
                     wd_id
@@ -213,7 +200,7 @@ impl BuiltinCommand for ConfigTrustCommand {
                 exit(1);
             }
 
-            if remove_trust(path_str.as_str()) {
+            if remove_trust(path_str) {
                 omni_info!(
                     format!("work directory is now {}", "untrusted".light_red()),
                     wd_id
@@ -226,7 +213,6 @@ impl BuiltinCommand for ConfigTrustCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO use partial to autocomplete repositories
         CommandAutocompletion::Null
     }
 

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -4,6 +4,7 @@ use std::process::exit;
 
 use crate::internal::cache::WorkdirsCache;
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::parser::ParseArgsValue;
 use crate::internal::config::CommandSyntax;
@@ -224,12 +225,17 @@ impl BuiltinCommand for ConfigTrustCommand {
         }
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        // TODO use partial to autocomplete repositories
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        // TODO: autocomplete repositories if first argument
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use crate::internal::cache::utils as cache_utils;
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::command_loader;
 use crate::internal::commands::void::VoidCommand;
 use crate::internal::commands::Command;
@@ -198,11 +199,17 @@ impl BuiltinCommand for HelpCommand {
         self.exec_with_exit_code(argv, 0);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        // TODO: convert to partial
+        CommandAutocompletion::Full
     }
 
-    fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(
+        &self,
+        comp_cword: usize,
+        argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         command_loader(".").complete(comp_cword, argv, false)
     }
 }

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -200,7 +200,7 @@ impl BuiltinCommand for HelpCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO: convert to partial
+        // TODO: convert to partial so the autocompletion works for options too
         CommandAutocompletion::Full
     }
 

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -1,4 +1,5 @@
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 
@@ -59,17 +60,16 @@ impl BuiltinCommand for HookCommand {
 
     fn exec(&self, _argv: Vec<String>) {}
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        if comp_cword == 0 {
-            println!("env");
-            println!("init");
-            println!("uuid");
-        }
-
-        Ok(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Err(())
     }
 }

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::process::exit;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::parser::ParseArgsValue;
 use crate::internal::config::CommandSyntax;
@@ -165,11 +166,16 @@ impl BuiltinCommand for HookEnvCommand {
         }
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -7,6 +7,7 @@ use tera::Context;
 use tera::Tera;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::global_config;
 use crate::internal::config::parser::ParseArgsValue;
@@ -304,12 +305,17 @@ impl BuiltinCommand for HookInitCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/hook/uuid.rs
+++ b/src/internal/commands/builtin/hook/uuid.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 use uuid::Uuid;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::config::CommandSyntax;
 
 #[derive(Debug, Clone)]
@@ -54,11 +55,16 @@ impl BuiltinCommand for HookUuidCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        false
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        Err(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Ok(())
     }
 }

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -177,6 +177,7 @@ impl BuiltinCommand for ScopeCommand {
                         .to_string(),
                     ),
                     required: true,
+                    arg_type: SyntaxOptArgType::RepoPath,
                     ..Default::default()
                 },
                 SyntaxOptArg {
@@ -237,7 +238,7 @@ impl BuiltinCommand for ScopeCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO: convert to partial
+        // TODO: convert to partial so the autocompletion work for options too
         CommandAutocompletion::Full
     }
 

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -249,7 +249,7 @@ impl BuiltinCommand for ScopeCommand {
     ) -> Result<(), ()> {
         match comp_cword.cmp(&0) {
             std::cmp::Ordering::Equal => {
-                let repo = argv.get(0).map_or("", String::as_str);
+                let repo = argv.first().map_or("", String::as_str);
                 path_auto_complete(repo, true)
                     .iter()
                     .for_each(|s| println!("{}", s));

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::process::exit;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::command_loader;
 use crate::internal::commands::Command;
 use crate::internal::config::parser::ParseArgsValue;
@@ -280,11 +281,17 @@ impl BuiltinCommand for ScopeCommand {
         exit(1);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        // TODO: convert to partial
+        CommandAutocompletion::Full
     }
 
-    fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+    fn autocomplete(
+        &self,
+        comp_cword: usize,
+        argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         match comp_cword.cmp(&0) {
             std::cmp::Ordering::Equal => {
                 let repo = if !argv.is_empty() {

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -250,7 +250,7 @@ impl BuiltinCommand for ScopeCommand {
         match comp_cword.cmp(&0) {
             std::cmp::Ordering::Equal => {
                 let repo = argv.first().map_or("", String::as_str);
-                path_auto_complete(repo, true)
+                path_auto_complete(repo, true, false)
                     .iter()
                     .for_each(|s| println!("{}", s));
                 Ok(())

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 
 use crate::internal::cache::utils::Empty;
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::path::omnipath_entries;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
@@ -390,24 +391,16 @@ impl BuiltinCommand for StatusCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
-        for arg in &[
-            "--shell-integration",
-            "--config",
-            "--config-files",
-            "--worktree",
-            "--orgs",
-            "--path",
-        ] {
-            if !argv.contains(&arg.to_string()) {
-                println!("{}", arg);
-            }
-        }
-
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         Ok(())
     }
 }

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -250,7 +250,7 @@ impl BuiltinCommand for TidyCommand {
                         )
                         .to_string(),
                     ),
-                    arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::Path)),
+                    arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::DirPath)),
                     ..Default::default()
                 },
                 SyntaxOptArg {

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -12,6 +12,7 @@ use walkdir::WalkDir;
 
 use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::base::CommandAutocompletion;
+use crate::internal::commands::builtin::UpCommand;
 use crate::internal::commands::path::global_omnipath_entries;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::commands::Command;
@@ -505,15 +506,30 @@ impl BuiltinCommand for TidyCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
+        CommandAutocompletion::Partial
     }
 
     fn autocomplete(
         &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
+        comp_cword: usize,
+        argv: Vec<String>,
+        parameter: Option<String>,
     ) -> Result<(), ()> {
+        if parameter.unwrap_or_default() == "up args" {
+            // Get the position of the `--` argument
+            let up_args_start = match argv.iter().position(|arg| arg == "--") {
+                Some(pos) => pos + 1,
+                None => return Ok(()),
+            };
+
+            // Compute the new comp_cword for the up command
+            let comp_cword = comp_cword - up_args_start;
+
+            // Let's use the autocompletion of the up command
+            let up_command = UpCommand::new_command();
+            return up_command.autocomplete(comp_cword, argv[up_args_start..].to_vec());
+        }
+
         Ok(())
     }
 }

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -249,7 +249,7 @@ impl BuiltinCommand for TidyCommand {
                         )
                         .to_string(),
                     ),
-                    arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::String)),
+                    arg_type: SyntaxOptArgType::Array(Box::new(SyntaxOptArgType::Path)),
                     ..Default::default()
                 },
                 SyntaxOptArg {

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -11,6 +11,7 @@ use indicatif::ProgressStyle;
 use walkdir::WalkDir;
 
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::path::global_omnipath_entries;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::commands::Command;
@@ -503,20 +504,16 @@ impl BuiltinCommand for TidyCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        // TODO: if the last parameter before completion is `search-path`,
-        // TODO: we should autocomplete with the file system paths
-        println!("--search-path");
-        println!("-y");
-        println!("--yes");
-        println!("--up-all");
-        println!("-h");
-        println!("--help");
-
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
         Ok(())
     }
 }

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -21,6 +21,7 @@ use crate::internal::cache::utils::Empty;
 use crate::internal::cache::PromptsCache;
 use crate::internal::cache::WorkdirsCache;
 use crate::internal::commands::base::BuiltinCommand;
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
 use crate::internal::config::flush_config;
@@ -1658,23 +1659,17 @@ impl BuiltinCommand for UpCommand {
         );
     }
 
-    fn autocompletion(&self) -> bool {
-        true
+    fn autocompletion(&self) -> CommandAutocompletion {
+        CommandAutocompletion::Null
     }
 
-    fn autocomplete(&self, _comp_cword: usize, _argv: Vec<String>) -> Result<(), ()> {
-        println!("--bootstrap");
-        println!("--clone-suggested");
-        println!("--fail-on-upgrade");
-        println!("--no-cache");
-        println!("--prompt");
-        println!("--prompt-all");
-        println!("--trust");
-        println!("--update-repository");
-        println!("--update-user-config");
-        println!("--upgrade");
-
-        Ok(())
+    fn autocomplete(
+        &self,
+        _comp_cword: usize,
+        _argv: Vec<String>,
+        _parameter: Option<String>,
+    ) -> Result<(), ()> {
+        Err(())
     }
 }
 

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -1234,7 +1234,10 @@ mod tests {
             let details = details.unwrap();
             assert_eq!(details.category, None);
             assert_eq!(details.help, None);
-            assert!(!details.autocompletion);
+            assert!(matches!(
+                details.autocompletion,
+                CommandAutocompletion::Null
+            ));
             assert_eq!(details.syntax, None);
             assert!(!details.sync_update);
         }
@@ -2717,7 +2720,10 @@ mod tests {
                 Some(vec!["test cat".to_string(), "more cat".to_string()])
             );
             assert_eq!(details.help, Some("test help\nmore help".to_string()));
-            assert!(details.autocompletion);
+            assert!(matches!(
+                details.autocompletion,
+                CommandAutocompletion::Full
+            ));
             assert!(details.argparser);
             assert!(!details.sync_update);
             assert!(details.syntax.is_some(), "Syntax is not present");

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use serde_yaml::Value as YamlValue;
 use walkdir::WalkDir;
 
+use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::path::omnipath;
 use crate::internal::commands::utils::str_to_bool;
 use crate::internal::commands::utils::SplitOnSeparators;
@@ -285,10 +286,10 @@ impl PathCommand {
         panic!("Something went wrong: {:?}", err);
     }
 
-    pub fn autocompletion(&self) -> bool {
+    pub fn autocompletion(&self) -> CommandAutocompletion {
         self.file_details()
             .map(|details| details.autocompletion)
-            .unwrap_or(false)
+            .unwrap_or(CommandAutocompletion::Null)
     }
 
     pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
@@ -331,7 +332,7 @@ impl PathCommand {
 pub struct PathCommandFileDetails {
     category: Option<Vec<String>>,
     help: Option<String>,
-    autocompletion: bool,
+    autocompletion: CommandAutocompletion,
     syntax: Option<CommandSyntax>,
     tags: BTreeMap<String, String>,
     sync_update: bool,
@@ -358,21 +359,27 @@ impl<'de> PathCommandFileDetails {
         let mut value = YamlValue::deserialize(deserializer)?;
 
         if let YamlValue::Mapping(ref mut map) = value {
-            // Deserialize the booleans
-            let autocompletion = map
+            // Deserialize the autocompletion field, which can be either a
+            // boolean or a string representing a boolean or 'partial'
+            // The result is stored as a CommandAutocompletion enum
+            // where 'true' is Full, 'partial' is Partial, and 'false' is Null
+            let autocompletion: CommandAutocompletion = map
                 .remove(YamlValue::String("autocompletion".to_string()))
-                .is_some_and(|v| match bool::deserialize(v.clone()) {
-                    Ok(b) => b,
-                    Err(_err) => {
+                .map_or(CommandAutocompletion::Null, |v| match v {
+                    YamlValue::Bool(b) => CommandAutocompletion::from(b),
+                    YamlValue::String(s) => CommandAutocompletion::from(s),
+                    _ => {
                         error_handler
                             .with_key("autocompletion")
-                            .with_expected("boolean")
+                            .with_expected(vec!["boolean", "string"])
                             .with_actual(v.to_owned())
                             .error(ConfigErrorKind::InvalidValueType);
 
-                        false
+                        CommandAutocompletion::Null
                     }
                 });
+
+            // Deserialize the booleans
             let sync_update = map
                 .remove(YamlValue::String("sync_update".to_string()))
                 .is_some_and(|v| match bool::deserialize(v.clone()) {
@@ -867,7 +874,7 @@ impl PathCommandFileDetails {
         reader: &mut R,
         error_handler: &ConfigErrorHandler,
     ) -> Option<Self> {
-        let mut autocompletion = false;
+        let mut autocompletion = CommandAutocompletion::Null;
         let mut sync_update = false;
         let mut argparser = false;
         let mut category: Option<Vec<String>> = None;
@@ -962,7 +969,8 @@ impl PathCommandFileDetails {
                 ("autocompletion", None, value) => {
                     key_tracker.handle_seen_key(&key, lineno, false, error_handler);
                     autocompletion = match str_to_bool(&value) {
-                        Some(b) => b,
+                        Some(b) => CommandAutocompletion::from(b),
+                        None if value.to_lowercase() == "partial" => CommandAutocompletion::Partial,
                         None => {
                             error_handler
                                 .with_lineno(lineno)
@@ -971,7 +979,7 @@ impl PathCommandFileDetails {
                                 .with_expected("boolean")
                                 .error(ConfigErrorKind::MetadataHeaderInvalidValueType);
 
-                            false
+                            CommandAutocompletion::Null
                         }
                     };
                 }
@@ -1365,7 +1373,27 @@ mod tests {
             assert!(details.is_some());
             let details = details.unwrap();
 
-            assert!(details.autocompletion);
+            assert!(matches!(
+                details.autocompletion,
+                CommandAutocompletion::Full
+            ));
+        }
+
+        #[test]
+        fn autocompletion_partial() {
+            let mut reader = BufReader::new("# autocompletion: partial\n".as_bytes());
+            let details = PathCommandFileDetails::from_source_file_header(
+                &mut reader,
+                &ConfigErrorHandler::noop(),
+            );
+
+            assert!(details.is_some());
+            let details = details.unwrap();
+
+            assert!(matches!(
+                details.autocompletion,
+                CommandAutocompletion::Partial
+            ));
         }
 
         #[test]
@@ -1379,7 +1407,10 @@ mod tests {
             assert!(details.is_some());
             let details = details.unwrap();
 
-            assert!(!details.autocompletion);
+            assert!(matches!(
+                details.autocompletion,
+                CommandAutocompletion::Null
+            ));
         }
 
         #[test]

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -292,11 +292,19 @@ impl PathCommand {
             .unwrap_or(CommandAutocompletion::Null)
     }
 
-    pub fn autocomplete(&self, comp_cword: usize, argv: Vec<String>) -> Result<(), ()> {
+    pub fn autocomplete(
+        &self,
+        comp_cword: usize,
+        argv: Vec<String>,
+        parameter: Option<String>,
+    ) -> Result<(), ()> {
         let mut command = ProcessCommand::new(self.source.clone());
         command.arg("--complete");
         command.args(argv);
         command.env("COMP_CWORD", comp_cword.to_string());
+        if let Some(parameter) = parameter {
+            command.env("OMNI_COMP_VALUE_OF", parameter);
+        }
 
         match command.output() {
             Ok(output) => {

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -252,7 +252,7 @@ impl CommandLoader {
                 .into_iter()
                 .find(|x| x.match_level == match_pos as f32 && x.match_name.len() == match_pos)
             {
-                if parent_command.command.autocompletion() {
+                if parent_command.command.autocompletion().into() {
                     // Set the environment variables that we need to pass to the
                     // subcommand
                     let new_comp_cword = comp_cword - parent_command.match_level as usize;
@@ -299,7 +299,7 @@ impl CommandLoader {
                 }
             }
 
-            if matched_command.command.autocompletion() {
+            if matched_command.command.autocompletion().into() {
                 // Set the environment variables that we need to pass to the
                 // subcommand
                 let new_comp_cword = comp_cword - matched_command.match_level as usize;

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -229,7 +229,7 @@ pub fn path_auto_complete(value: &str, include_repositories: bool) -> BTreeSet<S
     // Get all the repositories per org that match the value
     if include_repositories && !path_only {
         let add_space = if Shell::current().is_fish() { " " } else { "" };
-        for match_value in ORG_LOADER.complete(&value) {
+        for match_value in ORG_LOADER.complete(value) {
             completions.insert(format!("{}{}", match_value, add_space));
         }
     }

--- a/src/internal/commands/utils.rs
+++ b/src/internal/commands/utils.rs
@@ -5,7 +5,6 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
-use normalize_path::NormalizePath;
 use path_clean::PathClean;
 use requestty::question::completions;
 use requestty::question::Completions;
@@ -21,7 +20,7 @@ pub fn split_name(string: &str, split_on: &str) -> Vec<String> {
 
 pub fn abs_or_rel_path(path: &str) -> String {
     let current_dir = std::env::current_dir().unwrap();
-    let path = std::path::PathBuf::from(&path).normalize();
+    let path = std::path::PathBuf::from(&path).clean();
     let path = if path.is_absolute() {
         path
     } else {
@@ -56,7 +55,7 @@ pub fn abs_path_from_path<T>(path: T, frompath: Option<T>) -> PathBuf
 where
     T: AsRef<Path>,
 {
-    let path = path.as_ref().normalize();
+    let path = path.as_ref();
 
     let absolute_path = if path.is_absolute() {
         path.to_path_buf()

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -1170,6 +1170,10 @@ impl SyntaxOptArg {
         self.last_arg_double_hyphen
     }
 
+    pub fn is_repeatable(&self) -> bool {
+        self.arg_type().is_array() || matches!(self.arg_type(), SyntaxOptArgType::Counter)
+    }
+
     pub fn takes_value(&self) -> bool {
         if matches!(
             self.arg_type(),
@@ -2125,13 +2129,23 @@ impl SyntaxOptArgNumValues {
         }
     }
 
-    fn max(&self) -> Option<usize> {
+    pub fn max(&self) -> Option<usize> {
         match self {
             Self::Any => None,
             Self::Exactly(value) => Some(*value),
             Self::AtLeast(_min) => None,
             Self::AtMost(max) => Some(*max),
             Self::Between(_min, max) => Some(*max),
+        }
+    }
+
+    pub fn min(&self) -> Option<usize> {
+        match self {
+            Self::Any => None,
+            Self::Exactly(value) => Some(*value),
+            Self::AtLeast(min) => Some(*min),
+            Self::AtMost(_max) => None,
+            Self::Between(min, _max) => Some(*min),
         }
     }
 }

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -1877,6 +1877,13 @@ impl<T: Into<ParseArgsValue> + Clone + FromStr + Send + Sync + 'static> ParserEx
     }
 }
 
+/// A function that can transform a value into another value of the same type
+type TransformFn<T> = fn(Option<T>) -> Result<Option<T>, ParseArgsErrorKind>;
+
+/// Extracts a value from the matches and inserts it into the args map
+/// The value is extracted based on the type of the argument and the number of values
+/// The value is then transformed if a transform function is provided
+/// The value is then inserted into the args map with the correct destination
 #[allow(clippy::too_many_arguments)]
 #[inline]
 fn extract_value_to_typed<T>(
@@ -1888,7 +1895,7 @@ fn extract_value_to_typed<T>(
     has_occurrences: bool,
     has_multi: bool,
     group_occurrences: bool,
-    transform_fn: Option<fn(Option<T>) -> Result<Option<T>, ParseArgsErrorKind>>,
+    transform_fn: Option<TransformFn<T>>,
 ) -> Result<(), ParseArgsErrorKind>
 where
     T: Into<ParseArgsValue> + Clone + Send + Sync + FromStr + 'static,

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -1686,6 +1686,12 @@ impl SyntaxOptArg {
                     has_multi,
                     self.group_occurrences,
                 );
+
+                // TODO: for Path, FilePath and RepoPath, we should
+                // add a conversion of the value to an actual path and
+                // erroring out in case of issue, so that we allow all
+                // underlying command to take advantage of those types
+                // without having to handle parsing themselves
             }
             SyntaxOptArgType::Integer => {
                 extract_value_to_typed::<i64>(

--- a/src/internal/config/parser/errors.rs
+++ b/src/internal/config/parser/errors.rs
@@ -823,14 +823,15 @@ impl ConfigErrorKind {
 pub enum ParseArgsErrorKind {
     ParserBuildError(String),
     ArgumentParsingError(clap::Error),
+    InvalidValue(String),
 }
 
 impl ParseArgsErrorKind {
     #[cfg(test)]
     pub fn simple(&self) -> String {
         match self {
-            ParseArgsErrorKind::ParserBuildError(e) => e.clone(),
-            ParseArgsErrorKind::ArgumentParsingError(e) => {
+            Self::ParserBuildError(e) => e.clone(),
+            Self::ArgumentParsingError(e) => {
                 // Return the first block until the first empty line
                 let err_str = e
                     .to_string()
@@ -842,6 +843,7 @@ impl ParseArgsErrorKind {
                 let err_str = err_str.trim_start_matches("error: ");
                 err_str.to_string()
             }
+            Self::InvalidValue(e) => e.clone(),
         }
     }
 }
@@ -849,13 +851,11 @@ impl ParseArgsErrorKind {
 impl PartialEq for ParseArgsErrorKind {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (ParseArgsErrorKind::ParserBuildError(a), ParseArgsErrorKind::ParserBuildError(b)) => {
-                a == b
+            (Self::ParserBuildError(a), Self::ParserBuildError(b)) => a == b,
+            (Self::ArgumentParsingError(a), Self::ArgumentParsingError(b)) => {
+                a.to_string() == b.to_string()
             }
-            (
-                ParseArgsErrorKind::ArgumentParsingError(a),
-                ParseArgsErrorKind::ArgumentParsingError(b),
-            ) => a.to_string() == b.to_string(),
+            (Self::InvalidValue(a), Self::InvalidValue(b)) => a == b,
             _ => false,
         }
     }
@@ -864,8 +864,9 @@ impl PartialEq for ParseArgsErrorKind {
 impl fmt::Display for ParseArgsErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseArgsErrorKind::ParserBuildError(e) => write!(f, "{}", e),
-            ParseArgsErrorKind::ArgumentParsingError(e) => write!(f, "{}", e),
+            Self::ParserBuildError(e) => write!(f, "{}", e),
+            Self::ArgumentParsingError(e) => write!(f, "{}", e),
+            Self::InvalidValue(e) => write!(f, "{}", e),
         }
     }
 }


### PR DESCRIPTION
When a command enables the `argparser`, omni will now provide automatically `autocompletion` for that command using the information that was provided to configure the `argparser`. This means that we can auto-complete enum values for instance, as well as all parameters.

New argument types are introduced as `dir`, `file` and `repopath` allowing to respectively auto-complete directories, files and repository paths. When using those types, the value passed to the command will be an absolute path.

Commands that have auto-completion enabled (`true`) will skip the argparser auto-completion. There is also a new `partial` auto-completion that is available when the argparser is configured, if the command provider wants to offer extended auto-completion for the values of specific parameters. The `partial` auto-completion will callout to the underlying, trusted, command if and only if a _value_ should be auto-completed for the current cursor position.

Closes https://github.com/xaf/omni/issues/854