### PR TITLE
feat(gitignore): handle ignoring from workdir root

### DIFF
--- a/.omni.yaml
+++ b/.omni.yaml
@@ -8,6 +8,7 @@ up:
 
 commands:
   create-tag:
+    argparser: true
     desc: Create a new version tag for omni
     run: |
       set -e
@@ -45,6 +46,7 @@ commands:
       echo "Created tag: $new_tag"
 
   website-dev:
+    argparser: true
     desc: |
       Starts a local development server for the website
 
@@ -55,6 +57,7 @@ commands:
       yarn start
 
   cargo-package:
+    argparser: true
     desc: Runs cargo package after overriding the version
     run: |
       # Check if git is dirty
@@ -81,6 +84,7 @@ commands:
       git checkout Cargo.toml
 
   lint:
+    argparser: true
     desc: Runs the linter
     aliases:
       - clippy
@@ -89,18 +93,46 @@ commands:
       cargo clippy --all-features
 
   test:
-    desc: Runs the tests
+    argparser: true
+    desc: Runs all tests
+    syntax:
+      parameters:
+        - name: --unit
+          type: flag
+          desc: Select the unit tests
+        - name: --integration
+          type: flag
+          desc: Select the integration tests
     run: |
       set -e
-      cargo test
-      GENERATE_FIXTURES=false bats tests/
+
+      run_unit=${OMNI_ARG_UNIT_VALUE:-false}
+      run_integration=${OMNI_ARG_INTEGRATION_VALUE:-false}
+
+      if [[ "$run_unit" == "false" && "$run_integration" == "false" ]]; then
+        run_unit=true
+        run_integration=true
+      fi
+
+      if [[ "$run_unit" == "true" ]]; then
+        echo >&2 -e "\033[1;34mRunning unit tests...\033[0m"
+        cargo test
+      fi
+
+      if [[ "$run_integration" == "true" ]]; then
+        echo >&2 -e "\033[1;34mRunning integration tests...\033[0m"
+        GENERATE_FIXTURES=false bats tests/
+      fi
+
     subcommands:
       generate:
+        argparser: true
         desc: Generates the fixtures for the tests
         run: |
           GENERATE_FIXTURES=true bats --filter-tags generate tests/ "$@"
 
       renumber:
+        argparser: true
         desc: Renumber the bats tests
         run: |
           set -e
@@ -126,6 +158,7 @@ commands:
           done
 
   fix:
+    argparser: true
     desc: Fixes the code
     run: |
       set -e

--- a/src/internal/cache/up_environments_test.rs
+++ b/src/internal/cache/up_environments_test.rs
@@ -465,21 +465,23 @@ mod up_environment {
 
     #[test]
     fn test_paths() {
-        let mut env = UpEnvironment::new();
-        let data_home_path = PathBuf::from(data_home()).join("test");
-        let regular_path = PathBuf::from("/usr/local/bin");
+        run_with_env(&[], || {
+            let mut env = UpEnvironment::new();
+            let data_home_path = PathBuf::from(data_home()).join("test");
+            let regular_path = PathBuf::from("/usr/local/bin");
 
-        // Test adding single path
-        assert!(env.add_path(regular_path.clone()));
-        assert_eq!(env.paths.len(), 1);
+            // Test adding single path
+            assert!(env.add_path(regular_path.clone()));
+            assert_eq!(env.paths.len(), 1);
 
-        // Test data_home path gets prepended
-        assert!(env.add_path(data_home_path.clone()));
-        assert_eq!(env.paths[0], data_home_path);
+            // Test data_home path gets prepended
+            assert!(env.add_path(data_home_path.clone()));
+            assert_eq!(env.paths[0], data_home_path);
 
-        // Test adding multiple paths
-        assert!(env.add_paths(vec![PathBuf::from("/path1"), PathBuf::from("/path2")]));
-        assert_eq!(env.paths.len(), 4);
+            // Test adding multiple paths
+            assert!(env.add_paths(vec![PathBuf::from("/path1"), PathBuf::from("/path2")]));
+            assert_eq!(env.paths.len(), 4);
+        });
     }
 
     #[test]

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -47,7 +47,7 @@ use crate::internal::env::cache_home;
 use crate::internal::env::current_dir;
 use crate::internal::env::data_home;
 use crate::internal::env::state_home;
-use crate::internal::git::is_path_gitignored;
+use crate::internal::git::is_path_gitignored_from;
 use crate::internal::git_env;
 use crate::internal::user_interface::StringColor;
 use crate::internal::workdir;
@@ -1537,6 +1537,8 @@ impl UpConfigMise {
         detect_version_funcs.push(detect_version_from_tool_version_file);
 
         let in_repo = git_env(".").in_repo();
+        let wd = workdir(".");
+        let wd_root = wd.root();
         for search_dir in search_dirs.iter() {
             // For safety, we remove any leading slashes from the search directory,
             // as we only want to search in the workdir
@@ -1577,7 +1579,9 @@ impl UpConfigMise {
                     {
                         // Check if the entry is .gitignore'd, we do this now for now as it
                         // seems less costly than evaluating all files ahead of time
-                        if in_repo && matches!(is_path_gitignored(entry.path()), Ok(true)) {
+                        if in_repo
+                            && matches!(is_path_gitignored_from(entry.path(), wd_root), Ok(true))
+                        {
                             continue;
                         }
 

--- a/src/internal/git/mod.rs
+++ b/src/internal/git/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use utils::format_path_with_template;
 pub(crate) use utils::full_git_url_parse;
 pub(crate) use utils::id_from_git_url;
 pub(crate) use utils::is_path_gitignored;
+pub(crate) use utils::is_path_gitignored_from;
 pub(crate) use utils::package_path_from_git_url;
 pub(crate) use utils::package_path_from_handle;
 pub(crate) use utils::package_root_path;

--- a/src/internal/git/utils.rs
+++ b/src/internal/git/utils.rs
@@ -213,18 +213,7 @@ pub fn is_path_gitignored_from<P1: AsRef<Path>, P2: AsRef<Path>>(
     };
 
     // Try to find the Git repository from the path's directory
-    let repo = git2::Repository::discover(search_dir);
-    let repo = match repo {
-        Ok(r) => r,
-        Err(e) => {
-            println!(
-                "Warning: Could not find a Git repository from path '{}': {}",
-                path.display(),
-                e
-            );
-            return Err(Box::new(e));
-        }
-    };
+    let repo = git2::Repository::discover(search_dir)?;
 
     // Get the absolute path
     let abs_path = abs_path(path);

--- a/src/internal/git/utils_test.rs
+++ b/src/internal/git/utils_test.rs
@@ -1,0 +1,562 @@
+use super::*;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+mod package_root_path_tests {
+    use super::*;
+
+    #[test]
+    fn test_package_root_path_returns_package_path() {
+        let result = package_root_path();
+        assert!(result.contains("packages"));
+        assert!(result.ends_with("/packages"));
+    }
+}
+
+mod safe_git_url_parse_tests {
+    use super::*;
+
+    #[test]
+    fn test_safe_git_url_parse_valid_https_url() {
+        let url = "https://github.com/owner/repo.git";
+        let result = safe_git_url_parse(url);
+
+        assert!(result.is_ok());
+        let git_url = result.unwrap();
+        assert_eq!(git_url.host, Some("github.com".to_string()));
+        assert_eq!(git_url.owner, Some("owner".to_string()));
+        assert_eq!(git_url.name, "repo");
+    }
+
+    #[test]
+    fn test_safe_git_url_parse_valid_ssh_url() {
+        let url = "git@github.com:owner/repo.git";
+        let result = safe_git_url_parse(url);
+
+        assert!(result.is_ok());
+        let git_url = result.unwrap();
+        assert_eq!(git_url.host, Some("github.com".to_string()));
+        assert_eq!(git_url.owner, Some("owner".to_string()));
+        assert_eq!(git_url.name, "repo");
+    }
+
+    #[test]
+    fn test_safe_git_url_parse_invalid_url() {
+        let url = "completely-invalid-format";
+        let result = safe_git_url_parse(url);
+
+        if let Ok(git_url) = &result {
+            println!("Unexpectedly parsed: {:?}", git_url);
+        }
+        // The git_url_parse library is quite lenient, so let's test for a URL that should fail
+        // Try a URL that should definitely fail
+        let invalid_result = safe_git_url_parse("://invalid");
+        assert!(invalid_result.is_err());
+    }
+}
+
+mod id_from_git_url_tests {
+    use super::*;
+
+    #[test]
+    fn test_id_from_git_url_complete_url() {
+        let url = "https://github.com/owner/repo.git";
+        let git_url = safe_git_url_parse(url).unwrap();
+        let result = id_from_git_url(&git_url);
+
+        assert_eq!(result, Some("github.com:owner/repo".to_string()));
+    }
+
+    #[test]
+    fn test_id_from_git_url_missing_owner() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.owner = None;
+        let result = id_from_git_url(&git_url);
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_id_from_git_url_missing_host() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.host = None;
+        let result = id_from_git_url(&git_url);
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_id_from_git_url_empty_name() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.name = String::new();
+        let result = id_from_git_url(&git_url);
+
+        assert_eq!(result, None);
+    }
+}
+
+mod full_git_url_parse_tests {
+    use super::*;
+
+    #[test]
+    fn test_full_git_url_parse_valid_https_url() {
+        let url = "https://github.com/owner/repo.git";
+        let result = full_git_url_parse(url);
+
+        assert!(result.is_ok());
+        let git_url = result.unwrap();
+        assert_eq!(git_url.host, Some("github.com".to_string()));
+        assert_eq!(git_url.owner, Some("owner".to_string()));
+        assert_eq!(git_url.name, "repo");
+    }
+
+    #[test]
+    fn test_full_git_url_parse_file_scheme_rejected() {
+        let url = "file:///path/to/repo";
+        let result = full_git_url_parse(url);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GitUrlError::UnsupportedScheme(scheme) => assert_eq!(scheme, "file"),
+            _ => panic!("Expected UnsupportedScheme error"),
+        }
+    }
+
+    #[test]
+    fn test_full_git_url_parse_missing_name() {
+        // This would need to be crafted to have no name - testing the validation
+        let url = "https://github.com/owner/";
+        let result = full_git_url_parse(url);
+
+        if result.is_err() {
+            match result.unwrap_err() {
+                GitUrlError::MissingRepositoryName => (),
+                _ => panic!("Expected MissingRepositoryName error"),
+            }
+        }
+    }
+}
+
+mod format_path_with_template_tests {
+    use super::*;
+
+    #[test]
+    fn test_format_path_with_template_basic() {
+        let url = "https://github.com/owner/repo.git";
+        let git_url = safe_git_url_parse(url).unwrap();
+        let result = format_path_with_template("/base", &git_url, "%{host}/%{org}/%{repo}");
+
+        assert_eq!(result, PathBuf::from("/base/github.com/owner/repo"));
+    }
+
+    #[test]
+    fn test_format_path_with_template_custom_format() {
+        let url = "https://example.com/myorg/myproject.git";
+        let git_url = safe_git_url_parse(url).unwrap();
+        let result = format_path_with_template("/workspace", &git_url, "src/%{org}/%{repo}");
+
+        assert_eq!(result, PathBuf::from("/workspace/src/myorg/myproject"));
+    }
+}
+
+mod format_path_with_template_and_data_tests {
+    use super::*;
+
+    #[test]
+    fn test_format_path_with_template_and_data_basic() {
+        let result = format_path_with_template_and_data(
+            "/base",
+            "github.com",
+            "owner",
+            "repo",
+            "%{host}/%{org}/%{repo}",
+        );
+
+        assert_eq!(result, PathBuf::from("/base/github.com/owner/repo"));
+    }
+
+    #[test]
+    fn test_format_path_with_template_and_data_nested_path() {
+        let result = format_path_with_template_and_data(
+            "/workspace",
+            "gitlab.com",
+            "group",
+            "project",
+            "sources/%{host}/%{org}/%{repo}/code",
+        );
+
+        assert_eq!(
+            result,
+            PathBuf::from("/workspace/sources/gitlab.com/group/project/code")
+        );
+    }
+
+    #[test]
+    fn test_format_path_with_template_and_data_no_template() {
+        let result = format_path_with_template_and_data(
+            "/base",
+            "example.com",
+            "user",
+            "project",
+            "static/path",
+        );
+
+        assert_eq!(result, PathBuf::from("/base/static/path"));
+    }
+}
+
+mod package_path_from_handle_tests {
+    use super::*;
+
+    #[test]
+    fn test_package_path_from_handle_valid_url() {
+        let handle = "https://github.com/owner/repo.git";
+        let result = package_path_from_handle(handle);
+
+        assert!(result.is_some());
+        let path = result.unwrap();
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("github.com"));
+        assert!(path_str.contains("owner"));
+        assert!(path_str.contains("repo"));
+    }
+
+    #[test]
+    fn test_package_path_from_handle_invalid_url() {
+        let handle = "not-a-valid-url";
+        let result = package_path_from_handle(handle);
+
+        assert!(result.is_none());
+    }
+}
+
+mod package_path_from_git_url_tests {
+    use super::*;
+
+    #[test]
+    fn test_package_path_from_git_url_valid() {
+        let url = "https://github.com/owner/repo.git";
+        let git_url = safe_git_url_parse(url).unwrap();
+        let result = package_path_from_git_url(&git_url);
+
+        assert!(result.is_some());
+        let path = result.unwrap();
+        let path_str = path.to_string_lossy();
+        assert!(path_str.contains("github.com"));
+        assert!(path_str.contains("owner"));
+        assert!(path_str.contains("repo"));
+    }
+
+    #[test]
+    fn test_package_path_from_git_url_file_scheme() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.scheme = git_url_parse::Scheme::File;
+        let result = package_path_from_git_url(&git_url);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_package_path_from_git_url_empty_name() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.name = String::new();
+        let result = package_path_from_git_url(&git_url);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_package_path_from_git_url_missing_owner() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.owner = None;
+        let result = package_path_from_git_url(&git_url);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_package_path_from_git_url_missing_host() {
+        let mut git_url = safe_git_url_parse("https://github.com/owner/repo.git").unwrap();
+        git_url.host = None;
+        let result = package_path_from_git_url(&git_url);
+
+        assert!(result.is_none());
+    }
+}
+
+mod is_path_gitignored_tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn setup_test_repo() -> TempDir {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        // Canonicalize the path to resolve any symlinks (e.g., /var -> /private/var on macOS)
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize temp directory path");
+
+        // Initialize git repo
+        let _repo = git2::Repository::init(&repo_path).expect("Failed to init git repo");
+
+        // Create .gitignore
+        let gitignore_path = repo_path.join(".gitignore");
+        let mut gitignore_file =
+            File::create(&gitignore_path).expect("Failed to create .gitignore");
+        writeln!(gitignore_file, "*.log").expect("Failed to write to .gitignore");
+        writeln!(gitignore_file, "temp/").expect("Failed to write to .gitignore");
+        writeln!(gitignore_file, "secrets.txt").expect("Failed to write to .gitignore");
+
+        // Create some test files and directories
+        fs::create_dir_all(repo_path.join("src")).expect("Failed to create src dir");
+        fs::create_dir_all(repo_path.join("temp")).expect("Failed to create temp dir");
+
+        File::create(repo_path.join("README.md")).expect("Failed to create README.md");
+        File::create(repo_path.join("debug.log")).expect("Failed to create debug.log");
+        File::create(repo_path.join("secrets.txt")).expect("Failed to create secrets.txt");
+        File::create(repo_path.join("src").join("main.rs")).expect("Failed to create main.rs");
+
+        temp_dir
+    }
+
+    #[test]
+    fn test_is_path_gitignored_ignored_file() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("debug.log"));
+        if let Err(e) = &result {
+            println!("Error: {:?}", e);
+        }
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "debug.log should be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_non_ignored_file() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("README.md"));
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "README.md should not be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_ignored_directory() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("temp"));
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "temp/ directory should be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_non_ignored_directory() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("src"));
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "src/ directory should not be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_nonexistent_file() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("nonexistent.log"));
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap(),
+            "nonexistent.log should be ignored based on pattern"
+        );
+    }
+
+    #[test]
+    fn test_is_path_gitignored_file_in_subdirectory() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored(repo_path.join("src").join("main.rs"));
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "src/main.rs should not be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_no_git_repo() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let non_repo_path = temp_dir.path().join("some_file.txt");
+
+        let result = is_path_gitignored(non_repo_path);
+        assert!(result.is_err(), "Should error when not in a git repository");
+    }
+}
+
+mod is_path_gitignored_from_tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn setup_test_repo() -> TempDir {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        // Canonicalize the path to resolve any symlinks (e.g., /var -> /private/var on macOS)
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize temp directory path");
+
+        // Initialize git repo
+        let _repo = git2::Repository::init(&repo_path).expect("Failed to init git repo");
+
+        // Create .gitignore
+        let gitignore_path = repo_path.join(".gitignore");
+        let mut gitignore_file =
+            File::create(&gitignore_path).expect("Failed to create .gitignore");
+        writeln!(gitignore_file, "*.log").expect("Failed to write to .gitignore");
+        writeln!(gitignore_file, "temp/").expect("Failed to write to .gitignore");
+
+        // Create some test files and directories
+        fs::create_dir_all(repo_path.join("src")).expect("Failed to create src dir");
+        File::create(repo_path.join("README.md")).expect("Failed to create README.md");
+        File::create(repo_path.join("debug.log")).expect("Failed to create debug.log");
+        File::create(repo_path.join("src").join("main.rs")).expect("Failed to create main.rs");
+
+        temp_dir
+    }
+
+    #[test]
+    fn test_is_path_gitignored_from_with_root() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored_from(repo_path.join("debug.log"), Some(&repo_path));
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap(),
+            "debug.log should be ignored when specifying root"
+        );
+    }
+
+    #[test]
+    fn test_is_path_gitignored_from_without_root() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored_from(repo_path.join("README.md"), None::<&Path>);
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "README.md should not be ignored");
+    }
+
+    #[test]
+    fn test_is_path_gitignored_from_nonexistent_file_with_root() {
+        let temp_dir = setup_test_repo();
+        let repo_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        let result = is_path_gitignored_from(repo_path.join("test.log"), Some(&repo_path));
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap(),
+            "test.log should be ignored based on pattern"
+        );
+    }
+
+    #[test]
+    fn test_is_path_gitignored_nested_repos() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let base_path = temp_dir
+            .path()
+            .canonicalize()
+            .expect("Failed to canonicalize path");
+
+        // Create repo1 (outer repo)
+        let repo1_path = base_path.join("repo1");
+        fs::create_dir_all(&repo1_path).expect("Failed to create repo1 dir");
+        let _repo1 = git2::Repository::init(&repo1_path).expect("Failed to init repo1");
+
+        // Create .gitignore in repo1 that ignores repo2/
+        let gitignore1_path = repo1_path.join(".gitignore");
+        let mut gitignore1_file =
+            File::create(&gitignore1_path).expect("Failed to create .gitignore in repo1");
+        writeln!(gitignore1_file, "repo2/").expect("Failed to write to repo1 .gitignore");
+
+        // Create repo2 (inner repo) inside repo1
+        let repo2_path = repo1_path.join("repo2");
+        fs::create_dir_all(&repo2_path).expect("Failed to create repo2 dir");
+        let _repo2 = git2::Repository::init(&repo2_path).expect("Failed to init repo2");
+
+        // Create .gitignore in repo2 that doesn't ignore blah
+        let gitignore2_path = repo2_path.join(".gitignore");
+        let mut gitignore2_file =
+            File::create(&gitignore2_path).expect("Failed to create .gitignore in repo2");
+        writeln!(gitignore2_file, "*.log").expect("Failed to write to repo2 .gitignore");
+
+        // Create a file in repo2
+        let blah_file = repo2_path.join("blah");
+        File::create(&blah_file).expect("Failed to create blah file");
+
+        // Test 1: is_path_gitignored should use repo2 context (closest repo) and return false
+        let result_closest = is_path_gitignored(&blah_file);
+        assert!(
+            result_closest.is_ok(),
+            "Should successfully check gitignore status"
+        );
+        assert!(
+            !result_closest.unwrap(),
+            "blah should not be ignored in repo2 context"
+        );
+
+        // Test 2: is_path_gitignored_from with repo1 root should return true (repo2/ is ignored)
+        let result_from_repo1 = is_path_gitignored_from(&blah_file, Some(&repo1_path));
+        assert!(
+            result_from_repo1.is_ok(),
+            "Should successfully check from repo1"
+        );
+        assert!(
+            result_from_repo1.unwrap(),
+            "blah should be ignored when viewed from repo1 (repo2/ is ignored)"
+        );
+
+        // Test 3: is_path_gitignored_from with repo2 root should return false
+        let result_from_repo2 = is_path_gitignored_from(&blah_file, Some(&repo2_path));
+        assert!(
+            result_from_repo2.is_ok(),
+            "Should successfully check from repo2"
+        );
+        assert!(
+            !result_from_repo2.unwrap(),
+            "blah should not be ignored when viewed from repo2"
+        );
+    }
+}

--- a/src/internal/git/utils_test.rs
+++ b/src/internal/git/utils_test.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
+use crate::internal::testutils::run_with_env;
+
 mod package_root_path_tests {
     use super::*;
 
@@ -323,95 +325,109 @@ mod is_path_gitignored_tests {
 
     #[test]
     fn test_is_path_gitignored_ignored_file() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("debug.log"));
-        if let Err(e) = &result {
-            println!("Error: {:?}", e);
-        }
-        assert!(result.is_ok());
-        assert!(result.unwrap(), "debug.log should be ignored");
+            let result = is_path_gitignored(repo_path.join("debug.log"));
+            if let Err(e) = &result {
+                println!("Error: {:?}", e);
+            }
+            assert!(result.is_ok());
+            assert!(result.unwrap(), "debug.log should be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_non_ignored_file() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("README.md"));
-        assert!(result.is_ok());
-        assert!(!result.unwrap(), "README.md should not be ignored");
+            let result = is_path_gitignored(repo_path.join("README.md"));
+            assert!(result.is_ok());
+            assert!(!result.unwrap(), "README.md should not be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_ignored_directory() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("temp"));
-        assert!(result.is_ok());
-        assert!(result.unwrap(), "temp/ directory should be ignored");
+            let result = is_path_gitignored(repo_path.join("temp"));
+            assert!(result.is_ok());
+            assert!(result.unwrap(), "temp/ directory should be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_non_ignored_directory() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("src"));
-        assert!(result.is_ok());
-        assert!(!result.unwrap(), "src/ directory should not be ignored");
+            let result = is_path_gitignored(repo_path.join("src"));
+            assert!(result.is_ok());
+            assert!(!result.unwrap(), "src/ directory should not be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_nonexistent_file() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("nonexistent.log"));
-        assert!(result.is_ok());
-        assert!(
-            result.unwrap(),
-            "nonexistent.log should be ignored based on pattern"
-        );
+            let result = is_path_gitignored(repo_path.join("nonexistent.log"));
+            assert!(result.is_ok());
+            assert!(
+                result.unwrap(),
+                "nonexistent.log should be ignored based on pattern"
+            );
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_file_in_subdirectory() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored(repo_path.join("src").join("main.rs"));
-        assert!(result.is_ok());
-        assert!(!result.unwrap(), "src/main.rs should not be ignored");
+            let result = is_path_gitignored(repo_path.join("src").join("main.rs"));
+            assert!(result.is_ok());
+            assert!(!result.unwrap(), "src/main.rs should not be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_no_git_repo() {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let non_repo_path = temp_dir.path().join("some_file.txt");
+        run_with_env(&[], || {
+            let temp_dir = TempDir::new().expect("Failed to create temp directory");
+            let non_repo_path = temp_dir.path().join("some_file.txt");
 
-        let result = is_path_gitignored(non_repo_path);
-        assert!(result.is_err(), "Should error when not in a git repository");
+            let result = is_path_gitignored(non_repo_path);
+            assert!(result.is_err(), "Should error when not in a git repository");
+        });
     }
 }
 
@@ -449,114 +465,122 @@ mod is_path_gitignored_from_tests {
 
     #[test]
     fn test_is_path_gitignored_from_with_root() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored_from(repo_path.join("debug.log"), Some(&repo_path));
-        assert!(result.is_ok());
-        assert!(
-            result.unwrap(),
-            "debug.log should be ignored when specifying root"
-        );
+            let result = is_path_gitignored_from(repo_path.join("debug.log"), Some(&repo_path));
+            assert!(result.is_ok());
+            assert!(
+                result.unwrap(),
+                "debug.log should be ignored when specifying root"
+            );
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_from_without_root() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored_from(repo_path.join("README.md"), None::<&Path>);
-        assert!(result.is_ok());
-        assert!(!result.unwrap(), "README.md should not be ignored");
+            let result = is_path_gitignored_from(repo_path.join("README.md"), None::<&Path>);
+            assert!(result.is_ok());
+            assert!(!result.unwrap(), "README.md should not be ignored");
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_from_nonexistent_file_with_root() {
-        let temp_dir = setup_test_repo();
-        let repo_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = setup_test_repo();
+            let repo_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        let result = is_path_gitignored_from(repo_path.join("test.log"), Some(&repo_path));
-        assert!(result.is_ok());
-        assert!(
-            result.unwrap(),
-            "test.log should be ignored based on pattern"
-        );
+            let result = is_path_gitignored_from(repo_path.join("test.log"), Some(&repo_path));
+            assert!(result.is_ok());
+            assert!(
+                result.unwrap(),
+                "test.log should be ignored based on pattern"
+            );
+        });
     }
 
     #[test]
     fn test_is_path_gitignored_nested_repos() {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let base_path = temp_dir
-            .path()
-            .canonicalize()
-            .expect("Failed to canonicalize path");
+        run_with_env(&[], || {
+            let temp_dir = TempDir::new().expect("Failed to create temp directory");
+            let base_path = temp_dir
+                .path()
+                .canonicalize()
+                .expect("Failed to canonicalize path");
 
-        // Create repo1 (outer repo)
-        let repo1_path = base_path.join("repo1");
-        fs::create_dir_all(&repo1_path).expect("Failed to create repo1 dir");
-        let _repo1 = git2::Repository::init(&repo1_path).expect("Failed to init repo1");
+            // Create repo1 (outer repo)
+            let repo1_path = base_path.join("repo1");
+            fs::create_dir_all(&repo1_path).expect("Failed to create repo1 dir");
+            let _repo1 = git2::Repository::init(&repo1_path).expect("Failed to init repo1");
 
-        // Create .gitignore in repo1 that ignores repo2/
-        let gitignore1_path = repo1_path.join(".gitignore");
-        let mut gitignore1_file =
-            File::create(&gitignore1_path).expect("Failed to create .gitignore in repo1");
-        writeln!(gitignore1_file, "repo2/").expect("Failed to write to repo1 .gitignore");
+            // Create .gitignore in repo1 that ignores repo2/
+            let gitignore1_path = repo1_path.join(".gitignore");
+            let mut gitignore1_file =
+                File::create(&gitignore1_path).expect("Failed to create .gitignore in repo1");
+            writeln!(gitignore1_file, "repo2/").expect("Failed to write to repo1 .gitignore");
 
-        // Create repo2 (inner repo) inside repo1
-        let repo2_path = repo1_path.join("repo2");
-        fs::create_dir_all(&repo2_path).expect("Failed to create repo2 dir");
-        let _repo2 = git2::Repository::init(&repo2_path).expect("Failed to init repo2");
+            // Create repo2 (inner repo) inside repo1
+            let repo2_path = repo1_path.join("repo2");
+            fs::create_dir_all(&repo2_path).expect("Failed to create repo2 dir");
+            let _repo2 = git2::Repository::init(&repo2_path).expect("Failed to init repo2");
 
-        // Create .gitignore in repo2 that doesn't ignore blah
-        let gitignore2_path = repo2_path.join(".gitignore");
-        let mut gitignore2_file =
-            File::create(&gitignore2_path).expect("Failed to create .gitignore in repo2");
-        writeln!(gitignore2_file, "*.log").expect("Failed to write to repo2 .gitignore");
+            // Create .gitignore in repo2 that doesn't ignore blah
+            let gitignore2_path = repo2_path.join(".gitignore");
+            let mut gitignore2_file =
+                File::create(&gitignore2_path).expect("Failed to create .gitignore in repo2");
+            writeln!(gitignore2_file, "*.log").expect("Failed to write to repo2 .gitignore");
 
-        // Create a file in repo2
-        let blah_file = repo2_path.join("blah");
-        File::create(&blah_file).expect("Failed to create blah file");
+            // Create a file in repo2
+            let blah_file = repo2_path.join("blah");
+            File::create(&blah_file).expect("Failed to create blah file");
 
-        // Test 1: is_path_gitignored should use repo2 context (closest repo) and return false
-        let result_closest = is_path_gitignored(&blah_file);
-        assert!(
-            result_closest.is_ok(),
-            "Should successfully check gitignore status"
-        );
-        assert!(
-            !result_closest.unwrap(),
-            "blah should not be ignored in repo2 context"
-        );
+            // Test 1: is_path_gitignored should use repo2 context (closest repo) and return false
+            let result_closest = is_path_gitignored(&blah_file);
+            assert!(
+                result_closest.is_ok(),
+                "Should successfully check gitignore status"
+            );
+            assert!(
+                !result_closest.unwrap(),
+                "blah should not be ignored in repo2 context"
+            );
 
-        // Test 2: is_path_gitignored_from with repo1 root should return true (repo2/ is ignored)
-        let result_from_repo1 = is_path_gitignored_from(&blah_file, Some(&repo1_path));
-        assert!(
-            result_from_repo1.is_ok(),
-            "Should successfully check from repo1"
-        );
-        assert!(
-            result_from_repo1.unwrap(),
-            "blah should be ignored when viewed from repo1 (repo2/ is ignored)"
-        );
+            // Test 2: is_path_gitignored_from with repo1 root should return true (repo2/ is ignored)
+            let result_from_repo1 = is_path_gitignored_from(&blah_file, Some(&repo1_path));
+            assert!(
+                result_from_repo1.is_ok(),
+                "Should successfully check from repo1"
+            );
+            assert!(
+                result_from_repo1.unwrap(),
+                "blah should be ignored when viewed from repo1 (repo2/ is ignored)"
+            );
 
-        // Test 3: is_path_gitignored_from with repo2 root should return false
-        let result_from_repo2 = is_path_gitignored_from(&blah_file, Some(&repo2_path));
-        assert!(
-            result_from_repo2.is_ok(),
-            "Should successfully check from repo2"
-        );
-        assert!(
-            !result_from_repo2.unwrap(),
-            "blah should not be ignored when viewed from repo2"
-        );
+            // Test 3: is_path_gitignored_from with repo2 root should return false
+            let result_from_repo2 = is_path_gitignored_from(&blah_file, Some(&repo2_path));
+            assert!(
+                result_from_repo2.is_ok(),
+                "Should successfully check from repo2"
+            );
+            assert!(
+                !result_from_repo2.unwrap(),
+                "blah should not be ignored when viewed from repo2"
+            );
+        });
     }
 }

--- a/src/internal/testutils.rs
+++ b/src/internal/testutils.rs
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
             let tmp_dir = tempdir.path().join("tmp");
             std::fs::create_dir(&tmp_dir).expect("failed to create tmp dir");
 
-            // CPrepare a unique test ID that can be used to identify test resources
+            // Prepare a unique test ID that can be used to identify test resources
             let test_id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst).to_string();
 
             let run_env: Vec<(String, Option<String>)> = vec![


### PR DESCRIPTION
Omni already handles the global gitignore on top of the local gitignore, but when a subdirectory of a workdir is a git repository, the gitignore ends-up being checked from the most specific git repository, and not necessarily the one corresponding to the omni workdir.

This fixes that by passing down the workdir root path to be used as git-base, if in a git workdir.

Closes https://github.com/xaf/omni/issues/1143