### PR TITLE
feat(`config`): configuration commands can be exported in omnipath

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -86,6 +86,30 @@ impl Clone for Command {
     }
 }
 
+impl From<ConfigCommand> for Command {
+    fn from(command: ConfigCommand) -> Self {
+        Command::FromConfig(Box::new(command))
+    }
+}
+
+impl From<MakefileCommand> for Command {
+    fn from(command: MakefileCommand) -> Self {
+        Command::FromMakefile(command)
+    }
+}
+
+impl From<PathCommand> for Command {
+    fn from(command: PathCommand) -> Self {
+        Command::FromPath(command)
+    }
+}
+
+impl From<VoidCommand> for Command {
+    fn from(command: VoidCommand) -> Self {
+        Command::Void(command)
+    }
+}
+
 impl Command {
     pub fn name(&self) -> Vec<String> {
         match self {

--- a/src/internal/commands/builtin/config/check.rs
+++ b/src/internal/commands/builtin/config/check.rs
@@ -472,6 +472,11 @@ impl ConfigCheckCommand {
 
             let path_error_handler = error_handler.with_file(&entry);
             for command in PathCommand::aggregate_with_errors(&[entry.clone()], &path_error_handler)
+                .into_iter()
+                .filter_map(|c| match c {
+                    Command::FromPath(c) => Some(c),
+                    _ => None,
+                })
             {
                 command.check_errors(&path_error_handler);
 

--- a/src/internal/commands/builtin/config/check.rs
+++ b/src/internal/commands/builtin/config/check.rs
@@ -473,8 +473,8 @@ impl ConfigCheckCommand {
             let path_error_handler = error_handler.with_file(&entry);
             for command in PathCommand::aggregate_with_errors(&[entry.clone()], &path_error_handler)
                 .into_iter()
-                .filter_map(|c| match c {
-                    Command::FromPath(c) => Some(c),
+                .filter_map(|command| match command {
+                    Command::FromPath(path_command) => Some(path_command),
                     _ => None,
                 })
             {

--- a/src/internal/commands/fromconfig.rs
+++ b/src/internal/commands/fromconfig.rs
@@ -29,7 +29,7 @@ impl ConfigCommand {
         Self::all_commands(config(".").commands.clone(), vec![])
     }
 
-    fn all_commands(
+    pub fn all_commands(
         command_definitions: HashMap<String, CommandDefinition>,
         parent_aliases: Vec<String>,
     ) -> Vec<Self> {

--- a/src/internal/commands/fromconfig.rs
+++ b/src/internal/commands/fromconfig.rs
@@ -179,6 +179,10 @@ impl ConfigCommand {
         &self.details.tags
     }
 
+    pub fn export(&self) -> bool {
+        self.details.export
+    }
+
     pub fn exec_dir(&self) -> Result<PathBuf, String> {
         let config_file = self.source();
         let config_dir = abs_path(

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -145,7 +145,7 @@ impl PathCommand {
                 // Check if this is an omni configuration file
                 if WORKDIR_CONFIG_FILES.iter().any(|f| path.ends_with(f)) {
                     // TODO: validate the file is in a repository so we can define the scope properly
-                    let loader = ConfigLoader::new_from_file(&path, ConfigScope::Workdir);
+                    let loader = ConfigLoader::new_from_file(path, ConfigScope::Workdir);
                     let file_config = OmniConfig::from_config_value(
                         &loader.raw_config,
                         &error_handler.with_file(path.clone()),

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -137,9 +137,9 @@ impl PathCommand {
         let mut known_sources: HashMap<String, usize> = HashMap::new();
 
         for path in paths {
-            // TODO: we need to figure out how to make it work well given we're returning a
-            // list of PathCommand but we will get a list of ConfigCommand here
-            // If this is a file
+            // If this is a file, we either need to load configuration commands
+            // from an omni configuration file, or we can just skip to the next
+            // entry in the path list
             let pathobj = Path::new(path);
             if pathobj.is_file() {
                 // Check if this is an omni configuration file
@@ -151,10 +151,12 @@ impl PathCommand {
                         &error_handler.with_file(path.clone()),
                     );
 
-                    let config_commands =
-                        ConfigCommand::all_commands(file_config.commands.clone(), vec![]);
-
-                    all_commands.extend(config_commands.into_iter().map(|cmd| cmd.into()));
+                    all_commands.extend(
+                        ConfigCommand::all_commands(file_config.commands.clone(), vec![])
+                            .into_iter()
+                            .filter(|cmd| cmd.export())
+                            .map(|cmd| cmd.into()),
+                    );
                 }
 
                 continue;

--- a/src/internal/commands/frompath.rs
+++ b/src/internal/commands/frompath.rs
@@ -144,8 +144,13 @@ impl PathCommand {
             if pathobj.is_file() {
                 // Check if this is an omni configuration file
                 if WORKDIR_CONFIG_FILES.iter().any(|f| path.ends_with(f)) {
-                    // TODO: validate the file is in a repository so we can define the scope properly
-                    let loader = ConfigLoader::new_from_file(path, ConfigScope::Workdir);
+                    let loader = ConfigLoader::new_from_file(
+                        path,
+                        // We just consider it's workdir scope, but shouldn't be
+                        // important as we do not do anything specific with that
+                        // configuration besides reading the commands
+                        ConfigScope::Workdir,
+                    );
                     let file_config = OmniConfig::from_config_value(
                         &loader.raw_config,
                         &error_handler.with_file(path.clone()),

--- a/src/internal/commands/loader.rs
+++ b/src/internal/commands/loader.rs
@@ -126,7 +126,7 @@ impl CommandLoader {
 
         // Look for all commands in the configuration
         for command in ConfigCommand::all() {
-            add_fn(Command::FromConfig(Box::new(command)));
+            add_fn(command.into());
         }
 
         // Look for all commands in the path that would be
@@ -134,17 +134,17 @@ impl CommandLoader {
         // local commands first
         if lookup_local_first() {
             for command in PathCommand::local() {
-                add_fn(Command::FromPath(command));
+                add_fn(command);
             }
         }
 
         // Look for all commands in the path
         for command in PathCommand::all() {
-            add_fn(Command::FromPath(command));
+            add_fn(command);
         }
 
         for command in MakefileCommand::all_from_path(path) {
-            add_fn(Command::FromMakefile(command));
+            add_fn(command.into());
         }
 
         Self { commands }

--- a/src/internal/config/parser/command_definition.rs
+++ b/src/internal/config/parser/command_definition.rs
@@ -23,23 +23,25 @@ use crate::internal::ORG_LOADER;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CommandDefinition {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub desc: Option<String>,
     pub run: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub aliases: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub syntax: Option<CommandSyntax>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dir: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subcommands: Option<HashMap<String, CommandDefinition>>,
-    #[serde(skip_serializing_if = "cache_utils::is_false")]
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
     pub argparser: bool,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub tags: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "cache_utils::is_false")]
+    pub export: bool,
     #[serde(skip)]
     pub source: ConfigSource,
     #[serde(skip)]
@@ -140,6 +142,12 @@ impl CommandDefinition {
             &error_handler.with_key("argparser"),
         );
 
+        let export = config_value.get_as_bool_or_default(
+            "export",
+            false, // Do not export by default
+            &error_handler.with_key("export"),
+        );
+
         Self {
             desc,
             run,
@@ -150,6 +158,7 @@ impl CommandDefinition {
             subcommands,
             argparser,
             tags,
+            export,
             source: config_value.get_source().clone(),
             scope: config_value.current_scope().clone(),
         }

--- a/website/contents/reference/configuration/parameters/commands.md
+++ b/website/contents/reference/configuration/parameters/commands.md
@@ -16,6 +16,9 @@ Any command defined in a global configuration file will be available throughout 
 | `desc` | string | the description of the command that will be used in `omni help`. This can be on multiple lines, in which case the first paragraph (until the first empty line) will be shown in `omni help`, while the rest of the help message will be shown when calling `omni help <command>`. |
 | `run` | multiline string | the command to run when the command is being called. This will be called through `bash -c` and can thus receive any kind of bash scripting, or call to an executable file. |
 | `category` | string (list) | comma-separated or actual list of categories, organized hierarchically from the least significative to the most significative |
+| `argparser` | bool | whether or not to enable the [argument parser](/reference/custom-commands/path/argument-parser) for this command |
+| `export` | bool | whether or not to export the command when the configuration file is in the omnipath. The `export` configuration is not automatically inherited subcommands. _(default: `false`)_ |
+| `tags` | key-value map | a map of tags to attach to the command |
 | `dir` | string | path to the directory from which to execute the command, relative to the location of the configuration file, and needs to be a subdirectory |
 | `subcommands` | [`commands`](commands) (map) | Subcommands of that command; the name of those commands will be prefixed by the name of the current command (e.g. command `main` and subcommand `sub` would create a command `main sub`) |
 | `syntax` | [`syntax`](#syntax) | Define the parameters that the command can take. This will be used when calling `omni help <command>`. |


### PR DESCRIPTION
By adding an omni configuration file in the omnipath, any command it contains that have been flagged for exportation (`export: true`) will now be available as part of the global commands, with the priority corresponding to their position in the omnipath.

This will allow for easier writing of command wrappers for instance, where a shell script wrapper could be replaced by a simple, exported configuration command.

Closes https://github.com/xaf/omni/issues/925