### PR TITLE
fix(`github_release`): handle releases without name

### DIFF
--- a/src/internal/cache/github_release.rs
+++ b/src/internal/cache/github_release.rs
@@ -602,8 +602,8 @@ impl FromRow for GithubReleases {
 pub struct GithubReleaseVersion {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub tag_name: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default)]
     pub draft: bool,
     #[serde(default)]

--- a/src/internal/cache/github_release_test.rs
+++ b/src/internal/cache/github_release_test.rs
@@ -16,7 +16,7 @@ mod github_release_operation_cache {
             let releases = GithubReleases {
                 releases: vec![GithubReleaseVersion {
                     tag_name: "v1.0.0".to_string(),
-                    name: "Release 1.0.0".to_string(),
+                    name: Some("Release 1.0.0".to_string()),
                     draft: false,
                     prerelease: false,
                     assets: vec![],
@@ -243,7 +243,7 @@ mod github_release_operation_cache {
             let releases1 = GithubReleases {
                 releases: vec![GithubReleaseVersion {
                     tag_name: "v1.0.0".to_string(),
-                    name: "Release 1.0.0".to_string(),
+                    name: Some("Release 1.0.0".to_string()),
                     draft: false,
                     prerelease: false,
                     assets: vec![],
@@ -261,14 +261,14 @@ mod github_release_operation_cache {
                 releases: vec![
                     GithubReleaseVersion {
                         tag_name: "v1.0.0".to_string(),
-                        name: "Release 1.0.0".to_string(),
+                        name: Some("Release 1.0.0".to_string()),
                         draft: false,
                         prerelease: false,
                         assets: vec![],
                     },
                     GithubReleaseVersion {
                         tag_name: "v1.1.0".to_string(),
-                        name: "Release 1.1.0".to_string(),
+                        name: Some("Release 1.1.0".to_string()),
                         draft: false,
                         prerelease: false,
                         assets: vec![],


### PR DESCRIPTION
When releases exist but don't have name, omni failed to load the release, which made it fail handling _any_ release of that specific repository. This is now fixed by not expecting the name to exist.

Fixes https://github.com/xaf/omni/issues/1176