### PR TITLE
fix(did you mean): `OMNI_SUBCOMMAND` set to selected command

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -453,11 +453,11 @@ impl Command {
         std::env::set_var("OMNI_VERSION", env!("CARGO_PKG_VERSION"));
 
         // Clear all `OMNI_ARG_` environment variables
-        for (key, _) in std::env::vars() {
-            if key.starts_with("OMNI_ARG_") {
+        std::env::vars()
+            .filter(|(key, _)| key.starts_with("OMNI_ARG_"))
+            .for_each(|(key, _)| {
                 std::env::remove_var(&key);
-            }
-        }
+            });
 
         // Set environment variables for the parsed arguments, if we are parsing any
         if let Some(args) = self.exec_parse_args(argv.clone(), called_as.clone()) {


### PR DESCRIPTION
At this time, the `OMNI_SUBCOMMAND` kept the original value used by the caller before selecting the real command from the `Did you mean?` menu; this led to issues for commands depending on `OMNI_SUBCOMMAND` to show the help, for instance.

This is now fixed as it will set the `OMNI_SUBCOMMAND` environment variable to the selected command in the `Did you mean?` menu.

Fixes https://github.com/xaf/omni/issues/919