### PR TITLE
feat: ✨ extend `dir` support

### DIFF
--- a/src/internal/cache/up_environments.rs
+++ b/src/internal/cache/up_environments.rs
@@ -365,6 +365,7 @@ impl UpEnvironment {
         self.add_version(backend, tool, "", "", version, bin_path, dirs)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_version(
         &mut self,
         backend: &str,
@@ -959,6 +960,7 @@ mod tests {
 
             // Add versions for different directories
             env.add_version(
+                "backend1",
                 "tool1",
                 "plugin1",
                 "plugin-1",
@@ -967,6 +969,7 @@ mod tests {
                 BTreeSet::from(["dir1".to_string()]),
             );
             env.add_version(
+                "backend2",
                 "tool2",
                 "plugin2",
                 "plugin-2",
@@ -975,6 +978,7 @@ mod tests {
                 BTreeSet::from(["dir1/subdir".to_string()]),
             );
             env.add_version(
+                "backend3",
                 "tool3",
                 "plugin3",
                 "plugin-3",
@@ -1049,6 +1053,7 @@ mod tests {
 
             // Test adding version
             assert!(env.add_version(
+                "backend1",
                 "tool1",
                 "plugin1",
                 "plugin-1",
@@ -1060,6 +1065,7 @@ mod tests {
 
             // Test adding same version doesn't duplicate
             assert!(!env.add_version(
+                "backend1",
                 "tool1",
                 "plugin1",
                 "plugin-1",
@@ -1084,6 +1090,7 @@ mod tests {
                 "tool1",
                 "plugin1",
                 "plugin-1",
+                "backend1",
                 "1.0.0",
                 "bin/path/1",
                 "dir1",
@@ -1091,6 +1098,7 @@ mod tests {
             assert_eq!(version.tool, "tool1");
             assert_eq!(version.plugin_name, "plugin1");
             assert_eq!(version.normalized_name, "plugin-1");
+            assert_eq!(version.backend, "backend1");
             assert_eq!(version.version, "1.0.0");
             assert_eq!(version.bin_path, "bin/path/1");
             assert_eq!(version.dir, "dir1");

--- a/src/internal/config/up/cargo_install.rs
+++ b/src/internal/config/up/cargo_install.rs
@@ -729,7 +729,7 @@ impl UpConfigCargoInstall {
         environment.add_simple_version(
             "cargo-install",
             &self.crate_name,
-            &version,
+            version,
             "bin",
             self.dirs.clone(),
         );

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -1419,18 +1419,14 @@ impl UpConfigMise {
         }
 
         // Update environment
-        let mut dirs = self.dirs.clone();
-        if dirs.is_empty() {
-            dirs.insert("".to_string());
-        }
-
         environment.add_version(
+            "", // mise is the default backend
             fqtn.tool(),
             fqtn.plugin_name(),
             &normalized_name,
             &version,
             &bin_path,
-            dirs.clone(),
+            self.dirs.clone(),
         );
 
         progress_handler.progress("updated cache".to_string());

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -12,6 +12,9 @@ use crate::internal::cache::up_environments::UpEnvironment;
 use crate::internal::cache::UpEnvironmentsCache;
 use crate::internal::config;
 use crate::internal::config::parser::EnvOperationEnum;
+use crate::internal::config::up::cargo_install::cargo_install_tool_path;
+use crate::internal::config::up::github_release::github_release_tool_path;
+use crate::internal::config::up::go_install::go_install_tool_path;
 use crate::internal::config::up::mise::mise_path;
 use crate::internal::config::up::mise_tool_path;
 use crate::internal::config::up::utils::get_config_mod_times;
@@ -436,6 +439,8 @@ impl DynamicEnv {
 
             // Go over the tool versions in the up environment cache
             for toolversion in up_env.versions_for_dir(&dir).iter() {
+                hasher.update(toolversion.backend.as_bytes());
+                hasher.update(DATA_SEPARATOR.as_bytes());
                 hasher.update(toolversion.tool.as_bytes());
                 hasher.update(DATA_SEPARATOR.as_bytes());
                 hasher.update(toolversion.plugin_name.as_bytes());
@@ -476,36 +481,8 @@ impl DynamicEnv {
         }
 
         if let Some(up_env) = &up_env {
-            // Add the requested environments
-            if !up_env.env_vars.is_empty() {
-                self.features.push("env".to_string());
-            }
-            for env_var in up_env.env_vars.iter() {
-                match (env_var.operation, env_var.value.clone()) {
-                    (EnvOperationEnum::Set, Some(value)) => {
-                        envsetter.set_value(&env_var.name, &value);
-                    }
-                    (EnvOperationEnum::Set, None) => {
-                        envsetter.unset_value(&env_var.name);
-                    }
-                    (EnvOperationEnum::Prepend, Some(value)) => {
-                        envsetter.prepend_to_list(&env_var.name, &value);
-                    }
-                    (EnvOperationEnum::Append, Some(value)) => {
-                        envsetter.append_to_list(&env_var.name, &value);
-                    }
-                    (EnvOperationEnum::Remove, Some(value)) => {
-                        envsetter.remove_from_list(&env_var.name, &value);
-                    }
-                    (EnvOperationEnum::Prefix, Some(value)) => {
-                        envsetter.prefix_value(&env_var.name, &value);
-                    }
-                    (EnvOperationEnum::Suffix, Some(value)) => {
-                        envsetter.suffix_value(&env_var.name, &value);
-                    }
-                    (_, None) => {}
-                }
-            }
+            // Apply direct changes to the environment
+            self.apply_env(up_env, &mut envsetter);
 
             if !keep_shims {
                 // Remove the shims directory from the PATH
@@ -517,155 +494,9 @@ impl DynamicEnv {
                 envsetter.prepend_to_list("PATH", path.to_str().unwrap());
             }
 
-            // Go over the tool versions in the up environment cache
+            // Apply environment changes for the tool versions
             let dir = workdir.reldir(&path).unwrap_or("".to_string());
-            for toolversion in up_env.versions_for_dir(&dir).iter() {
-                let tool = toolversion.tool.clone();
-                let normalized_name = toolversion.normalized_name.clone();
-                let version = toolversion.version.clone();
-                let version_minor = version.split('.').take(2).join(".");
-                let tool_prefix = mise_tool_path(&normalized_name, &version);
-                let bin_path = if toolversion.bin_path.is_empty() {
-                    String::new()
-                } else {
-                    format!("/{}", toolversion.bin_path.clone())
-                };
-
-                self.features.push(format!("{}:{}", tool, version));
-
-                match tool.as_str() {
-                    "ruby" => {
-                        envsetter.remove_from_list_by_fn("PATH", || {
-                            let mut values_to_remove = Vec::new();
-
-                            if let Some(rubyroot) = std::env::var_os("RUBY_ROOT") {
-                                values_to_remove
-                                    .push(format!("{}/bin", rubyroot.to_str().unwrap()));
-                            }
-
-                            if let Some(gemroot) = std::env::var_os("GEM_ROOT") {
-                                values_to_remove.push(format!("{}/bin", gemroot.to_str().unwrap()));
-                            }
-
-                            if let Some(gemhome) = std::env::var_os("GEM_HOME") {
-                                values_to_remove.push(format!("{}/bin", gemhome.to_str().unwrap()));
-                            }
-
-                            values_to_remove
-                        });
-
-                        let gems_dir = format!("{}/lib/ruby/gems", tool_prefix);
-                        let gem_home = format!("{}/{}.0", gems_dir, version_minor);
-
-                        envsetter.set_value("GEM_HOME", &gem_home);
-                        envsetter.set_value("GEM_ROOT", &gem_home);
-                        envsetter.set_value("RUBY_ENGINE", "ruby");
-                        envsetter.set_value("RUBY_ROOT", &tool_prefix);
-                        envsetter.set_value("RUBY_VERSION", &version);
-                        envsetter.prepend_to_list("GEM_PATH", &gem_home);
-                        envsetter.prepend_to_list(
-                            "PATH",
-                            &format!("{}/{}/bin", gems_dir, version_minor),
-                        );
-                        envsetter.prepend_to_list("PATH", &format!("{}/bin", tool_prefix));
-
-                        // Handle the isolated GEM_HOME
-                        if let Some(data_path) = &toolversion.data_path {
-                            envsetter.set_value("GEM_HOME", data_path);
-                            envsetter.prepend_to_list("GEM_PATH", data_path);
-                            envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
-                        }
-                    }
-                    "rust" => {
-                        envsetter.set_value("RUSTUP_HOME", &format!("{}/rustup", mise_path()));
-                        envsetter.set_value("CARGO_HOME", &format!("{}/cargo", mise_path()));
-                        envsetter.set_value("RUSTUP_TOOLCHAIN", &version);
-                        envsetter.prepend_to_list("PATH", &tool_prefix);
-
-                        // Handle the isolated CARGO_INSTALL_PATH
-                        if let Some(data_path) = &toolversion.data_path {
-                            envsetter.set_value("CARGO_INSTALL_ROOT", data_path);
-                            envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
-                        }
-                    }
-                    "go" => {
-                        if let Some(goroot) = std::env::var_os("GOROOT") {
-                            envsetter.remove_from_list(
-                                "PATH",
-                                &format!("{}/bin", goroot.to_str().unwrap()),
-                            );
-                        }
-
-                        if std::env::var_os("GOMODCACHE").is_none() {
-                            let gopath = match std::env::var_os("GOPATH") {
-                                Some(gopath) => match gopath.to_str() {
-                                    Some("") | None => format!("{}/go", user_home()),
-                                    Some(gopath) => gopath.to_string(),
-                                },
-                                None => format!("{}/go", user_home()),
-                            };
-                            envsetter.set_value("GOMODCACHE", &format!("{}/pkg/mod", gopath));
-                        }
-
-                        envsetter.set_value("GOROOT", &tool_prefix);
-                        envsetter.set_value("GOVERSION", &version);
-
-                        let gorootbin = format!("{}/bin", tool_prefix);
-                        envsetter.set_value("GOBIN", &gorootbin);
-                        envsetter.prepend_to_list("PATH", &gorootbin);
-
-                        // Handle the isolated GOPATH
-                        if let Some(data_path) = &toolversion.data_path {
-                            envsetter.prepend_to_list("GOPATH", data_path);
-
-                            let gobin = format!("{}/bin", data_path);
-                            envsetter.set_value("GOBIN", &gobin);
-                            envsetter.prepend_to_list("PATH", &gobin);
-                        }
-                    }
-                    "python" => {
-                        let tool_prefix = if let Some(data_path) = &toolversion.data_path {
-                            envsetter.set_value("VIRTUAL_ENV", data_path);
-                            envsetter.set_value("UV_PROJECT_ENVIRONMENT", data_path);
-                            data_path.clone()
-                        } else {
-                            tool_prefix
-                        };
-
-                        envsetter.unset_value("PYTHONHOME");
-                        envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
-
-                        let poetry_dir = format!("{}/poetry", tool_prefix);
-                        envsetter.set_value("POETRY_CONFIG_DIR", &format!("{}/config", poetry_dir));
-                        envsetter.set_value("POETRY_CACHE_DIR", &format!("{}/cache", poetry_dir));
-                        envsetter.set_value("POETRY_DATA_DIR", &poetry_dir);
-                    }
-                    "node" => {
-                        envsetter.set_value("NODE_VERSION", &version);
-                        envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
-
-                        // Handle the isolated NPM prefix
-                        if let Some(data_path) = &toolversion.data_path {
-                            envsetter.set_value("npm_config_prefix", data_path);
-                            envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
-                        };
-                    }
-                    "helm" => {
-                        envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
-
-                        // Handle the isolated HELM configuration and cache
-                        if let Some(data_path) = &toolversion.data_path {
-                            envsetter
-                                .set_value("HELM_CONFIG_HOME", &format!("{}/config", data_path));
-                            envsetter.set_value("HELM_CACHE_HOME", &format!("{}/cache", data_path));
-                            envsetter.set_value("HELM_DATA_HOME", &format!("{}/data", data_path));
-                        }
-                    }
-                    _ => {
-                        envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
-                    }
-                }
-            }
+            self.apply_versions(up_env, &mut envsetter, &dir);
         }
 
         // If any FLAGS variable is set, we can clean it up by removing the duplicate
@@ -717,6 +548,225 @@ impl DynamicEnv {
         let mut data = self.data.clone().unwrap();
         data.prepare_undo();
         data.export(export_mode.clone());
+    }
+
+    fn apply_env(&mut self, up_env: &UpEnvironment, envsetter: &mut DynamicEnvSetter) {
+        if up_env.env_vars.is_empty() {
+            return;
+        }
+
+        self.features.push("env".to_string());
+
+        // Add the requested environments
+        for env_var in up_env.env_vars.iter() {
+            match (env_var.operation, env_var.value.clone()) {
+                (EnvOperationEnum::Set, Some(value)) => {
+                    envsetter.set_value(&env_var.name, &value);
+                }
+                (EnvOperationEnum::Set, None) => {
+                    envsetter.unset_value(&env_var.name);
+                }
+                (EnvOperationEnum::Prepend, Some(value)) => {
+                    envsetter.prepend_to_list(&env_var.name, &value);
+                }
+                (EnvOperationEnum::Append, Some(value)) => {
+                    envsetter.append_to_list(&env_var.name, &value);
+                }
+                (EnvOperationEnum::Remove, Some(value)) => {
+                    envsetter.remove_from_list(&env_var.name, &value);
+                }
+                (EnvOperationEnum::Prefix, Some(value)) => {
+                    envsetter.prefix_value(&env_var.name, &value);
+                }
+                (EnvOperationEnum::Suffix, Some(value)) => {
+                    envsetter.suffix_value(&env_var.name, &value);
+                }
+                (_, None) => {}
+            }
+        }
+    }
+
+    fn apply_versions(
+        &mut self,
+        up_env: &UpEnvironment,
+        envsetter: &mut DynamicEnvSetter,
+        dir: &str,
+    ) {
+        // Go over the tool versions in the up environment cache
+        for toolversion in up_env.versions_for_dir(&dir).iter() {
+            let tool = toolversion.tool.clone();
+            let version = toolversion.version.clone();
+
+            // Handle backends that won't require extra setup
+            match toolversion.backend.as_str() {
+                "" | "default" => {
+                    // Do not do anything here if we use the default backend
+                }
+                "ghrelease" => {
+                    envsetter.prepend_to_list(
+                        "PATH",
+                        &github_release_tool_path(&tool, &version).to_string_lossy(),
+                    );
+                    continue;
+                }
+                "cargo-install" => {
+                    envsetter.prepend_to_list(
+                        "PATH",
+                        &cargo_install_tool_path(&tool, &version).to_string_lossy(),
+                    );
+                    continue;
+                }
+                "go-install" => {
+                    envsetter.prepend_to_list(
+                        "PATH",
+                        &go_install_tool_path(&tool, &version).to_string_lossy(),
+                    );
+                    continue;
+                }
+                _ => {
+                    // Skip the tool if we don't know the backend
+                    continue;
+                }
+            }
+
+            self.features.push(format!("{}:{}", tool, version));
+
+            let normalized_name = toolversion.normalized_name.clone();
+            let tool_prefix = mise_tool_path(&normalized_name, &version);
+            let bin_path = if toolversion.bin_path.is_empty() {
+                String::new()
+            } else {
+                format!("/{}", toolversion.bin_path.clone())
+            };
+
+            match tool.as_str() {
+                "ruby" => {
+                    envsetter.remove_from_list_by_fn("PATH", || {
+                        let mut values_to_remove = Vec::new();
+
+                        if let Some(rubyroot) = std::env::var_os("RUBY_ROOT") {
+                            values_to_remove.push(format!("{}/bin", rubyroot.to_str().unwrap()));
+                        }
+
+                        if let Some(gemroot) = std::env::var_os("GEM_ROOT") {
+                            values_to_remove.push(format!("{}/bin", gemroot.to_str().unwrap()));
+                        }
+
+                        if let Some(gemhome) = std::env::var_os("GEM_HOME") {
+                            values_to_remove.push(format!("{}/bin", gemhome.to_str().unwrap()));
+                        }
+
+                        values_to_remove
+                    });
+
+                    let version_minor = version.split('.').take(2).join(".");
+                    let gems_dir = format!("{}/lib/ruby/gems", tool_prefix);
+                    let gem_home = format!("{}/{}.0", gems_dir, version_minor);
+
+                    envsetter.set_value("GEM_HOME", &gem_home);
+                    envsetter.set_value("GEM_ROOT", &gem_home);
+                    envsetter.set_value("RUBY_ENGINE", "ruby");
+                    envsetter.set_value("RUBY_ROOT", &tool_prefix);
+                    envsetter.set_value("RUBY_VERSION", &version);
+                    envsetter.prepend_to_list("GEM_PATH", &gem_home);
+                    envsetter
+                        .prepend_to_list("PATH", &format!("{}/{}/bin", gems_dir, version_minor));
+                    envsetter.prepend_to_list("PATH", &format!("{}/bin", tool_prefix));
+
+                    // Handle the isolated GEM_HOME
+                    if let Some(data_path) = &toolversion.data_path {
+                        envsetter.set_value("GEM_HOME", data_path);
+                        envsetter.prepend_to_list("GEM_PATH", data_path);
+                        envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
+                    }
+                }
+                "rust" => {
+                    envsetter.set_value("RUSTUP_HOME", &format!("{}/rustup", mise_path()));
+                    envsetter.set_value("CARGO_HOME", &format!("{}/cargo", mise_path()));
+                    envsetter.set_value("RUSTUP_TOOLCHAIN", &version);
+                    envsetter.prepend_to_list("PATH", &tool_prefix);
+
+                    // Handle the isolated CARGO_INSTALL_PATH
+                    if let Some(data_path) = &toolversion.data_path {
+                        envsetter.set_value("CARGO_INSTALL_ROOT", data_path);
+                        envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
+                    }
+                }
+                "go" => {
+                    if let Some(goroot) = std::env::var_os("GOROOT") {
+                        envsetter
+                            .remove_from_list("PATH", &format!("{}/bin", goroot.to_str().unwrap()));
+                    }
+
+                    if std::env::var_os("GOMODCACHE").is_none() {
+                        let gopath = match std::env::var_os("GOPATH") {
+                            Some(gopath) => match gopath.to_str() {
+                                Some("") | None => format!("{}/go", user_home()),
+                                Some(gopath) => gopath.to_string(),
+                            },
+                            None => format!("{}/go", user_home()),
+                        };
+                        envsetter.set_value("GOMODCACHE", &format!("{}/pkg/mod", gopath));
+                    }
+
+                    envsetter.set_value("GOROOT", &tool_prefix);
+                    envsetter.set_value("GOVERSION", &version);
+
+                    let gorootbin = format!("{}/bin", tool_prefix);
+                    envsetter.set_value("GOBIN", &gorootbin);
+                    envsetter.prepend_to_list("PATH", &gorootbin);
+
+                    // Handle the isolated GOPATH
+                    if let Some(data_path) = &toolversion.data_path {
+                        envsetter.prepend_to_list("GOPATH", data_path);
+
+                        let gobin = format!("{}/bin", data_path);
+                        envsetter.set_value("GOBIN", &gobin);
+                        envsetter.prepend_to_list("PATH", &gobin);
+                    }
+                }
+                "python" => {
+                    let tool_prefix = if let Some(data_path) = &toolversion.data_path {
+                        envsetter.set_value("VIRTUAL_ENV", data_path);
+                        envsetter.set_value("UV_PROJECT_ENVIRONMENT", data_path);
+                        data_path.clone()
+                    } else {
+                        tool_prefix
+                    };
+
+                    envsetter.unset_value("PYTHONHOME");
+                    envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
+
+                    let poetry_dir = format!("{}/poetry", tool_prefix);
+                    envsetter.set_value("POETRY_CONFIG_DIR", &format!("{}/config", poetry_dir));
+                    envsetter.set_value("POETRY_CACHE_DIR", &format!("{}/cache", poetry_dir));
+                    envsetter.set_value("POETRY_DATA_DIR", &poetry_dir);
+                }
+                "node" => {
+                    envsetter.set_value("NODE_VERSION", &version);
+                    envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
+
+                    // Handle the isolated NPM prefix
+                    if let Some(data_path) = &toolversion.data_path {
+                        envsetter.set_value("npm_config_prefix", data_path);
+                        envsetter.prepend_to_list("PATH", &format!("{}/bin", data_path));
+                    };
+                }
+                "helm" => {
+                    envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
+
+                    // Handle the isolated HELM configuration and cache
+                    if let Some(data_path) = &toolversion.data_path {
+                        envsetter.set_value("HELM_CONFIG_HOME", &format!("{}/config", data_path));
+                        envsetter.set_value("HELM_CACHE_HOME", &format!("{}/cache", data_path));
+                        envsetter.set_value("HELM_DATA_HOME", &format!("{}/data", data_path));
+                    }
+                }
+                _ => {
+                    envsetter.prepend_to_list("PATH", &format!("{}{}", tool_prefix, bin_path));
+                }
+            }
+        }
     }
 }
 

--- a/src/internal/dynenv.rs
+++ b/src/internal/dynenv.rs
@@ -593,7 +593,7 @@ impl DynamicEnv {
         dir: &str,
     ) {
         // Go over the tool versions in the up environment cache
-        for toolversion in up_env.versions_for_dir(&dir).iter() {
+        for toolversion in up_env.versions_for_dir(dir).iter() {
             let tool = toolversion.tool.clone();
             let version = toolversion.version.clone();
 

--- a/website/contents/reference/configuration/parameters/up/cargo-install.md
+++ b/website/contents/reference/configuration/parameters/up/cargo-install.md
@@ -14,6 +14,7 @@ This will automatically install a version of [`rust`](rust) if none is available
 
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
+| `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use this tool |
 | `crate` | string | The name of the crate to install |
 | `version` | string | The version to install; see [version handling](#version-handling) below for more details. |
 | `exact` | boolean | Whether to match the exact version or not; if set to `true`, `cargo install <crate>@<version>` will be called directly instead of listing the available versions and following the [version handling](#version-handling) rules *(default: `false`)* |
@@ -94,6 +95,20 @@ up:
       - exa: 0.9.0
       - crate: bat
         version: 0.15.0
+        
+  # Use this tool only in the specified directory
+  - cargo-install:
+      crate: ripgrep
+      version: 14.0.1
+      dir: tools/dir
+      
+  # Use this tool in multiple directories
+  - cargo-install:
+      crate: ripgrep
+      version: 14.0.1
+      dir:
+        - tools/dir
+        - scripts/dir
 ```
 
 ## Dynamic environment

--- a/website/contents/reference/configuration/parameters/up/github-release.md
+++ b/website/contents/reference/configuration/parameters/up/github-release.md
@@ -35,6 +35,7 @@ This supports authenticated requests using [the `gh` command line interface](htt
 
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
+| `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use this tool |
 | `repository` | string | The name of the repository to download the release from, in the `<owner>/<name>` format; can also be provided as an object with the `owner` and `name` keys |
 | `version` | string | The version of the tool to install; see [version handling](#version-handling) below for more details. |
 | `upgrade` | boolean | whether or not to always upgrade to the most up to date matching release, even if an already-installed version matches the requirements *(default: false)* |
@@ -154,6 +155,20 @@ up:
       asset_name: "cross-platform-binary"
       skip_os_matching: true
       skip_arch_matching: true
+
+  # Use this tool only in the specified directory
+  - github-release:
+      repository: xaf/omni
+      version: 1.2.3
+      dir: some/specific/dir
+      
+  # Use this tool in multiple directories
+  - github-release:
+      repository: xaf/omni
+      version: 1.2.3
+      dir:
+        - some/specific/dir
+        - another/dir
 ```
 
 ## Dynamic environment

--- a/website/contents/reference/configuration/parameters/up/go-install.md
+++ b/website/contents/reference/configuration/parameters/up/go-install.md
@@ -14,6 +14,7 @@ This will automatically install a version of [`go`](go) if none is available thr
 
 | Parameter        | Type      | Description                                           |
 |------------------|-----------|-------------------------------------------------------|
+| `dir` | path | Relative path (or list of relative paths) to the directory in the project for which to use this tool |
 | `path` | string | The `<path>` part of `go install <path>[@<version>]` |
 | `version` | string | The version to install; see [version handling](#version-handling) below for more details. |
 | `exact` | boolean | Whether to match the exact version or not; if set to `true`, `go install <path>@<version>` will be called directly instead of listing the available versions and following the [version handling](#version-handling) rules *(default: `false`)* |
@@ -94,6 +95,20 @@ up:
       - google.golang.org/grpc/cmd/protoc-gen-go: 1.27.1
       - path: google.golang.org/grpc/cmd/protoc-gen-go-grpc
         version: 1.5.0
+        
+  # Use this tool only in the specified directory
+  - go-install:
+      path: google.golang.org/protobuf/cmd/protoc-gen-go
+      version: 1.27.0
+      dir: proto/gen
+      
+  # Use this tool in multiple directories
+  - go-install:
+      path: google.golang.org/protobuf/cmd/protoc-gen-go
+      version: 1.27.0
+      dir:
+        - proto/gen
+        - api/gen
 ```
 
 ## Dynamic environment


### PR DESCRIPTION
The `github-release`, `cargo-install` and `go-install` operations did not support per-directory installation before.

By adding a `dir` parameter to any entry in those operations, we can now scope the subdirectory in which it will be installed.

Closes https://github.com/xaf/omni/issues/882