### PR TITLE
feat(`help`): ✨ show `-h`/`--help` flags for argparser-enabled commands

### DIFF
--- a/src/internal/commands/base.rs
+++ b/src/internal/commands/base.rs
@@ -531,6 +531,10 @@ impl Command {
         }
     }
 
+    pub fn internal_argparser(&self) -> bool {
+        self.argparser() || matches!(self, Command::Builtin(_))
+    }
+
     pub fn autocompletion(&self) -> CommandAutocompletion {
         let completion = match self {
             Command::Builtin(command) => command.autocompletion(),
@@ -548,9 +552,7 @@ impl Command {
             _ => true,
         };
 
-        let argparser = self.argparser() || matches!(self, Command::Builtin(_));
-
-        match (completion, trusted, argparser) {
+        match (completion, trusted, self.internal_argparser()) {
             (CommandAutocompletion::Full, true, _) => CommandAutocompletion::Full,
             (CommandAutocompletion::Partial, true, true) => CommandAutocompletion::Partial,
             (CommandAutocompletion::Partial, true, false) => CommandAutocompletion::Null,

--- a/tests/fixtures/omni/help-cd.txt
+++ b/tests/fixtures/omni/help-cd.txt
@@ -24,5 +24,6 @@ Options:
   --no-include-packages   If provided, will NOT include packages when running the command;
                           this defaults to including packages when using --locate, and not
                           including packages otherwise.
+  -h, --help              Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-clone.txt
+++ b/tests/fixtures/omni/help-clone.txt
@@ -15,5 +15,6 @@ Arguments:
 
 Options:
   -p, --package  Clone the repository as a package (default: no)
+  -h, --help     Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-config-bootstrap.txt
+++ b/tests/fixtures/omni/help-config-bootstrap.txt
@@ -12,5 +12,6 @@ Options:
   --repo-path-format  Bootstrap the repository path format
   --organizations     Bootstrap the organizations
   --shell             Bootstrap the shell integration
+  -h, --help          Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-config-check.txt
+++ b/tests/fixtures/omni/help-config-check.txt
@@ -23,5 +23,6 @@ Options:
                                    not passed, all files are included.
   -o, --output <OUTPUT>            Output format [default: plain] [possible values: json,
                                    plain]
+  -h, --help                       Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-config-path-switch.txt
+++ b/tests/fixtures/omni/help-config-path-switch.txt
@@ -22,5 +22,6 @@ Options:
   -w, --worktree  Switch the source to use the worktree in the omnipath; this will clone the
                   repository if it does not exist. This defaults to toggling  between the two
                   sources if not specified.
+  -h, --help      Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-config-reshim.txt
+++ b/tests/fixtures/omni/help-config-reshim.txt
@@ -6,4 +6,7 @@ omni and create a shim for them in the shim directory.
 
 Usage: omni config reshim
 
+Options:
+  -h, --help     Show this help message and exit
+
 Source: builtin

--- a/tests/fixtures/omni/help-config-trust.txt
+++ b/tests/fixtures/omni/help-config-trust.txt
@@ -11,5 +11,6 @@ Arguments:
 
 Options:
   --check        Check the trust status of the repository instead of changing it
+  -h, --help     Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-config-untrust.txt
+++ b/tests/fixtures/omni/help-config-untrust.txt
@@ -11,5 +11,6 @@ Arguments:
 
 Options:
   --check        Check the trust status of the repository instead of changing it
+  -h, --help     Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-down.txt
+++ b/tests/fixtures/omni/help-down.txt
@@ -39,5 +39,6 @@ Options:
                                        already installed version for another repository
                                        matches version contraints, we will avoid downloading
                                        and building a more recent version
+  -h, --help                           Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-help.txt
+++ b/tests/fixtures/omni/help-help.txt
@@ -11,5 +11,6 @@ Arguments:
 Options:
   --unfold               Show all subcommands
   -o, --output <OUTPUT>  Output format [default: plain] [possible values: json, plain]
+  -h, --help             Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-hook-env.txt
+++ b/tests/fixtures/omni/help-hook-env.txt
@@ -16,5 +16,6 @@ Options:
                  environment update.
   --keep-shims   Keep the shims directory in the PATH. This is useful for instance if you are
                  used to launch your IDE from the terminal.
+  -h, --help     Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-hook-init.txt
+++ b/tests/fixtures/omni/help-hook-init.txt
@@ -31,5 +31,6 @@ Options:
                                         environment.
   --print-shims-path                    Print the path to the shims directory and exit. This
                                         should not be used to eval in a shell environment.
+  -h, --help                            Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-hook-uuid.txt
+++ b/tests/fixtures/omni/help-hook-uuid.txt
@@ -6,4 +6,7 @@ can work without extra dependencies..
 
 Usage: omni hook uuid
 
+Options:
+  -h, --help     Show this help message and exit
+
 Source: builtin

--- a/tests/fixtures/omni/help-hook.txt
+++ b/tests/fixtures/omni/help-hook.txt
@@ -7,6 +7,9 @@ Arguments:
   <HOOK>         Which hook to call
   [OPTIONS]...   Any options to pass to the hook.
 
+Options:
+  -h, --help     Show this help message and exit
+
 General
   env            Hook used to update the dynamic environment
   init           Hook used to initialize the shell

--- a/tests/fixtures/omni/help-scope.txt
+++ b/tests/fixtures/omni/help-scope.txt
@@ -18,5 +18,6 @@ Options:
                           defaults to including packages.
   --no-include-packages   If provided, will NOT include packages when running the command;
                           this defaults to including packages.
+  -h, --help              Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-status.txt
+++ b/tests/fixtures/omni/help-status.txt
@@ -15,5 +15,6 @@ Options:
   --worktree           Show the default worktree.
   --orgs               Show the organizations.
   --path               Show the current omnipath.
+  -h, --help           Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-tidy.txt
+++ b/tests/fixtures/omni/help-tidy.txt
@@ -19,5 +19,6 @@ Options:
                                    configuration; any argument passed to the tidy command
                                    after -- will be passed to omni up (e.g. omni tidy --up-all
                                    -- --update-repository)
+  -h, --help                       Show this help message and exit
 
 Source: builtin

--- a/tests/fixtures/omni/help-up.txt
+++ b/tests/fixtures/omni/help-up.txt
@@ -39,5 +39,6 @@ Options:
                                        already installed version for another repository
                                        matches version contraints, we will avoid downloading
                                        and building a more recent version
+  -h, --help                           Show this help message and exit
 
 Source: builtin


### PR DESCRIPTION
Those flags exist and are working by default, but weren't showing-up in the help message. This is now fixed.

Closes https://github.com/xaf/omni/issues/937