### PR TITLE
feat(self-update): support disabled updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ exclude = [
 name = "omni"
 path = "src/main.rs"
 
+[features]
+default = ["self-update-check"]
+self-update = []
+self-update-check = ["self-update"]
+
 [build-dependencies]
 time = { version = "0.3.41", features = ["serde-well-known"] }
 

--- a/src/internal/build.rs
+++ b/src/internal/build.rs
@@ -1,0 +1,138 @@
+use std::process::Command as ProcessCommand;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref RELEASE_ARCH: String = {
+        let arch = match std::env::consts::ARCH {
+            "aarch64" => "arm64",
+            _ => std::env::consts::ARCH,
+        };
+        arch.to_string()
+    };
+
+    static ref RELEASE_OS: String = {
+        let os = match std::env::consts::OS {
+            "macos" => "darwin",
+            _ => std::env::consts::OS,
+        };
+        os.to_string()
+    };
+
+    static ref ROSETTA_AVAILABLE: bool = compute_check_rosetta_available();
+}
+
+pub fn current_os() -> String {
+    (*RELEASE_OS).clone()
+}
+
+pub fn current_arch() -> String {
+    (*RELEASE_ARCH).clone()
+}
+
+const RELEASE_ARCH_X86_64: &[&str] = &["x86_64", "amd64", "x64"];
+const RELEASE_ARCH_ARM64: &[&str] = &["arm64", "aarch64", "aarch_64"];
+const RELEASE_ARCH_DARWIN_UNIVERSAL: &[&str] = &["universal", "all", "any"];
+
+/// This function returns the compatible release architectures for the current
+/// system, based on the current architecture. It returns a vector of vectors
+/// as there are different layers of compatibility that should be followed for
+/// preference, e.g. for Darwin, we will find direct-compatibility, universal
+/// compatibility, and finally Rosetta compatibility.
+pub fn compatible_release_arch() -> Vec<Vec<String>> {
+    let mut archs = vec![];
+
+    // First add the direct compatibility
+    archs.push(if *RELEASE_ARCH == "x86_64" {
+        RELEASE_ARCH_X86_64.iter().map(|s| s.to_string()).collect()
+    } else if *RELEASE_ARCH == "arm64" {
+        RELEASE_ARCH_ARM64.iter().map(|s| s.to_string()).collect()
+    } else {
+        vec![(*RELEASE_ARCH).to_string()]
+    });
+
+    // Then, if we're on Darwin, add the universal compatibility
+    if *RELEASE_OS == "darwin" {
+        archs.push(
+            RELEASE_ARCH_DARWIN_UNIVERSAL
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
+
+        // Finally, if Rosetta is available, add the Rosetta compatibility
+        if check_rosetta_available() {
+            archs.push(RELEASE_ARCH_X86_64.iter().map(|s| s.to_string()).collect());
+        }
+    }
+
+    archs
+}
+
+fn compute_check_rosetta_available() -> bool {
+    if *RELEASE_OS != "darwin" || *RELEASE_ARCH == "x86_64" {
+        return false;
+    }
+
+    // Verify that /usr/bin/pgrep, /usr/bin/arch and /usr/bin/uname
+    // exist and are executable
+    for binary in &["/usr/bin/pgrep", "/usr/bin/arch", "/usr/bin/uname"] {
+        if !std::path::Path::new(binary).exists() || !std::path::Path::new(binary).is_file() {
+            return false;
+        }
+
+        // Get the metadata
+        let metadata = match std::fs::metadata(binary) {
+            Ok(metadata) => metadata,
+            Err(_) => return false,
+        };
+
+        // Check if it's executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if metadata.permissions().mode() & 0o111 == 0 {
+                return false;
+            }
+        }
+    }
+
+    // Verify that the `oahd` process is running; if not,
+    // it means Rosetta is not available
+    if !ProcessCommand::new("/usr/bin/pgrep")
+        .arg("oahd")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    // Run `uname -m` through `arch` and check if the answer is `x86_64`, we also
+    // redirect the error output to `/dev/null` as we don't care about it
+    let output = ProcessCommand::new("/usr/bin/arch")
+        .arg("-x86_64")
+        .arg("/usr/bin/uname")
+        .arg("-m")
+        .stderr(std::process::Stdio::null())
+        .output();
+
+    // Validate that the output is `x86_64`
+    output
+        .map(|output| {
+            output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "x86_64"
+        })
+        .unwrap_or(false)
+}
+
+fn check_rosetta_available() -> bool {
+    *ROSETTA_AVAILABLE
+}
+
+pub fn compatible_release_os() -> Vec<String> {
+    if *RELEASE_OS == "darwin" {
+        vec!["darwin".to_string(), "macos".to_string(), "osx".to_string()]
+    } else {
+        vec![(*RELEASE_OS).to_string()]
+    }
+}

--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -20,8 +20,8 @@ use crate::internal::config::up::github_release::AssetNameMatcher;
 use crate::internal::config::up::utils::VersionMatcher;
 use crate::internal::config::up::utils::VersionParser;
 use crate::internal::env::now as omni_now;
-use crate::internal::self_updater::compatible_release_arch;
-use crate::internal::self_updater::compatible_release_os;
+use crate::internal::build::compatible_release_arch;
+use crate::internal::build::compatible_release_os;
 
 lazy_static! {
     static ref OS_REGEX: Regex = match Regex::new(&format!(

--- a/src/internal/config/parser/path_repo_updates.rs
+++ b/src/internal/config/parser/path_repo_updates.rs
@@ -198,7 +198,7 @@ impl PathRepoUpdatesConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum PathRepoUpdatesSelfUpdateEnum {
     #[serde(rename = "true")]
     True,
@@ -206,9 +206,18 @@ pub enum PathRepoUpdatesSelfUpdateEnum {
     False,
     #[serde(rename = "nocheck")]
     NoCheck,
-    #[default]
     #[serde(other, rename = "ask")]
     Ask,
+}
+
+impl Default for PathRepoUpdatesSelfUpdateEnum {
+    fn default() -> Self {
+        if cfg!(feature = "self-update-check") {
+            Self::Ask
+        } else {
+            Self::NoCheck
+        }
+    }
 }
 
 impl PathRepoUpdatesSelfUpdateEnum {
@@ -242,6 +251,7 @@ impl PathRepoUpdatesSelfUpdateEnum {
         matches!(self, PathRepoUpdatesSelfUpdateEnum::NoCheck)
     }
 
+    #[cfg(feature = "self-update")]
     pub fn is_false(&self) -> bool {
         match self {
             Self::False => true,
@@ -250,6 +260,7 @@ impl PathRepoUpdatesSelfUpdateEnum {
         }
     }
 
+    #[cfg(feature = "self-update")]
     pub fn is_ask(&self) -> bool {
         match self {
             Self::Ask => shell_is_interactive(),

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -21,6 +21,8 @@ use sha2::Sha256;
 use sha2::Sha384;
 use sha2::Sha512;
 
+use crate::internal::build::current_arch;
+use crate::internal::build::current_os;
 use crate::internal::cache::github_release::GithubReleaseAsset;
 use crate::internal::cache::github_release::GithubReleasesSelector;
 use crate::internal::cache::up_environments::UpEnvironment;
@@ -46,8 +48,6 @@ use crate::internal::config::utils::check_allowed;
 use crate::internal::config::ConfigValue;
 use crate::internal::dynenv::update_dynamic_env_for_command_from_env;
 use crate::internal::env::data_home;
-use crate::internal::build::current_arch;
-use crate::internal::build::current_os;
 use crate::internal::user_interface::StringColor;
 
 const GITHUB_API_URL: &str = "https://api.github.com";
@@ -2543,8 +2543,8 @@ mod tests {
     mod up {
         use super::*;
 
-        use crate::internal::self_updater::compatible_release_arch;
-        use crate::internal::self_updater::compatible_release_os;
+        use crate::internal::build::compatible_release_arch;
+        use crate::internal::build::compatible_release_os;
         use crate::internal::testutils::run_with_env;
 
         #[test]

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -46,8 +46,8 @@ use crate::internal::config::utils::check_allowed;
 use crate::internal::config::ConfigValue;
 use crate::internal::dynenv::update_dynamic_env_for_command_from_env;
 use crate::internal::env::data_home;
-use crate::internal::self_updater::current_arch;
-use crate::internal::self_updater::current_os;
+use crate::internal::build::current_arch;
+use crate::internal::build::current_os;
 use crate::internal::user_interface::StringColor;
 
 const GITHUB_API_URL: &str = "https://api.github.com";

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -677,6 +677,7 @@ fn resolve_homebrew_repository() -> Option<String> {
 }
 
 /// Returns the homebrew repository, if available.
+#[cfg(feature = "self-update")]
 pub fn homebrew_repository() -> Option<String> {
     (*HOMEBREW_REPOSITORY).clone()
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -30,7 +30,15 @@ pub(crate) mod utils;
 
 pub(crate) mod dynenv;
 
+pub(crate) mod build;
+
+#[cfg(feature = "self-update")]
 pub(crate) mod self_updater;
+
+#[cfg(not(feature = "self-update"))]
+#[path = "disabled_self_updater.rs"]
+pub(crate) mod self_updater;
+
 pub(crate) use self_updater::self_update;
 
 #[cfg(test)]


### PR DESCRIPTION
This introduces support for disabling self-updates entirely at compile time, or compiling omni for defaulting to not check for new updates.

This also introduces support for versioned brew formulas, and disabling self-updates automatically if omni was installed through a versioned formula.