### PR TITLE
feat(`packages`): ✨ make git updates more aggressive

### DIFF
--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -1084,17 +1084,8 @@ impl UpCommand {
             return true;
         }
 
-        let git_env = git_env(".");
-        let repo_id = match git_env.id() {
-            Some(repo_id) => repo_id,
-            None => {
-                omni_error!("Unable to get repository id");
-                exit(1);
-            }
-        };
-
-        let config = config(".");
-        let updated = config.path_repo_updates.update(&repo_id);
+        let config = global_config();
+        let updated = config.path_repo_updates.update(".");
 
         if updated {
             flush_config(".");

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -52,6 +52,7 @@ use crate::internal::git::format_path_with_template;
 use crate::internal::git::package_path_from_git_url;
 use crate::internal::git::path_entry_config;
 use crate::internal::git::safe_git_url_parse;
+use crate::internal::git::GitRepoUpdater;
 use crate::internal::git::ORG_LOADER;
 use crate::internal::git_env;
 use crate::internal::git_env_fresh;
@@ -1084,8 +1085,12 @@ impl UpCommand {
             return true;
         }
 
-        let config = global_config();
-        let updated = config.path_repo_updates.update(".");
+        let updater = match GitRepoUpdater::from_path(".") {
+            Some(updater) => updater,
+            None => return false,
+        };
+
+        let updated = updater.update(None).unwrap_or(false);
 
         if updated {
             flush_config(".");

--- a/src/internal/config/parser/mod.rs
+++ b/src/internal/config/parser/mod.rs
@@ -45,6 +45,7 @@ pub(crate) use errors::ParseArgsErrorKind;
 mod github;
 pub(crate) use github::GithubAuthConfig;
 pub(crate) use github::GithubConfig;
+pub(crate) use github::StringFilter;
 
 mod makefile_commands;
 pub(crate) use makefile_commands::MakefileCommandsConfig;

--- a/src/internal/config/parser/path_repo_updates.rs
+++ b/src/internal/config/parser/path_repo_updates.rs
@@ -1,14 +1,13 @@
-use std::collections::HashMap;
-
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::config::parser::ConfigErrorHandler;
 use crate::internal::config::parser::ConfigErrorKind;
+use crate::internal::config::parser::StringFilter;
 use crate::internal::config::utils::parse_duration_or_default;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::shell_is_interactive;
-use crate::internal::git::update_git_repo;
+use crate::internal::git::GitRepoUpdater;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PathRepoUpdatesConfig {
@@ -21,10 +20,10 @@ pub struct PathRepoUpdatesConfig {
     pub background_updates_timeout: u64,
     pub interval: u64,
     pub ref_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ref_match: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub per_repo_config: HashMap<String, PathRepoUpdatesPerRepoConfig>,
+    #[serde(skip_serializing_if = "StringFilter::is_default")]
+    pub ref_match: StringFilter,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub per_repo_config: Vec<PathRepoUpdatesPerRepoConfig>,
 }
 
 impl Default for PathRepoUpdatesConfig {
@@ -39,8 +38,8 @@ impl Default for PathRepoUpdatesConfig {
             background_updates_timeout: Self::DEFAULT_BACKGROUND_UPDATES_TIMEOUT,
             interval: Self::DEFAULT_INTERVAL,
             ref_type: Self::DEFAULT_REF_TYPE.to_string(),
-            ref_match: None,
-            per_repo_config: HashMap::new(),
+            ref_match: StringFilter::default(),
+            per_repo_config: Vec::new(),
         }
     }
 }
@@ -63,16 +62,33 @@ impl PathRepoUpdatesConfig {
             None => return Self::default(),
         };
 
-        let mut per_repo_config = HashMap::new();
+        let mut per_repo_config = Vec::new();
         if let Some(value) = config_value.get("per_repo_config") {
-            for (key, value) in value.as_table().unwrap() {
-                per_repo_config.insert(
-                    key.to_string(),
-                    PathRepoUpdatesPerRepoConfig::from_config_value(
+            // This can be either a table (old format) or a list (new format)
+            // In the case it's a table, we need to extract the repository id from the key
+
+            if let Some(array) = value.as_array() {
+                for (index, value) in array.iter().enumerate() {
+                    per_repo_config.push(PathRepoUpdatesPerRepoConfig::from_config_value(
+                        value,
+                        &error_handler.with_key("per_repo_config").with_index(index),
+                        None,
+                    ));
+                }
+            } else if let Some(table) = value.as_table() {
+                for (key, value) in table {
+                    per_repo_config.push(PathRepoUpdatesPerRepoConfig::from_config_value(
                         &value,
-                        &error_handler.with_key("per_repo_config").with_key(key),
-                    ),
-                );
+                        &error_handler.with_key("per_repo_config").with_key(&key),
+                        Some(key.to_string()),
+                    ));
+                }
+            } else {
+                error_handler
+                    .with_key("per_repo_config")
+                    .with_expected(vec!["array", "table"])
+                    .with_actual(value)
+                    .error(ConfigErrorKind::InvalidValueType);
             }
         };
 
@@ -150,21 +166,10 @@ impl PathRepoUpdatesConfig {
             Self::DEFAULT_REF_TYPE.to_string()
         };
 
-        let ref_match = if let Some(value) = config_value.get("ref_match") {
-            if let Some(value) = value.as_str() {
-                Some(value.to_string())
-            } else {
-                error_handler
-                    .with_key("ref_match")
-                    .with_expected("string")
-                    .with_actual(value)
-                    .error(ConfigErrorKind::InvalidValueType);
-
-                None
-            }
-        } else {
-            None
-        };
+        let ref_match = StringFilter::from_config_value(
+            config_value.get("ref_match"),
+            &error_handler.with_key("ref_match"),
+        );
 
         Self {
             enabled: config_value.get_as_bool_or_default(
@@ -193,25 +198,11 @@ impl PathRepoUpdatesConfig {
         }
     }
 
-    pub fn update_config(&self, repo_id: &str) -> (bool, String, Option<String>) {
-        match self.per_repo_config.get(repo_id) {
-            Some(value) => (
-                value.enabled,
-                value.ref_type.clone(),
-                value.ref_match.clone(),
-            ),
-            None => (self.enabled, self.ref_type.clone(), self.ref_match.clone()),
+    pub fn update(&self, path: &str) -> bool {
+        match GitRepoUpdater::from_path(path) {
+            Some(updater) => updater.update(None).unwrap_or(false),
+            None => false,
         }
-    }
-
-    pub fn update(&self, repo_id: &str) -> bool {
-        let (enabled, ref_type, ref_match) = self.update_config(repo_id);
-
-        if !enabled {
-            return false;
-        }
-
-        update_git_repo(repo_id, ref_type, ref_match, None, None).unwrap_or(false)
     }
 }
 
@@ -330,17 +321,29 @@ impl PathRepoUpdatesOnCommandNotFoundEnum {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PathRepoUpdatesPerRepoConfig {
+    pub workdir_id: StringFilter,
     pub enabled: bool,
     pub ref_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ref_match: Option<String>,
+    #[serde(skip_serializing_if = "StringFilter::is_default")]
+    pub ref_match: StringFilter,
 }
 
 impl PathRepoUpdatesPerRepoConfig {
     pub(super) fn from_config_value(
         config_value: &ConfigValue,
         error_handler: &ConfigErrorHandler,
+        workdir_id: Option<String>,
     ) -> Self {
+        let workdir_id = if let Some(wdid) = workdir_id {
+            // If the workdir id is provided in the function call, use it as exact match
+            StringFilter::Exact(wdid)
+        } else {
+            StringFilter::from_config_value(
+                config_value.get("workdir_id"),
+                &error_handler.with_key("workdir_id"),
+            )
+        };
+
         let enabled = config_value.get_as_bool_or_default(
             "enabled",
             true,
@@ -353,10 +356,13 @@ impl PathRepoUpdatesPerRepoConfig {
             &error_handler.with_key("ref_type"),
         );
 
-        let ref_match =
-            config_value.get_as_str_or_none("ref_match", &error_handler.with_key("ref_match"));
+        let ref_match = StringFilter::from_config_value(
+            config_value.get("ref_match"),
+            &error_handler.with_key("ref_match"),
+        );
 
         Self {
+            workdir_id,
             enabled,
             ref_type,
             ref_match,

--- a/src/internal/config/parser/path_repo_updates.rs
+++ b/src/internal/config/parser/path_repo_updates.rs
@@ -7,7 +7,6 @@ use crate::internal::config::parser::StringFilter;
 use crate::internal::config::utils::parse_duration_or_default;
 use crate::internal::config::ConfigValue;
 use crate::internal::env::shell_is_interactive;
-use crate::internal::git::GitRepoUpdater;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PathRepoUpdatesConfig {
@@ -195,13 +194,6 @@ impl PathRepoUpdatesConfig {
             ref_type,
             ref_match,
             per_repo_config,
-        }
-    }
-
-    pub fn update(&self, path: &str) -> bool {
-        match GitRepoUpdater::from_path(path) {
-            Some(updater) => updater.update(None).unwrap_or(false),
-            None => false,
         }
     }
 }

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -21,4 +21,4 @@ pub(crate) use updater::auto_update_on_command_not_found;
 pub(crate) use updater::exec_update;
 pub(crate) use updater::exec_update_and_log_on_error;
 pub(crate) use updater::report_update_error;
-pub(crate) use updater::update_git_repo;
+pub(crate) use updater::GitRepoUpdater;

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -19,6 +19,8 @@ use crate::internal::cache::OmniPathCache;
 use crate::internal::commands::base::Command;
 use crate::internal::commands::path::global_omnipath_entries;
 use crate::internal::config::global_config;
+use crate::internal::config::parser::PathEntryConfig;
+use crate::internal::config::parser::StringFilter;
 use crate::internal::config::up::utils::get_command_output;
 use crate::internal::config::up::utils::run_command_with_handler;
 use crate::internal::config::up::utils::PrintProgressHandler;
@@ -35,6 +37,7 @@ use crate::internal::git_env_flush_cache;
 use crate::internal::self_update;
 use crate::internal::user_interface::ensure_newline;
 use crate::internal::user_interface::StringColor;
+use crate::internal::workdir;
 use crate::omni_error;
 use crate::omni_info;
 use crate::omni_print;
@@ -492,13 +495,11 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
                 continue;
             }
 
-            // Get the configuration for that repository
-            let (enabled, ref_type, ref_match) = config.path_repo_updates.update_config(&repo_id);
-
-            if !enabled {
-                // Skipping repository if updates are not enabled for it
-                continue;
-            }
+            // Get the updater for that repository
+            let updater = match GitRepoUpdater::from_path(&path) {
+                Some(updater) => updater,
+                None => continue,
+            };
 
             let desc = format!(
                 "Updating {} {}:",
@@ -523,13 +524,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
             let _multiprogress = multiprogress.clone();
             let sender = sender.clone();
             threads.push(thread::spawn(move || {
-                let result = update_git_repo(
-                    &repo_id,
-                    ref_type,
-                    ref_match,
-                    Some(&repo_root.clone()),
-                    Some(progress_handler.as_ref()),
-                );
+                let result = updater.update(Some(progress_handler.as_ref()));
 
                 sender.send((repo_root, result)).unwrap();
             }));
@@ -574,7 +569,7 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
                     location,
                 ));
 
-                let mut omni_up_command = std::process::Command::new(current_exe.clone());
+                let mut omni_up_command = StdCommand::new(current_exe.clone());
                 omni_up_command.arg("up");
                 omni_up_command.current_dir(repo_path);
                 omni_up_command.env_remove("OMNI_FORCE_UPDATE");
@@ -684,197 +679,355 @@ pub fn update(options: &UpdateOptions) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
     (updated_paths, errored_paths)
 }
 
-pub fn update_git_repo(
-    repo_id: &str,
-    ref_type: String,
-    ref_match: Option<String>,
-    repo_path: Option<&str>,
-    progress_handler: Option<&dyn ProgressHandler>,
-) -> Result<bool, String> {
-    let desc = format!("Updating {}:", repo_id.italic().light_cyan()).light_blue();
-    let spinner;
-    let printer;
+pub enum GitRepoUpdaterRefType {
+    Branch,
+    Tag,
+}
 
-    let progress_handler: Box<&dyn ProgressHandler> =
-        if let Some(progress_handler) = progress_handler {
-            Box::new(progress_handler)
-        } else if shell_is_interactive() {
-            spinner = SpinnerProgressHandler::new(desc, None);
-            Box::new(&spinner)
-        } else {
-            printer = PrintProgressHandler::new(desc, None);
-            Box::new(&printer)
-        };
+impl GitRepoUpdaterRefType {
+    fn from_ref_type(ref_type: &str) -> Self {
+        match ref_type {
+            "branch" => Self::Branch,
+            "tag" => Self::Tag,
+            _ => unreachable!("invalid ref type: {}", ref_type),
+        }
+    }
 
-    match ref_type.as_str() {
-        "branch" => update_git_branch(repo_id, ref_match, repo_path, Some(*progress_handler)),
-        "tag" => update_git_tag(repo_id, ref_match, repo_path, Some(*progress_handler)),
-        _ => {
-            let msg = format!("invalid ref type: {}", ref_type);
-            progress_handler.error_with_message(msg.clone());
-            Err(msg)
+    fn update(
+        &self,
+        repo_path: &str,
+        ref_match: StringFilter,
+        progress_handler: &dyn ProgressHandler,
+    ) -> Result<bool, String> {
+        match self {
+            Self::Branch => update_git_branch(repo_path, ref_match, progress_handler),
+            Self::Tag => update_git_tag(repo_path, ref_match, progress_handler),
         }
     }
 }
 
-fn update_git_branch(
-    repo_id: &str,
-    ref_match: Option<String>,
-    repo_path: Option<&str>,
-    progress_handler: Option<&dyn ProgressHandler>,
-) -> Result<bool, String> {
-    let desc = format!("Updating {}:", repo_id.italic().light_cyan()).light_blue();
-    let spinner;
-    let printer;
+pub struct GitRepoUpdater {
+    repo_id: String,
+    path: String,
+    ref_type: GitRepoUpdaterRefType,
+    pattern: StringFilter,
+}
 
-    let progress_handler: Box<&dyn ProgressHandler> =
-        if let Some(progress_handler) = progress_handler {
-            Box::new(progress_handler)
-        } else if shell_is_interactive() {
-            spinner = SpinnerProgressHandler::new(desc, None);
-            Box::new(&spinner)
-        } else {
-            printer = PrintProgressHandler::new(desc, None);
-            Box::new(&printer)
+impl GitRepoUpdater {
+    pub fn from_path<T: AsRef<str>>(path: T) -> Option<Self> {
+        let config = global_config();
+        let prucfg = config.path_repo_updates;
+
+        let wd = workdir(path);
+        let wd_root = wd.root()?;
+        if !wd.in_git() {
+            return None;
+        }
+
+        let (clean_id, typed_id) = match (wd.trust_id(), wd.typed_id()) {
+            (Some(clean_id), Some(typed_id)) => (clean_id, typed_id),
+            _ => return None,
         };
 
+        for value in &prucfg.per_repo_config {
+            if value.workdir_id.matches(&clean_id) || value.workdir_id.matches(&typed_id) {
+                if !value.enabled {
+                    return None;
+                }
+
+                return Some(Self {
+                    repo_id: clean_id.to_string(),
+                    path: wd_root.to_string(),
+                    ref_type: GitRepoUpdaterRefType::from_ref_type(&value.ref_type),
+                    pattern: value.ref_match.clone(),
+                });
+            }
+        }
+
+        if !prucfg.enabled {
+            return None;
+        }
+
+        Some(Self {
+            repo_id: clean_id.to_string(),
+            path: wd_root.to_string(),
+            ref_type: GitRepoUpdaterRefType::from_ref_type(&prucfg.ref_type),
+            pattern: prucfg.ref_match.clone(),
+        })
+    }
+
+    pub fn update(&self, progress_handler: Option<&dyn ProgressHandler>) -> Result<bool, String> {
+        let desc = format!("Updating {}:", self.repo_id.italic().light_cyan()).light_blue();
+        let spinner;
+        let printer;
+
+        let progress_handler: Box<&dyn ProgressHandler> =
+            if let Some(progress_handler) = progress_handler {
+                Box::new(progress_handler)
+            } else if shell_is_interactive() {
+                spinner = SpinnerProgressHandler::new(desc, None);
+                Box::new(&spinner)
+            } else {
+                printer = PrintProgressHandler::new(desc, None);
+                Box::new(&printer)
+            };
+
+        self.ref_type
+            .update(&self.path, self.pattern.clone(), *progress_handler)
+    }
+}
+
+fn update_git_branch(
+    repo_path: &str,
+    ref_match: StringFilter,
+    progress_handler: &dyn ProgressHandler,
+) -> Result<bool, String> {
     progress_handler.progress("checking current branch".to_string());
 
     // Check if the currently checked out branch matches the one we want to update
-    let mut git_branch_cmd = std::process::Command::new("git");
-    if let Some(repo_path) = repo_path {
-        git_branch_cmd.current_dir(repo_path);
-    }
-    git_branch_cmd.arg("branch");
-    git_branch_cmd.arg("--show-current");
-    git_branch_cmd.stdout(std::process::Stdio::piped());
-    git_branch_cmd.stderr(std::process::Stdio::null());
+    let mut local_branch_cmd = StdCommand::new("git");
+    local_branch_cmd.arg("branch");
+    local_branch_cmd.arg("--show-current");
+    local_branch_cmd.current_dir(repo_path);
+    local_branch_cmd.stdout(std::process::Stdio::piped());
+    local_branch_cmd.stderr(std::process::Stdio::null());
 
-    let output = git_branch_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let output = local_branch_cmd.output().map_err(|err| {
+        let msg = format!("git branch failed: {}", err);
+        progress_handler.error_with_message(msg.clone());
+        msg
+    })?;
+
+    if !output.status.success() {
         let msg = "git branch failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
-    let git_branch = String::from_utf8(output.unwrap().stdout)
-        .unwrap()
-        .trim()
-        .to_string();
-    if git_branch.is_empty() {
+
+    let local_branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if local_branch.is_empty() {
         let msg = "not currently checked out on a branch; skipping update".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
 
-    let regex = match ref_match {
-        Some(ref ref_match) => regex::Regex::new(ref_match),
-        None => regex::Regex::new(".*"),
-    };
-    if regex.is_err() {
-        let msg = format!("invalid ref match: {}", ref_match.unwrap());
-        progress_handler.error_with_message(msg.clone());
-        return Err(msg);
-    }
-
-    if !regex.unwrap().is_match(&git_branch) {
+    if !ref_match.matches(&local_branch) {
         let msg = format!(
             "current branch {} does not match {}; skipping update",
-            git_branch,
-            ref_match.unwrap()
+            local_branch, ref_match,
         );
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
 
-    progress_handler.progress("pulling latest changes".to_string());
+    let is_package = PathEntryConfig::from_path(repo_path).is_package();
+    if is_package {
+        // If we're on a package, we can be aggressive on the update
+        // since we are the ones managing the repository
 
-    let mut git_pull_cmd = TokioCommand::new("git");
-    if let Some(repo_path) = repo_path {
-        git_pull_cmd.current_dir(repo_path);
-    }
-    git_pull_cmd.arg("pull");
-    git_pull_cmd.arg("--ff-only");
-    git_pull_cmd.stdout(std::process::Stdio::piped());
-    git_pull_cmd.stderr(std::process::Stdio::piped());
+        // Get the remote name we are tracking
+        let mut remote_name_cmd = StdCommand::new("git");
+        remote_name_cmd.arg("config");
+        remote_name_cmd.arg("--get");
+        remote_name_cmd.arg(format!("branch.{}.remote", local_branch));
+        remote_name_cmd.current_dir(repo_path);
+        remote_name_cmd.stdout(std::process::Stdio::piped());
+        remote_name_cmd.stderr(std::process::Stdio::null());
 
-    let output = get_command_output(&mut git_pull_cmd, RunConfig::new().with_askpass());
-
-    match output {
-        Err(err) => {
-            let msg = format!("git pull failed: {}", err);
+        let output = remote_name_cmd.output().map_err(|err| {
+            let msg = format!("git config failed: {}", err);
             progress_handler.error_with_message(msg.clone());
-            Err(msg)
+            msg
+        })?;
+        if !output.status.success() {
+            let msg = "failed to get remote name".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
         }
-        Ok(output) if !output.status.success() => {
+
+        let remote_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if remote_name.is_empty() {
+            let msg = "no remote name configured".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
+
+        // Get the remote branch we are tracking
+        let mut remote_branch_cmd = StdCommand::new("git");
+        remote_branch_cmd.arg("rev-parse");
+        remote_branch_cmd.arg("--abbrev-ref");
+        remote_branch_cmd.arg("@{u}");
+        remote_branch_cmd.current_dir(repo_path);
+        remote_branch_cmd.stdout(std::process::Stdio::piped());
+        remote_branch_cmd.stderr(std::process::Stdio::null());
+
+        let output = local_branch_cmd.output().map_err(|err| {
+            let msg = format!("git rev-parse failed: {}", err);
+            progress_handler.error_with_message(msg.clone());
+            msg
+        })?;
+        if !output.status.success() {
+            let msg = format!(
+                "failed to get remote branch for {}: {}",
+                local_branch,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
+
+        let remote_branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if remote_branch.is_empty() {
+            let msg = "no remote branch configured".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
+
+        let remote_branch_full = format!("{}/{}", remote_name, remote_branch);
+
+        // Fetch the updates for the remote branch
+        let mut git_fetch_cmd = TokioCommand::new("git");
+        git_fetch_cmd.arg("fetch");
+        git_fetch_cmd.arg(remote_name);
+        git_fetch_cmd.arg(remote_branch);
+        git_fetch_cmd.current_dir(repo_path);
+        git_fetch_cmd.stdout(std::process::Stdio::piped());
+        git_fetch_cmd.stderr(std::process::Stdio::piped());
+
+        let output = get_command_output(&mut git_fetch_cmd, RunConfig::new().with_askpass())
+            .map_err(|err| {
+                let msg = format!("git fetch failed: {}", err);
+                progress_handler.error_with_message(msg.clone());
+                msg
+            })?;
+        if !output.status.success() {
+            let msg = format!(
+                "failed to fetch updates for {}: {}",
+                remote_branch_full,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
+
+        // Check if there was any new contents fetched
+        let fetched_err = String::from_utf8_lossy(&output.stderr);
+
+        // Check if there is a line containing `-> <remote-branch>` in the error output
+        let remote_branch_updated = fetched_err
+            .lines()
+            .any(|line| line.contains(&format!("-> {}", remote_branch_full)));
+
+        if !remote_branch_updated {
+            progress_handler.success_with_message("already up to date".light_black());
+            return Ok(false);
+        }
+
+        // If there was new contents fetched, we need to reset to the local branch
+        // to the remote branch
+        let mut git_reset_cmd = StdCommand::new("git");
+        git_reset_cmd.arg("reset");
+        git_reset_cmd.arg("--hard");
+        git_reset_cmd.arg(remote_branch_full);
+        git_reset_cmd.current_dir(repo_path);
+        git_reset_cmd.stdout(std::process::Stdio::null());
+        git_reset_cmd.stderr(std::process::Stdio::piped());
+
+        let output = git_reset_cmd.output().map_err(|err| {
+            let msg = format!("git reset failed: {}", err);
+            progress_handler.error_with_message(msg.clone());
+            msg
+        })?;
+        if !output.status.success() {
+            let msg = format!(
+                "failed to reset local branch: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
+
+        // NOTE: do we want to `git clean -fdx` here?
+        //       the main concern is if we have a package generating
+        //       local binaries, we would be removing all of that
+
+        // Now we are done
+        progress_handler.success_with_message("updated".light_green());
+        git_env_flush_cache(repo_path);
+        Ok(true)
+    } else {
+        // If we are not on a package, we need to be more conservative as it could be
+        // that someone is working on this repository
+        progress_handler.progress("pulling latest changes".to_string());
+
+        let mut git_pull_cmd = TokioCommand::new("git");
+        git_pull_cmd.arg("pull");
+        git_pull_cmd.arg("--ff-only");
+        git_pull_cmd.current_dir(repo_path);
+        git_pull_cmd.stdout(std::process::Stdio::piped());
+        git_pull_cmd.stderr(std::process::Stdio::piped());
+
+        let output = get_command_output(&mut git_pull_cmd, RunConfig::new().with_askpass())
+            .map_err(|err| {
+                let msg = format!("git pull failed: {}", err);
+                progress_handler.error_with_message(msg.clone());
+                msg
+            })?;
+
+        if !output.status.success() {
             let msg = format!(
                 "git pull failed: {}",
-                String::from_utf8(output.stderr)
-                    .unwrap()
+                String::from_utf8_lossy(&output.stderr)
                     .replace('\n', " ")
                     .trim()
             );
             progress_handler.error_with_message(msg.clone());
-            Err(msg)
+            return Err(msg);
         }
-        Ok(output) => {
-            let output = String::from_utf8(output.stdout).unwrap().trim().to_string();
-            let output_lines = output.lines().collect::<Vec<&str>>();
 
-            if output_lines.len() == 1 && output_lines[0].contains("Already up to date.") {
-                progress_handler.success_with_message("already up to date".light_black());
-                Ok(false)
-            } else {
-                progress_handler.success_with_message("updated".light_green());
-                git_env_flush_cache(repo_path.unwrap_or("."));
-                Ok(true)
-            }
+        let contents = String::from_utf8_lossy(&output.stdout);
+        let lines = contents.lines().collect::<Vec<&str>>();
+
+        if lines.len() == 1 && lines[0].contains("Already up to date.") {
+            progress_handler.success_with_message("already up to date".light_black());
+            Ok(false)
+        } else {
+            progress_handler.success_with_message("updated".light_green());
+            git_env_flush_cache(repo_path);
+            Ok(true)
         }
     }
 }
 
 fn update_git_tag(
-    repo_id: &str,
-    ref_match: Option<String>,
-    repo_path: Option<&str>,
-    progress_handler: Option<&dyn ProgressHandler>,
+    repo_path: &str,
+    ref_match: StringFilter,
+    progress_handler: &dyn ProgressHandler,
 ) -> Result<bool, String> {
-    let desc = format!("Updating {}:", repo_id.italic().light_cyan()).light_blue();
-    let spinner;
-    let printer;
-
-    let progress_handler: Box<&dyn ProgressHandler> =
-        if let Some(progress_handler) = progress_handler {
-            Box::new(progress_handler)
-        } else if shell_is_interactive() {
-            spinner = SpinnerProgressHandler::new(desc, None);
-            Box::new(&spinner)
-        } else {
-            printer = PrintProgressHandler::new(desc, None);
-            Box::new(&printer)
-        };
-
     // Check if we're currently checked out on a branch
     progress_handler.progress("checking current branch".to_string());
-    let mut git_branch_cmd = std::process::Command::new("git");
-    if let Some(repo_path) = repo_path {
-        git_branch_cmd.current_dir(repo_path);
-    }
-    git_branch_cmd.arg("branch");
-    git_branch_cmd.arg("--show-current");
-    git_branch_cmd.stdout(std::process::Stdio::piped());
-    git_branch_cmd.stderr(std::process::Stdio::null());
 
-    let output = git_branch_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let mut local_branch_cmd = StdCommand::new("git");
+    local_branch_cmd.arg("branch");
+    local_branch_cmd.arg("--show-current");
+    local_branch_cmd.current_dir(repo_path);
+    local_branch_cmd.stdout(std::process::Stdio::piped());
+    local_branch_cmd.stderr(std::process::Stdio::null());
+
+    let output = local_branch_cmd.output().map_err(|err| {
+        let msg = format!("git branch failed: {}", err);
+        progress_handler.error_with_message(msg.clone());
+        msg
+    })?;
+
+    if !output.status.success() {
         let msg = "git branch failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
-    let git_branch = String::from_utf8(output.unwrap().stdout)
-        .unwrap()
-        .trim()
-        .to_string();
-    if !git_branch.is_empty() {
+
+    let local_branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !local_branch.is_empty() {
         let msg = "currently checked out on a branch; skipping update".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
@@ -882,27 +1035,28 @@ fn update_git_tag(
 
     // Check which tag we are currently checked out on, if any
     progress_handler.progress("checking current tag".to_string());
-    let mut git_tag_cmd = std::process::Command::new("git");
-    if let Some(repo_path) = repo_path {
-        git_tag_cmd.current_dir(repo_path);
-    }
+    let mut git_tag_cmd = StdCommand::new("git");
     git_tag_cmd.arg("tag");
     git_tag_cmd.arg("--points-at");
     git_tag_cmd.arg("HEAD");
     git_tag_cmd.arg("--sort=-creatordate");
+    git_tag_cmd.current_dir(repo_path);
     git_tag_cmd.stdout(std::process::Stdio::piped());
     git_tag_cmd.stderr(std::process::Stdio::null());
 
-    let output = git_tag_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let output = git_tag_cmd.output().map_err(|err| {
+        let msg = format!("git tag failed: {}", err);
+        progress_handler.error_with_message(msg.clone());
+        msg
+    })?;
+
+    if !output.status.success() {
         let msg = "git tag failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
-    let git_tag = String::from_utf8(output.unwrap().stdout)
-        .unwrap()
-        .trim()
-        .to_string();
+
+    let git_tag = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if git_tag.is_empty() {
         let msg = "not currently checked out on a tag; skipping update".to_string();
         progress_handler.error_with_message(msg.clone());
@@ -915,25 +1069,28 @@ fn update_git_tag(
     // Fetch all the tags for the repository
     progress_handler.progress("fetching last tags".to_string());
     let mut git_fetch_tags_cmd = TokioCommand::new("git");
-    if let Some(repo_path) = repo_path {
-        git_fetch_tags_cmd.current_dir(repo_path);
-    }
     git_fetch_tags_cmd.arg("fetch");
     git_fetch_tags_cmd.arg("--tags");
+    git_fetch_tags_cmd.current_dir(repo_path);
     git_fetch_tags_cmd.stdout(std::process::Stdio::piped());
     git_fetch_tags_cmd.stderr(std::process::Stdio::piped());
 
-    let output = get_command_output(&mut git_fetch_tags_cmd, RunConfig::new().with_askpass());
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let output = get_command_output(&mut git_fetch_tags_cmd, RunConfig::new().with_askpass())
+        .map_err(|err| {
+            let msg = format!("git fetch failed: {}", err);
+            progress_handler.error_with_message(msg.clone());
+            msg
+        })?;
+
+    if !output.status.success() {
         let msg = "git fetch failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
 
     // Check if there was any new tags fetched
-    let fetched = output.unwrap();
-    let fetched_out = String::from_utf8(fetched.stdout).unwrap();
-    let fetched_err = String::from_utf8(fetched.stderr).unwrap();
+    let fetched_out = String::from_utf8_lossy(&output.stdout);
+    let fetched_err = String::from_utf8_lossy(&output.stderr);
     if fetched_out.trim().is_empty() && fetched_err.trim().is_empty() {
         // If no new tags, nothing more to do!
         progress_handler.success_with_message("no new tags, nothing to do".light_black());
@@ -943,25 +1100,26 @@ fn update_git_tag(
     // If any new tags, we need to check what is the most recent tag
     // that matches the passed tag parameter (if any)
     progress_handler.progress("checking latest tag".to_string());
-    let mut git_tag_cmd = std::process::Command::new("git");
-    if let Some(repo_path) = repo_path {
-        git_tag_cmd.current_dir(repo_path);
-    }
+    let mut git_tag_cmd = StdCommand::new("git");
     git_tag_cmd.arg("tag");
     git_tag_cmd.arg("--sort=-creatordate");
+    git_tag_cmd.current_dir(repo_path);
     git_tag_cmd.stdout(std::process::Stdio::piped());
     git_tag_cmd.stderr(std::process::Stdio::null());
 
-    let output = git_tag_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let output = git_tag_cmd.output().map_err(|err| {
+        let msg = format!("git tag failed: {}", err);
+        progress_handler.error_with_message(msg.clone());
+        msg
+    })?;
+
+    if !output.status.success() {
         let msg = "git tag failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
-    let git_tags = String::from_utf8(output.unwrap().stdout)
-        .unwrap()
-        .trim()
-        .to_string();
+
+    let git_tags = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if git_tags.is_empty() {
         let msg = "no tags found; skipping update".to_string();
         progress_handler.error_with_message(msg.clone());
@@ -970,24 +1128,14 @@ fn update_git_tag(
 
     // Find the most recent git tag in git_tags that matches
     // the passed tag parameter (if any)
-    let regex = match ref_match {
-        Some(ref ref_match) => regex::Regex::new(ref_match),
-        None => regex::Regex::new(".*"),
+    let target_tag = match git_tags.lines().find(|git_tag| ref_match.matches(git_tag)) {
+        Some(target_tag) => target_tag.trim().to_string(),
+        None => {
+            let msg = "no matching tags found; skipping update".to_string();
+            progress_handler.error_with_message(msg.clone());
+            return Err(msg);
+        }
     };
-    if regex.is_err() {
-        let msg = "invalid tag regex".to_string();
-        progress_handler.error_with_message(msg.clone());
-        return Err(msg);
-    }
-    let regex = regex.unwrap();
-
-    let target_tag = git_tags.lines().find(|git_tag| regex.is_match(git_tag));
-    if target_tag.is_none() {
-        let msg = "no matching tags found; skipping update".to_string();
-        progress_handler.error_with_message(msg.clone());
-        return Err(msg);
-    }
-    let target_tag = target_tag.unwrap().trim().to_string();
 
     // If the current tag is the same as the target tag, nothing more to do!
     if current_tag == target_tag {
@@ -997,25 +1145,28 @@ fn update_git_tag(
 
     // Check out the target tag
     progress_handler.progress(format!("checking out {}", target_tag.light_green()));
-    let mut git_checkout_cmd = std::process::Command::new("git");
-    if let Some(repo_path) = repo_path {
-        git_checkout_cmd.current_dir(repo_path);
-    }
+    let mut git_checkout_cmd = StdCommand::new("git");
     git_checkout_cmd.arg("checkout");
     git_checkout_cmd.arg("--no-guess");
     git_checkout_cmd.arg(&target_tag);
+    git_checkout_cmd.current_dir(repo_path);
     git_checkout_cmd.stdout(std::process::Stdio::null());
     git_checkout_cmd.stderr(std::process::Stdio::null());
 
-    let output = git_checkout_cmd.output();
-    if output.is_err() || !output.as_ref().unwrap().status.success() {
+    let output = git_checkout_cmd.output().map_err(|err| {
+        let msg = format!("git checkout failed: {}", err);
+        progress_handler.error_with_message(msg.clone());
+        msg
+    })?;
+
+    if !output.status.success() {
         let msg = "git checkout failed".to_string();
         progress_handler.error_with_message(msg.clone());
         return Err(msg);
     }
 
     progress_handler.success_with_message("updated".light_green());
-    git_env_flush_cache(repo_path.unwrap_or("."));
+    git_env_flush_cache(repo_path);
 
     Ok(true)
 }

--- a/src/internal/git/updater.rs
+++ b/src/internal/git/updater.rs
@@ -757,7 +757,17 @@ impl GitRepoUpdater {
     }
 
     pub fn update(&self, progress_handler: Option<&dyn ProgressHandler>) -> Result<bool, String> {
-        let desc = format!("Updating {}:", self.repo_id.italic().light_cyan()).light_blue();
+        let desc = format!(
+            "Updating {} {}:",
+            if PathEntryConfig::from_path(&self.path).is_package() {
+                "📦"
+            } else {
+                "🌳"
+            },
+            self.repo_id.italic().light_cyan()
+        )
+        .light_blue();
+
         let spinner;
         let printer;
 
@@ -826,6 +836,7 @@ fn update_git_branch(
         // since we are the ones managing the repository
 
         // Get the remote name we are tracking
+        progress_handler.progress("fetching remote".to_string());
         let mut remote_name_cmd = StdCommand::new("git");
         remote_name_cmd.arg("config");
         remote_name_cmd.arg("--get");
@@ -853,6 +864,7 @@ fn update_git_branch(
         }
 
         // Get the remote branch we are tracking
+        progress_handler.progress("fetching remote branch".to_string());
         let mut remote_branch_cmd = StdCommand::new("git");
         remote_branch_cmd.arg("rev-parse");
         remote_branch_cmd.arg("--abbrev-ref");
@@ -886,6 +898,7 @@ fn update_git_branch(
         let remote_branch_full = format!("{}/{}", remote_name, remote_branch);
 
         // Fetch the updates for the remote branch
+        progress_handler.progress(format!("fetching updates for {}", remote_branch_full));
         let mut git_fetch_cmd = TokioCommand::new("git");
         git_fetch_cmd.arg("fetch");
         git_fetch_cmd.arg(remote_name);
@@ -925,6 +938,7 @@ fn update_git_branch(
 
         // If there was new contents fetched, we need to reset to the local branch
         // to the remote branch
+        progress_handler.progress("resetting local branch".to_string());
         let mut git_reset_cmd = StdCommand::new("git");
         git_reset_cmd.arg("reset");
         git_reset_cmd.arg("--hard");


### PR DESCRIPTION
By default, `git` updates for a repository are using fast-forward only to avoid breaking anything that the user might have been working on. This requirement does not apply to packages since packages are managed by omni and omni only. We can thus be more aggressive when working in packages by fetching any new commits, and resetting to the origin's branch.

Closes https://github.com/xaf/omni/issues/908