### PR TITLE
chore(deps): bump sha1, sha2, and md-5 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +362,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -442,6 +451,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -595,6 +610,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,9 +690,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1138,7 +1173,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1200,6 +1235,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1719,12 +1763,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1980,8 +2024,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "shell-escape",
  "shell-words",
  "strsim",
@@ -2136,7 +2180,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -2186,7 +2230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2919,7 +2963,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2930,7 +2985,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4395,7 +4461,7 @@ dependencies = [
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "xz2",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ itertools = "0.14.0"
 lazy_static = "1.4.0"
 libz-sys = { version = "1.1.28", features = ["static"] }  # So we can force static linking
 machine-uid = "0.5.4"
-md-5 = "0.10.6"
+md-5 = "0.11.0"
 nix = { version = "0.31.1", features = ["fs", "process", "signal"] }
 node-semver = "2.2.0"
 normalize-path = "0.2.1"
@@ -76,8 +76,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10.0" }
 toml = "1.1.2"
-sha1 = "0.10.6"
-sha2 = "0.10.9"
+sha1 = "0.11.0"
+sha2 = "0.11.0"
 shell-escape = "0.1.5"
 shell-words = "1.1.1"
 strsim = "0.11.1"

--- a/src/internal/config/up/github_release.rs
+++ b/src/internal/config/up/github_release.rs
@@ -1717,7 +1717,7 @@ impl UpConfigGithubRelease {
             hasher.update(b"prefer_dist");
         }
 
-        let hash = format!("{:x}", hasher.finalize());
+        let hash = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect::<String>();
         let short_hash = &hash[0..8];
         Some(short_hash.to_string())
     }
@@ -2575,38 +2575,35 @@ impl GithubReleaseChecksumAlgorithm {
     }
 
     pub fn compute_file_hash(&self, path: &PathBuf) -> io::Result<String> {
-        match self {
+        let data = std::fs::read(path)?;
+        let hash_bytes: Vec<u8> = match self {
             GithubReleaseChecksumAlgorithm::Md5 => {
                 let mut hasher = Md5::new();
-                let mut file = std::fs::File::open(path)?;
-                std::io::copy(&mut file, &mut hasher)?;
-                Ok(format!("{:x}", hasher.finalize()))
+                hasher.update(&data);
+                hasher.finalize().to_vec()
             }
             GithubReleaseChecksumAlgorithm::Sha1 => {
                 let mut hasher = Sha1::new();
-                let mut file = std::fs::File::open(path)?;
-                std::io::copy(&mut file, &mut hasher)?;
-                Ok(format!("{:x}", hasher.finalize()))
+                hasher.update(&data);
+                hasher.finalize().to_vec()
             }
             GithubReleaseChecksumAlgorithm::Sha256 => {
                 let mut hasher = Sha256::new();
-                let mut file = std::fs::File::open(path)?;
-                std::io::copy(&mut file, &mut hasher)?;
-                Ok(format!("{:x}", hasher.finalize()))
+                hasher.update(&data);
+                hasher.finalize().to_vec()
             }
             GithubReleaseChecksumAlgorithm::Sha384 => {
                 let mut hasher = Sha384::new();
-                let mut file = std::fs::File::open(path)?;
-                std::io::copy(&mut file, &mut hasher)?;
-                Ok(format!("{:x}", hasher.finalize()))
+                hasher.update(&data);
+                hasher.finalize().to_vec()
             }
             GithubReleaseChecksumAlgorithm::Sha512 => {
                 let mut hasher = Sha512::new();
-                let mut file = std::fs::File::open(path)?;
-                std::io::copy(&mut file, &mut hasher)?;
-                Ok(format!("{:x}", hasher.finalize()))
+                hasher.update(&data);
+                hasher.finalize().to_vec()
             }
-        }
+        };
+        Ok(hash_bytes.iter().map(|b| format!("{:02x}", b)).collect())
     }
 }
 

--- a/src/internal/config/up/mise.rs
+++ b/src/internal/config/up/mise.rs
@@ -928,7 +928,7 @@ impl FullyQualifiedToolName {
             let plugin_name = if suffix {
                 let mut hasher = Sha256::new();
                 hasher.update(url.as_bytes());
-                let hash = format!("{:x}", hasher.finalize());
+                let hash = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect::<String>();
                 let short_hash = &hash[0..8];
 
                 // The plugin name will be the tool name with the hash appended
@@ -977,7 +977,7 @@ impl FullyQualifiedToolName {
                 // to be able to list the versions and install the tool
                 let mut hasher = Sha256::new();
                 hasher.update(url.as_bytes());
-                let hash = format!("{:x}", hasher.finalize());
+                let hash = hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect::<String>();
                 let short_hash = &hash[0..8];
 
                 // The plugin name will be the tool name with the hash appended


### PR DESCRIPTION
All three crates depend on the `digest` crate and must be bumped together to avoid version conflicts (digest 0.10 vs 0.11). Supersedes #1350, #1359, and #1360.