### PR TITLE
feat(`argparser`): use `partial` auto-completion for internal commands

### DIFF
--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 
 use shell_escape::escape;
 
+use crate::internal::commands::base::AutocompleteParameter;
 use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::utils::omni_cmd;
@@ -279,11 +280,11 @@ impl BuiltinCommand for CdCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<(String, usize)>,
+        parameter: Option<AutocompleteParameter>,
     ) -> Result<(), ()> {
         // We only have the work directory to autocomplete
-        if let Some((param_name, _param_idx)) = parameter {
-            if param_name == "workdir" {
+        if let Some(param) = parameter {
+            if param.name == "workdir" {
                 let repo = argv.get(comp_cword).map_or("", String::as_str);
 
                 path_auto_complete(repo, true, false)

--- a/src/internal/commands/builtin/cd.rs
+++ b/src/internal/commands/builtin/cd.rs
@@ -279,15 +279,17 @@ impl BuiltinCommand for CdCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<String>,
+        parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
         // We only have the work directory to autocomplete
-        if parameter.unwrap_or_default() == "workdir" {
-            let repo = argv.get(comp_cword).map_or("", String::as_str);
+        if let Some((param_name, _param_idx)) = parameter {
+            if param_name == "workdir" {
+                let repo = argv.get(comp_cword).map_or("", String::as_str);
 
-            path_auto_complete(repo, true, false)
-                .iter()
-                .for_each(|s| println!("{}", s));
+                path_auto_complete(repo, true, false)
+                    .iter()
+                    .for_each(|s| println!("{}", s));
+            }
         }
 
         Ok(())

--- a/src/internal/commands/builtin/clone.rs
+++ b/src/internal/commands/builtin/clone.rs
@@ -11,7 +11,6 @@ use shell_words::join as shell_join;
 use tokio::process::Command as TokioCommand;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::UpCommand;
 use crate::internal::commands::utils::omni_cmd;
 use crate::internal::commands::Command;
@@ -489,16 +488,5 @@ impl BuiltinCommand for CloneCommand {
         exit(0);
     }
 
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
-    }
+    // TODO: add autocompletion for supported git clone options?
 }

--- a/src/internal/commands/builtin/config/bootstrap.rs
+++ b/src/internal/commands/builtin/config/bootstrap.rs
@@ -15,7 +15,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::TidyGitRepo;
 use crate::internal::commands::utils::abs_path;
 use crate::internal::commands::utils::file_auto_complete;
@@ -136,19 +135,6 @@ impl BuiltinCommand for ConfigBootstrapCommand {
         }
 
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/config/check.rs
+++ b/src/internal/commands/builtin/config/check.rs
@@ -6,7 +6,6 @@ use std::process::exit;
 use itertools::Itertools;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::frompath::PathCommand;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
@@ -304,19 +303,6 @@ impl BuiltinCommand for ConfigCheckCommand {
         self.aggregate_config_errors(&error_handler, &args);
         self.aggregate_path_errors(&error_handler, &args);
         self.filter_and_print_errors(&error_handler, &args);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/config/path/switch.rs
+++ b/src/internal/commands/builtin/config/path/switch.rs
@@ -7,7 +7,6 @@ use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::CloneCommand;
 use crate::internal::commands::builtin::TidyGitRepo;
 use crate::internal::commands::builtin::UpCommand;
@@ -470,18 +469,5 @@ impl BuiltinCommand for ConfigPathSwitchCommand {
         }
 
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/reshim.rs
+++ b/src/internal/commands/builtin/config/reshim.rs
@@ -1,7 +1,6 @@
 use std::process::exit;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::up::utils::reshim;
 use crate::internal::config::up::utils::PrintProgressHandler;
@@ -78,18 +77,5 @@ impl BuiltinCommand for ConfigReshimCommand {
         }
 
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/config/trust.rs
+++ b/src/internal/commands/builtin/config/trust.rs
@@ -3,7 +3,6 @@ use std::process::exit;
 
 use crate::internal::cache::WorkdirsCache;
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::parser::ParseArgsValue;
 use crate::internal::config::CommandSyntax;
@@ -210,18 +209,5 @@ impl BuiltinCommand for ConfigTrustCommand {
                 exit(1);
             }
         }
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -5,6 +5,7 @@ use std::process::exit;
 use serde::Serialize;
 
 use crate::internal::cache::utils as cache_utils;
+use crate::internal::commands::base::AutocompleteParameter;
 use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::command_loader;
@@ -207,13 +208,13 @@ impl BuiltinCommand for HelpCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<(String, usize)>,
+        parameter: Option<AutocompleteParameter>,
     ) -> Result<(), ()> {
-        if let Some((param_name, param_idx)) = parameter {
-            if param_name == "command" {
+        if let Some(param) = parameter {
+            if param.name == "command" {
                 // Get the command parameters that will require autocompletion
-                let command_argv = argv[param_idx..].to_vec();
-                let command_comp_cword = comp_cword - param_idx;
+                let command_argv = argv[param.index..].to_vec();
+                let command_comp_cword = comp_cword - param.index;
 
                 // We can try completing the command
                 let command_loader = command_loader(".");

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -208,7 +208,7 @@ impl BuiltinCommand for HelpCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        _parameter: Option<String>,
+        _parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
         command_loader(".").complete(comp_cword, argv, false)
     }

--- a/src/internal/commands/builtin/help.rs
+++ b/src/internal/commands/builtin/help.rs
@@ -200,17 +200,30 @@ impl BuiltinCommand for HelpCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO: convert to partial so the autocompletion works for options too
-        CommandAutocompletion::Full
+        CommandAutocompletion::Partial
     }
 
     fn autocomplete(
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        _parameter: Option<(String, usize)>,
+        parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
-        command_loader(".").complete(comp_cword, argv, false)
+        if let Some((param_name, param_idx)) = parameter {
+            if param_name == "command" {
+                // Get the command parameters that will require autocompletion
+                let command_argv = argv[param_idx..].to_vec();
+                let command_comp_cword = comp_cword - param_idx;
+
+                // We can try completing the command
+                let command_loader = command_loader(".");
+                let result = command_loader.complete(command_comp_cword, command_argv, false);
+
+                return result;
+            }
+        }
+
+        Err(())
     }
 }
 

--- a/src/internal/commands/builtin/hook/base.rs
+++ b/src/internal/commands/builtin/hook/base.rs
@@ -1,5 +1,4 @@
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::config::CommandSyntax;
 use crate::internal::config::SyntaxOptArg;
 
@@ -59,17 +58,4 @@ impl BuiltinCommand for HookCommand {
     }
 
     fn exec(&self, _argv: Vec<String>) {}
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Err(())
-    }
 }

--- a/src/internal/commands/builtin/hook/env.rs
+++ b/src/internal/commands/builtin/hook/env.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::process::exit;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::parser::ParseArgsValue;
 use crate::internal::config::CommandSyntax;
@@ -164,18 +163,5 @@ impl BuiltinCommand for HookEnvCommand {
                 exit(1);
             }
         }
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/hook/init.rs
+++ b/src/internal/commands/builtin/hook/init.rs
@@ -7,7 +7,6 @@ use tera::Context;
 use tera::Tera;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::global_config;
 use crate::internal::config::parser::ParseArgsValue;
@@ -303,19 +302,6 @@ impl BuiltinCommand for HookInitCommand {
             }
         }
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }
 

--- a/src/internal/commands/builtin/hook/uuid.rs
+++ b/src/internal/commands/builtin/hook/uuid.rs
@@ -3,7 +3,6 @@ use std::process::exit;
 use uuid::Uuid;
 
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::config::CommandSyntax;
 
 #[derive(Debug, Clone)]
@@ -53,18 +52,5 @@ impl BuiltinCommand for HookUuidCommand {
         let uuid = Uuid::new_v4();
         println!("{}", uuid);
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -239,7 +239,6 @@ impl BuiltinCommand for ScopeCommand {
     }
 
     fn autocompletion(&self) -> CommandAutocompletion {
-        // TODO: convert to partial so the autocompletion work for options too
         CommandAutocompletion::Partial
     }
 
@@ -290,46 +289,5 @@ impl BuiltinCommand for ScopeCommand {
         }
 
         Err(())
-
-        // match comp_cword.cmp(&0) {
-        // std::cmp::Ordering::Equal => {
-        // let repo = argv.first().map_or("", String::as_str);
-        // path_auto_complete(repo, true, false)
-        // .iter()
-        // .for_each(|s| println!("{}", s));
-        // Ok(())
-        // }
-        // std::cmp::Ordering::Greater => {
-        // if argv.is_empty() {
-        // // Unsure why we would get here, but if we try to complete
-        // // a command but a repository is not provided, we can't, so
-        // // let's simply skip it
-        // return Ok(());
-        // }
-
-        // // We want to switch context to the repository, so we can offer
-        // // completion of the commands for that specific repository
-        // let mut argv = argv.clone();
-        // let repo = argv.remove(0);
-
-        // let curdir = current_dir();
-        // // TODO: use the previous arguments to know if we should include packages or not
-        // if self.switch_scope(&repo, true, true).is_err() {
-        // return Err(());
-        // }
-
-        // // Finally, we can try completing the command
-        // let command_loader = command_loader(".");
-        // let result = command_loader.complete(comp_cword - 1, argv.to_vec(), true);
-
-        // // Restore current scope
-        // if std::env::set_current_dir(curdir).is_err() {
-        // return Err(());
-        // }
-
-        // result
-        // }
-        // std::cmp::Ordering::Less => Err(()),
-        // }
     }
 }

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -258,20 +258,31 @@ impl BuiltinCommand for ScopeCommand {
 
                 return Ok(());
             } else if param_name == "command" {
+                // TODO: this function should receive the "seen params" with their value
+                //       so we can know if the user has passed --include-packages or not,
+                //       and read the repo name from the correct position without guessing
+
                 // Get the repository, return an error if we can't
                 // Since all is positional, the repository should be the positional
                 // right before the command
-                // TODO: this function should receive the "seen params" with their value
-                let repo = argv.get(param_idx - 1).ok_or(())?;
+                let repo = argv
+                    .iter()
+                    .take(param_idx)
+                    .rev()
+                    .find(|v| !v.starts_with("-"))
+                    .ok_or(())?;
 
                 // Get the command parameters that will require autocompletion
                 let command_argv = argv[param_idx..].to_vec();
                 let command_comp_cword = comp_cword - param_idx;
 
                 // Switch to the scope of the repository
-                // TODO: use the previous arguments to know if we should include packages or not
                 let curdir = current_dir();
-                if self.switch_scope(&repo, true, true).is_err() {
+                let include_packages = !argv
+                    .iter()
+                    .take(param_idx)
+                    .any(|v| v == "--no-include-packages");
+                if self.switch_scope(&repo, include_packages, true).is_err() {
                     return Err(());
                 }
 

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -246,7 +246,7 @@ impl BuiltinCommand for ScopeCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        _parameter: Option<String>,
+        _parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
         match comp_cword.cmp(&0) {
             std::cmp::Ordering::Equal => {

--- a/src/internal/commands/builtin/scope.rs
+++ b/src/internal/commands/builtin/scope.rs
@@ -264,8 +264,7 @@ impl BuiltinCommand for ScopeCommand {
                     .seen
                     .iter()
                     .find(|(k, _)| k == "scope")
-                    .map(|(_, v)| v.first())
-                    .flatten()
+                    .and_then(|(_, v)| v.first())
                     .ok_or(())?;
 
                 // Get the command parameters that will require autocompletion
@@ -276,7 +275,7 @@ impl BuiltinCommand for ScopeCommand {
                 let curdir = current_dir();
                 let include_packages =
                     !param.seen.iter().any(|(k, _)| k == "--no-include-packages");
-                if self.switch_scope(&scope, include_packages, true).is_err() {
+                if self.switch_scope(scope, include_packages, true).is_err() {
                     return Err(());
                 }
 

--- a/src/internal/commands/builtin/status.rs
+++ b/src/internal/commands/builtin/status.rs
@@ -7,7 +7,6 @@ use regex::Regex;
 
 use crate::internal::cache::utils::Empty;
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::path::omnipath_entries;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
@@ -389,18 +388,5 @@ impl BuiltinCommand for StatusCommand {
         self.print_path(&args);
 
         exit(0);
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Ok(())
     }
 }

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -10,6 +10,7 @@ use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 use walkdir::WalkDir;
 
+use crate::internal::commands::base::AutocompleteParameter;
 use crate::internal::commands::base::BuiltinCommand;
 use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::builtin::UpCommand;
@@ -513,18 +514,16 @@ impl BuiltinCommand for TidyCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<(String, usize)>,
+        parameter: Option<AutocompleteParameter>,
     ) -> Result<(), ()> {
-        if let Some((param_name, param_idx)) = parameter {
-            if param_name == "up args" {
+        if let Some(param) = parameter {
+            if param.name == "up args" {
                 // Compute the new comp_cword for the up command
-                let comp_cword = comp_cword - param_idx;
-
-                // TODO: review -1 / +1
+                let comp_cword = comp_cword - param.index;
 
                 // Let's use the autocompletion of the up command
                 let up_command = UpCommand::new_command();
-                return up_command.autocomplete(comp_cword, argv[param_idx..].to_vec());
+                return up_command.autocomplete(comp_cword, argv[param.index..].to_vec());
             }
         }
 

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -513,21 +513,17 @@ impl BuiltinCommand for TidyCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<String>,
+        parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
-        if parameter.unwrap_or_default() == "up args" {
-            // Get the position of the `--` argument
-            let up_args_start = match argv.iter().position(|arg| arg == "--") {
-                Some(pos) => pos + 1,
-                None => return Ok(()),
-            };
+        if let Some((param_name, param_idx)) = parameter {
+            if param_name == "up args" {
+                // Compute the new comp_cword for the up command
+                let comp_cword = comp_cword - param_idx - 1;
 
-            // Compute the new comp_cword for the up command
-            let comp_cword = comp_cword - up_args_start;
-
-            // Let's use the autocompletion of the up command
-            let up_command = UpCommand::new_command();
-            return up_command.autocomplete(comp_cword, argv[up_args_start..].to_vec());
+                // Let's use the autocompletion of the up command
+                let up_command = UpCommand::new_command();
+                return up_command.autocomplete(comp_cword, argv[param_idx + 1..].to_vec());
+            }
         }
 
         Ok(())

--- a/src/internal/commands/builtin/tidy.rs
+++ b/src/internal/commands/builtin/tidy.rs
@@ -518,11 +518,13 @@ impl BuiltinCommand for TidyCommand {
         if let Some((param_name, param_idx)) = parameter {
             if param_name == "up args" {
                 // Compute the new comp_cword for the up command
-                let comp_cword = comp_cword - param_idx - 1;
+                let comp_cword = comp_cword - param_idx;
+
+                // TODO: review -1 / +1
 
                 // Let's use the autocompletion of the up command
                 let up_command = UpCommand::new_command();
-                return up_command.autocomplete(comp_cword, argv[param_idx + 1..].to_vec());
+                return up_command.autocomplete(comp_cword, argv[param_idx..].to_vec());
             }
         }
 

--- a/src/internal/commands/builtin/up.rs
+++ b/src/internal/commands/builtin/up.rs
@@ -21,7 +21,6 @@ use crate::internal::cache::utils::Empty;
 use crate::internal::cache::PromptsCache;
 use crate::internal::cache::WorkdirsCache;
 use crate::internal::commands::base::BuiltinCommand;
-use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::Command;
 use crate::internal::config::config;
 use crate::internal::config::flush_config;
@@ -1653,19 +1652,6 @@ impl BuiltinCommand for UpCommand {
             suggest_clone_updated,
             &options,
         );
-    }
-
-    fn autocompletion(&self) -> CommandAutocompletion {
-        CommandAutocompletion::Null
-    }
-
-    fn autocomplete(
-        &self,
-        _comp_cword: usize,
-        _argv: Vec<String>,
-        _parameter: Option<String>,
-    ) -> Result<(), ()> {
-        Err(())
     }
 }
 

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -296,14 +296,15 @@ impl PathCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<String>,
+        parameter: Option<(String, usize)>,
     ) -> Result<(), ()> {
         let mut command = ProcessCommand::new(self.source.clone());
         command.arg("--complete");
         command.args(argv);
         command.env("COMP_CWORD", comp_cword.to_string());
-        if let Some(parameter) = parameter {
-            command.env("OMNI_COMP_VALUE_OF", parameter);
+        if let Some((param_name, param_idx)) = parameter {
+            command.env("OMNI_COMP_VALUE_OF", param_name);
+            command.env("OMNI_COMP_VALUE_START_INDEX", param_idx.to_string());
         }
 
         match command.output() {

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use serde_yaml::Value as YamlValue;
 use walkdir::WalkDir;
 
+use crate::internal::commands::base::AutocompleteParameter;
 use crate::internal::commands::base::CommandAutocompletion;
 use crate::internal::commands::path::omnipath;
 use crate::internal::commands::utils::str_to_bool;
@@ -296,15 +297,15 @@ impl PathCommand {
         &self,
         comp_cword: usize,
         argv: Vec<String>,
-        parameter: Option<(String, usize)>,
+        parameter: Option<AutocompleteParameter>,
     ) -> Result<(), ()> {
         let mut command = ProcessCommand::new(self.source.clone());
         command.arg("--complete");
         command.args(argv);
         command.env("COMP_CWORD", comp_cword.to_string());
-        if let Some((param_name, param_idx)) = parameter {
-            command.env("OMNI_COMP_VALUE_OF", param_name);
-            command.env("OMNI_COMP_VALUE_START_INDEX", param_idx.to_string());
+        if let Some(param) = parameter {
+            command.env("OMNI_COMP_VALUE_OF", param.name);
+            command.env("OMNI_COMP_VALUE_START_INDEX", param.index.to_string());
         }
 
         match command.output() {


### PR DESCRIPTION
This improves the `partial` auto-completion behavior to be usable by commands that were still using the full auto-completion, so that built-in commands only use `partial` or `null` (argparser only) now.