### PR TITLE
feat(argparser): support list for parameter type

### DIFF
--- a/tests/test_config_commands.bats
+++ b/tests/test_config_commands.bats
@@ -368,7 +368,56 @@ EOF
 }
 
 # bats test_tags=config:commands,config:commands:argparser
-@test "[config_commands=11] omni config commands argparser with multiple values" {
+@test "[config_commands=11] omni config commands argparser with enum list syntax" {
+  cat > .omni.yaml <<EOF
+commands:
+  customcommand:
+    argparser: true
+    syntax:
+      parameters:
+      - name: --level
+        desc: The log level
+        type: [debug, info, warn, error]
+        default: info
+    desc: This is a custom command with list-as-enum syntax
+    run: |
+      echo "Log level is: \${OMNI_ARG_LEVEL_VALUE:-default}!"
+EOF
+
+  run omni customcommand --help 3>&-
+  echo "1. STATUS: $status"
+  echo "1. OUTPUT: $output"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Usage: omni customcommand"
+  echo "$output" | grep -q -- "--level <LEVEL>\s*The log level \[default: info\] \[possible values: debug, info, warn, error\]"
+
+  run omni customcommand 3>&-
+  echo "2. STATUS: $status"
+  echo "2. OUTPUT: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Log level is: info!" ]
+
+  run omni customcommand --level debug 3>&-
+  echo "3. STATUS: $status"
+  echo "3. OUTPUT: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Log level is: debug!" ]
+
+  run omni customcommand --level warn 3>&-
+  echo "4. STATUS: $status"
+  echo "4. OUTPUT: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Log level is: warn!" ]
+
+  run omni customcommand --level invalid 3>&-
+  echo "5. STATUS: $status"
+  echo "5. OUTPUT: $output"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "invalid value 'invalid'"
+}
+
+# bats test_tags=config:commands,config:commands:argparser
+@test "[config_commands=12] omni config commands argparser with multiple values" {
   cat > .omni.yaml <<EOF
 commands:
   customcommand:
@@ -426,7 +475,7 @@ EOF
 }
 
 # bats test_tags=config:commands,config:commands:argparser
-@test "[config_commands=12] omni config commands argparser with default values" {
+@test "[config_commands=13] omni config commands argparser with default values" {
   cat > .omni.yaml <<EOF
 commands:
   customcommand:

--- a/website/contents/reference/configuration/parameters/commands.md
+++ b/website/contents/reference/configuration/parameters/commands.md
@@ -43,7 +43,7 @@ Each `parameter` object can take the following parameters:
 | `desc` | string | the description/help for the parameter |
 | `required` | bool | whether or not this parameter is required |
 | `placeholders` | string (list) | the placeholders to show in the help for that parameter; if multiple placeholders are provided, they will be used one after the other depending on the `num_values` configuration |
-| `type` | string | the type of the parameter, can be one of `str`, `int`, `float`, `bool`, `flag`, `counter`, `enum(vals, ...)` or `array/<type>` for any of those except `flag` and `counter`. See below for more details on the types. |
+| `type` | string or list | the type of the parameter, can be one of `str`, `int`, `float`, `bool`, `flag`, `counter`, `enum(vals, ...)` or `array/<type>` for any of those except `flag` and `counter`. If a list is provided, it will be treated as `enum` with those values as the allowed options. See below for more details on the types. |
 | `values` | string (list) | for `enum` type parameters, the list of allowed values. Alternative to inline syntax `enum(vals, ...)`. |
 | `default` | string | the default value for the parameter |
 | `num_values` | string | the number of values that the parameter can take. This can take ranges in the format `..max` (open), `..=max` (closed), `min..`, `min..max` (half-open), `min..=max` (closed) |
@@ -127,9 +127,17 @@ commands:
         desc: Deployment mode
         type: enum(fast, safe, rollback)
         default: safe
+      - name: --level
+        desc: Log level
+        type:
+          - debug
+          - info
+          - warn
+          - error
+        default: info
     desc: "Deploy the application to specified environment"
     run: |
-      echo "Deploying to $1 with mode $2"
+      echo "Deploying to $1 with mode $2 and log level $3"
 
   # A command with alternative ways to be called
   # Can be called as `omni main`, `omni alt1` or `omni alt2`


### PR DESCRIPTION
Add support for using a list directly as the parameter type to create enum parameters, on top of existing syntaxes accepted for enum.

This provides:
  `type: [debug, info, warn, error]`
which is equivalent to the existing:
   `type: enum`
   with `values: [debug, info, warn, error]`
and to:
   `type: enum(debug, info, warn, error)`

If the `type` field is a list, the `values` field will be entirely ignored, and the items in the `type` field will be used as `values`.