### PR TITLE
fix(`node`): 🐛 dynamic environment was not loaded properly

### DIFF
--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -626,7 +626,7 @@ impl DynamicEnv {
                         envsetter.unset_value("PYTHONHOME");
                         envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
                     }
-                    "nodejs" => {
+                    "node" => {
                         envsetter.set_value("NODE_VERSION", &version);
                         envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
 


### PR DESCRIPTION
This was an issue since the move to `mise`.

Closes https://github.com/xaf/omni/issues/938