### PR TITLE
fix(`shell integration`): 🐛 fix the bash shell integration

### DIFF
--- a/templates/shell_integration.bash.tmpl
+++ b/templates/shell_integration.bash.tmpl
@@ -100,7 +100,7 @@ else
 			{{ OMNI_BIN }} --complete ${words[@]})
 
 		while read -r opt; do
-			if [[ "${opt}" != "${cur}"* ]]; then
+			if [[ -z "${opt}" ]] || [[ "${opt}" != "${cur}"* ]]; then
 				continue
 			fi
 


### PR DESCRIPTION
This was adding a space when no more completion was available, but the autocompletion command still returned a successful exit code. This is fixed by checking if the autocompletion value is empty and skipping it in this case.